### PR TITLE
Added means of getting a context for better type conversion support

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModelCompiler.java
@@ -99,7 +99,7 @@ public class ModelCompiler {
         return result.getTsType();
     }
 
-    private String getMappedName(Class<?> cls) {
+    public String getMappedName(Class<?> cls) {
         if (cls == null) {
             return null;
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -1,13 +1,14 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.TypeProcessor.*;
 import cz.habarta.typescript.generator.emitter.*;
 import cz.habarta.typescript.generator.parser.*;
 import java.io.*;
+import java.lang.reflect.Type;
 import java.nio.charset.*;
 import java.util.*;
 import java.util.logging.Logger;
-
 
 public class TypeScriptGenerator {
 
@@ -64,6 +65,25 @@ public class TypeScriptGenerator {
         }
     }
 
+    public static TypeProcessor.Context createTypeProcessorContext(Settings settings) {
+        Logger logger = Logger.getGlobal();
+        final TypeProcessor typeProcessor = createTypeProcessor(settings);
+        final ModelCompiler compiler = new ModelCompiler(logger, settings, typeProcessor);
+
+        return new Context() {
+
+            @Override
+            public Result processType(Type javaType) {
+                return typeProcessor.processType(javaType, this);
+            }
+
+            @Override
+            public String getMappedName(Class<?> cls) {
+                return compiler.getMappedName(cls);
+            }
+        };
+    }
+
     private static String getVersion() {
         try {
             final InputStream inputStream = TypeScriptGenerator.class.getResourceAsStream(
@@ -78,5 +98,4 @@ public class TypeScriptGenerator {
             return null;
         }
     }
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/StyleConfigurationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/StyleConfigurationTest.java
@@ -34,6 +34,7 @@ public class StyleConfigurationTest {
         TypeScriptGenerator.generateEmbeddableTypeScript(classList, settings, output, true, 1);
 
         assertEquals(expected, new String(output.toByteArray()));
+        assertEquals("IA", TypeScriptGenerator.createTypeProcessorContext(settings).processType(A.class).getTsType().toString());
     }
 
     public static class A {


### PR DESCRIPTION
I (the client) don't want to have to create a `TypeProcessor.Context` to convert a type. Specifically, my reasoning is that there's some potentially complicated logic in implementing getMappedName (probably going to get even more complicated when I add generics)