### PR TITLE
Allow annotations to determine optionality

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import java.io.File;
+import java.lang.annotation.Annotation;
 import java.util.*;
 
 
@@ -27,6 +28,21 @@ public class Settings {
     public boolean noFileComment = false;
     public List<File> javadocXmlFiles = null;
     public List<EmitterExtension> extensions = new ArrayList<>();
+
+    /**
+     * The presence of any annotation in this list on a json property will cause the
+     * typescript generator to treat that property as optional when generating the
+     * corresponding typescript interface.
+     * <p>
+     * Note: When using a {@link cz.habarta.typescript.generator.parser.Jackson1Parser}
+     * to generate your model, any annotation specified here will need to pass the
+     * {@link org.codehaus.jackson.map.AnnotationIntrospector#isHandled} check performed
+     * by the {@link org.codehaus.jackson.map.ObjectMapper} used to construct your model
+     * parser. If you control the annotations in question, the easiest way to do this is
+     * to annotate your annotations as
+     * {@link org.codehaus.jackson.annotate.JacksonAnnotation}s.
+     */
+    public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
 
     public void validate() {
         if (jsonLibrary == null) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.*;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.*;
 import org.codehaus.jackson.JsonNode;
@@ -13,10 +14,15 @@ import org.codehaus.jackson.type.JavaType;
 
 public class Jackson1Parser extends ModelParser {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public Jackson1Parser(Settings settings, TypeProcessor typeProcessor) {
+        this(settings, typeProcessor, new ObjectMapper());
+    }
+
+    public Jackson1Parser(Settings settings, TypeProcessor typeProcessor, ObjectMapper objectMapper) {
         super(settings, typeProcessor);
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -30,7 +36,14 @@ public class Jackson1Parser extends ModelParser {
                     if (propertyType == JsonNode.class) {
                         propertyType = Object.class;
                     }
-                    properties.add(processTypeAndCreateProperty(beanPropertyWriter.getName(), propertyType, false, sourceClass.type));
+                    boolean optional = false;
+                    for (Class<? extends Annotation> optionalAnnotation : settings.optionalAnnotations) {
+                        if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
+                            optional = true;
+                            break;
+                        }
+                    }
+                    properties.add(processTypeAndCreateProperty(beanPropertyWriter.getName(), propertyType, optional, sourceClass.type));
                 }
             }
         }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
@@ -1,0 +1,80 @@
+package cz.habarta.typescript.generator;
+
+import cz.habarta.typescript.generator.parser.*;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class OptionalAnnotationTest {
+
+    @Test
+    public void testJackson1OptionalAnnotation() {
+        Settings settings = new Settings();
+        settings.optionalAnnotations.add(Nullable.class);
+        ModelParser parser = new Jackson1Parser(settings, new DefaultTypeProcessor());
+        testModel(parser.parseModel(Jackson1Bean.class), true);
+    }
+
+    @Test
+    public void testJackson1NoAnnotation() {
+        Settings settings = new Settings();
+        ModelParser parser = new Jackson1Parser(settings, new DefaultTypeProcessor());
+        testModel(parser.parseModel(Jackson1Bean.class), false);
+    }
+
+    @Test
+    public void testJackson2OptionalAnnotation() {
+        Settings settings = new Settings();
+        settings.optionalAnnotations.add(Nullable.class);
+        ModelParser parser = new Jackson2Parser(settings, new DefaultTypeProcessor());
+        testModel(parser.parseModel(Jackson2Bean.class), true);
+    }
+
+    @Test
+    public void testJackson2NoAnnotation() {
+        Settings settings = new Settings();
+        ModelParser parser = new Jackson2Parser(settings, new DefaultTypeProcessor());
+        testModel(parser.parseModel(Jackson2Bean.class), false);
+    }
+
+    private void testModel(Model model, boolean optional) {
+        Assert.assertEquals(1, model.getBeans().size());
+        BeanModel beanModel = model.getBeans().get(0);
+        Assert.assertEquals(2, beanModel.getProperties().size());
+        for (PropertyModel propertyModel : beanModel.getProperties()) {
+            Assert.assertEquals(optional, propertyModel.isOptional());
+        }
+    }
+
+    @org.codehaus.jackson.annotate.JacksonAnnotation
+    @Retention(RetentionPolicy.RUNTIME)
+    static @interface Nullable {
+        // marker
+    }
+
+    static class Jackson1Bean {
+        @Nullable
+        @org.codehaus.jackson.annotate.JsonProperty
+        private String fieldProperty;
+
+        @Nullable
+        @org.codehaus.jackson.annotate.JsonProperty
+        public String getMethodProperty() {
+            return fieldProperty;
+        }
+    }
+
+    static class Jackson2Bean {
+        @Nullable
+        @com.fasterxml.jackson.annotation.JsonProperty
+        private String fieldProperty;
+
+        @Nullable
+        @com.fasterxml.jackson.annotation.JsonProperty
+        public String getMethodProperty() {
+            return fieldProperty;
+        }
+    }
+}


### PR DESCRIPTION
This allows methods and fields that are annotated as @Nullable (or any
other user chosen annotation) to generate optional fields in your
typescript definitions.