### PR TITLE
Changes emitEnums to emit 'enum' instead of 'type'; adds export keyword to modules, and declare keyword to ambient files.

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -1,8 +1,9 @@
 
 package cz.habarta.typescript.generator;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 
 public class EnumTest {
@@ -11,14 +12,12 @@ public class EnumTest {
     public void test() {
         final Settings settings = TestUtils.settings();
         final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
-        final String expected =
-                "\n" +
-                "interface AClass {\n" +
-                "    direction: Direction;\n" +
-                "}\n" +
-                "\n" +
-                "type Direction = 'North' | 'East' | 'South' | 'West';\n"
-                .replace("'", "\"");
+        final String expected = "\n" +
+                        "interface AClass {\n" +
+                        "    direction: Direction;\n" +
+                        "}\n" +
+                        "\n" +
+                        "declare enum Direction {North, East, South, West}\n";
         assertEquals(expected, actual);
     }
 
@@ -26,10 +25,20 @@ public class EnumTest {
     public void testSingleEnum() {
         final Settings settings = TestUtils.settings();
         final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Direction.class));
-        final String expected =
-                "\n" +
-                "type Direction = 'North' | 'East' | 'South' | 'West';\n"
-                .replace("'", "\"");
+        final String expected = "\n" +
+                        "declare enum Direction {North, East, South, West}\n";
+        System.out.println(actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSingleEnumAsModule() throws Exception {
+        Settings settings = TestUtils.settings();
+        settings.outputKind = TypeScriptOutputKind.module;
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Direction.class));
+        final String expected = "\n" +
+                        "export enum Direction {North, East, South, West}\n";
         System.out.println(actual);
         assertEquals(expected, actual);
     }
@@ -40,7 +49,7 @@ public class EnumTest {
 
     enum Direction {
         North,
-        East, 
+        East,
         South,
         West
     }


### PR DESCRIPTION
`typescript-generator` outputs type aliases for java enums, which I believe is wrong, according to the [spec](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.10). 

This PR proposes to solve the problem by changing `type` to `enum`. It also adds the `export` keyword for `outputFileType=module`, and the `declare` keyword for other output file types. 

This works for our setup, which produces `.ts` files from Java classes and enums. However, I might have missed other use cases. 