### PR TITLE
Support for customized TypeScript-Mapping

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
@@ -1,0 +1,43 @@
+
+package cz.habarta.typescript.generator;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomMappingTypeProcessor implements TypeProcessor {
+
+    private final Map<String, String> customMappings = new HashMap<>();
+
+    public CustomMappingTypeProcessor(List<String> customMappings) {
+        if (customMappings != null) {
+            for (String customMapping : customMappings) {
+                this.customMappings.putAll(convertToMap(customMapping));
+            }
+        }
+    }
+
+    @Override
+    public Result processType(Type javaType, Context context) {
+        final Class<?> rawClass = Utils.getRawClassOrNull(javaType);
+        if (rawClass != null) {
+            String type = customMappings.get(rawClass.getName());
+            if (type != null) {
+                return new Result(new TsType.BasicType(type));
+            }
+        }
+
+        return null;
+    }
+
+    private Map<String, String> convertToMap(String mappingString) {
+
+        Map<String, String> customMapping = new HashMap<>();
+        String[] values = mappingString.split(":");
+        customMapping.put(values[0], values[1]);
+
+        return customMapping;
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import java.lang.reflect.*;
 import java.math.*;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 
@@ -82,6 +83,7 @@ public class DefaultTypeProcessor implements TypeProcessor {
         knownTypes.put(BigDecimal.class, TsType.Number);
         knownTypes.put(BigInteger.class, TsType.Number);
         knownTypes.put(Date.class, TsType.Date);
+        knownTypes.put(ZonedDateTime.class, TsType.Date);
         knownTypes.put(UUID.class, TsType.String);
         return knownTypes;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -27,6 +27,8 @@ public class Settings {
     public String removeTypeNameSuffix = null;
     public String addTypeNamePrefix = null;
     public String addTypeNameSuffix = null;
+    public List<String> references = null;
+    public List<String> customMappings = null;
     public DateMapping mapDate = DateMapping.asDate;
     public TypeProcessor customTypeProcessor = null;
     public boolean sortDeclarations = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -58,6 +58,9 @@ public class TypeScriptGenerator {
             if (settings.customTypeProcessor != null) {
                 processors.add(settings.customTypeProcessor);
             }
+            if (settings.customMappings != null) {
+                processors.add(new CustomMappingTypeProcessor(settings.customMappings));
+            }
             processors.add(new GenericsTypeProcessor());
             processors.add(new DefaultTypeProcessor());
             typeProcessor = new TypeProcessor.Chain(processors);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -26,6 +26,7 @@ public class Emitter {
             System.out.println("Writing declarations to: " + outputName);
         }
         emitFileComment();
+        emitReferences();
         emitModule(model);
         if (closeOutput) {
             close();
@@ -36,6 +37,14 @@ public class Emitter {
         if (!settings.noFileComment) {
             final String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
             writeIndentedLine("// Generated using typescript-generator version " + TypeScriptGenerator.Version + " on " + timestamp + ".");
+        }
+    }
+
+    private void emitReferences() {
+        if (settings.references != null) {
+            for (String reference : settings.references) {
+                writeIndentedLine(String.format("///<reference path='%s' />", reference));
+            }
         }
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
@@ -1,11 +1,14 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.compiler.SymbolTable;
+import org.junit.Test;
+
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
+
 import static org.junit.Assert.assertEquals;
-import org.junit.Test;
 
 public class DefaultTypeProcessorTest {
 
@@ -18,6 +21,7 @@ public class DefaultTypeProcessorTest {
         assertEquals(TsType.Void, converter.processType(void.class, context).getTsType());
         assertEquals(TsType.Number, converter.processType(BigDecimal.class, context).getTsType());
         assertEquals(TsType.String, converter.processType(UUID.class, context).getTsType());
+        assertEquals(TsType.Date, converter.processType(ZonedDateTime.class, context).getTsType());
     }
 
     @Test

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -1,13 +1,23 @@
 
 package cz.habarta.typescript.generator.gradle;
 
-import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.DateMapping;
 import cz.habarta.typescript.generator.Input;
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import org.gradle.api.*;
-import org.gradle.api.tasks.*;
+import cz.habarta.typescript.generator.JsonLibrary;
+import cz.habarta.typescript.generator.Output;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeScriptFileType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class GenerateTask extends DefaultTask {
@@ -27,6 +37,8 @@ public class GenerateTask extends DefaultTask {
     public String removeTypeNameSuffix;
     public String addTypeNamePrefix;
     public String addTypeNameSuffix;
+    public List<String> references;
+    public List<String> customMappings;
     public DateMapping mapDate;
     public String customTypeProcessor;
     public boolean sortDeclarations;
@@ -75,6 +87,8 @@ public class GenerateTask extends DefaultTask {
         settings.removeTypeNameSuffix = removeTypeNameSuffix;
         settings.addTypeNamePrefix = addTypeNamePrefix;
         settings.addTypeNameSuffix = addTypeNameSuffix;
+        settings.references = references;
+        settings.customMappings = customMappings;
         settings.mapDate = mapDate;
         settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
         settings.sortDeclarations = sortDeclarations;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -199,6 +199,21 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter
     private boolean experimentalInlineEnums;
 
+	/**
+     * List of references, which should be included as &quot;///<reference path='filepath'&quot; />
+     */
+    @Parameter
+    private List<String> references;
+
+	/**
+     * Definition of custom mappings to override any class-mapping to a designated value.
+     * Format Class:TypeScriptMapping.
+     * E.g. mapping a java.time.ZonedDateTime to a Date would result in:
+     * &quot;java.time.ZonedDateTime:Date&quot;
+     */
+    @Parameter
+    private List<String> customMappings;
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -229,6 +244,8 @@ public class GenerateMojo extends AbstractMojo {
             settings.removeTypeNameSuffix = removeTypeNameSuffix;
             settings.addTypeNamePrefix = addTypeNamePrefix;
             settings.addTypeNameSuffix = addTypeNameSuffix;
+            settings.references = references;
+            settings.customMappings = customMappings;
             settings.mapDate = mapDate;
             settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
             settings.sortDeclarations = sortDeclarations;


### PR DESCRIPTION
Hi Voji,

I just implemented some enhancements for your TypeScript-Generator, that enables me (and possibly other users) to define their custom-mappings.
We currently have a file with our common definitions for basic data (such as Money etc). As we already talked about the problem with using custom JsonSerializers and mapping them to TypeScript-Types, this would solve the problem for us now, as we can simply override the "any"-declaration with any type we would like to use.
Furthermore this also solves the problem with using JDK8 classes or joda-time, as this can simply be done by defining a custom-mapping.

E.g. adding the following properties to the config-file would already solve this:
`
references = [
    'references/references.ts'
  ]
  customMappings = [
    'org.joda.money.Money:Money',
    'java.time.ZonedDateTime:Date'
  ]
`
I hope you like the solution