### PR TITLE
Several bug fixes

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -74,6 +74,8 @@ public class DefaultTypeProcessor implements TypeProcessor {
         knownTypes.put(Character.TYPE, TsType.String);
         knownTypes.put(String.class, TsType.String);
         knownTypes.put(Date.class, TsType.Date);
+        knownTypes.put(void.class, TsType.Void);
+        knownTypes.put(Void.class, TsType.Void);
         return knownTypes;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -11,6 +11,7 @@ public abstract class TsType {
     public static final TsType Number = new BasicType("number");
     public static final TsType String = new BasicType("string");
     public static final TsType Date = new BasicType("Date");
+    public static final TsType Void = new BasicType("void");
 
     public static final AliasType DateAsNumber = new AliasType("DateAsNumber", "type DateAsNumber = number;");
     public static final AliasType DateAsString = new AliasType("DateAsString", "type DateAsString = string;");

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
@@ -12,6 +12,7 @@ public class DefaultTypeProcessorTest {
         final TypeProcessor.Context context = getTestContext(converter);
         assertEquals("A", converter.processType(A.class, context).getTsType().toString());
         assertEquals("B", converter.processType(B.class, context).getTsType().toString());
+        assertEquals(TsType.Void, converter.processType(void.class, context).getTsType());
     }
 
     private static class A {


### PR DESCRIPTION
Added void.class and Void.class as known types.
Enum conversion now works (calling to string on an enumType now
correctly returns "string")
Made ModelCompiler.join public