### PR TITLE
Added equals for tsType and made toString mandatory

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -16,9 +16,22 @@ public abstract class TsType {
     public static final AliasType DateAsNumber = new AliasType("DateAsNumber", "type DateAsNumber = number;");
     public static final AliasType DateAsString = new AliasType("DateAsString", "type DateAsString = string;");
 
+    @Override
+    public boolean equals(Object rhs) {
+        return rhs != null && this.getClass() == rhs.getClass() && this.toString().equals(rhs.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
     public TsType.OptionalType optional() {
         return new TsType.OptionalType(this);
     }
+
+    @Override
+    public abstract String toString();
 
     public static class BasicType extends TsType {
 
@@ -32,7 +45,6 @@ public abstract class TsType {
         public String toString() {
             return name;
         }
-
     }
 
     public static class AliasType extends TsType {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
@@ -1,0 +1,23 @@
+package cz.habarta.typescript.generator;
+
+import static org.junit.Assert.*;
+
+import org.junit.*;
+
+public class TsTypeTest {
+
+    @Test
+    public void testEquals() {
+        assertEquals(new TsType.StructuralType(new String("Foo")), new TsType.StructuralType("Foo"));
+    }
+
+    @Test
+    public void testNotEquals() {
+        assertNotEquals(new TsType.StructuralType("Foo"), new TsType.StructuralType("Bar"));
+    }
+
+    @Test
+    public void testNotEqualsNull() {
+        assertNotEquals(new TsType.StructuralType("Foo"), null);
+    }
+}


### PR DESCRIPTION
My use case here is to make it easier to test the library that depends on this one.

By the way, I created a typescript service generating library that is based of yours! Check it out and let me know what you think!

https://github.com/palantir/typescript-service-generator/