### PR TITLE
ability to specify which files to convert also with a glob pattern instead of listing all the classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ In Maven build you can use `typescript-generator-maven-plugin` like this:
 </plugin>
 ```
 
+Instead of listing all the classes, you can also define a list of glob patterns patterns matching the classes to export, like that for instance:
+``` xml
+<classPatterns>
+    <classPattern>*TsDto</classPattern>
+</classPatterns>
+```
+
 More complete sample can be found [here](sample-maven).
 Detailed description how to configure typescript-generator-maven-plugin is on generated [site](http://vojtechhabarta.github.io/typescript-generator/maven/typescript-generator-maven-plugin/generate-mojo.html).
 
@@ -95,7 +102,7 @@ generateTypeScript {
 ```
 
 More complete sample can be found [here](sample-gradle).
-Gradle plugin has the same features as Maven plugin, for detailed description see Maven generated [site](http://vojtechhabarta.github.io/typescript-generator/maven/typescript-generator-maven-plugin/generate-mojo.html). 
+Gradle plugin has the same features as Maven plugin, for detailed description see Maven generated [site](http://vojtechhabarta.github.io/typescript-generator/maven/typescript-generator-maven-plugin/generate-mojo.html).
 
 
 Direct invocation
@@ -113,7 +120,7 @@ Architecture
 ```
            (Model)            (TsModel)
 ModelParser  ==>  ModelCompiler  ==>  Emitter
-         |         | 
+         |         |
          V         V
         TypeProcessor
 ```


### PR DESCRIPTION
this maven plugin looks great, however for bigger applications, it will quickly become a burden to list all the DTOs. With this change it's possible to simply specify a glob pattern for the classes to convert and the plugin finds them itself.

I have concerns about the implementation, it's the first time I touch a maven mojo... To find the classes, I walk the directory tree, and then have a little function to guess the class name from the file name. I would expect I could enumerate the classes from the classloader, but it seems to be possible [only through hacks](http://stackoverflow.com/questions/2681459/how-can-i-list-all-classes-loaded-in-a-specific-class-loader). I also thought about using the `reflections` library, but it seems overkill to add that new dependency to your mojo only for that?