### PR TITLE
Add enum values bean mapping

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -40,6 +40,8 @@ public class Settings {
     public List<EmitterExtension> extensions = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean experimentalInlineEnums = false;
+    public boolean enumValueModel = false;
+    public String addEnumValueSuffix = "Value";
 
 
     public void loadCustomTypeProcessor(ClassLoader classLoader, String customTypeProcessor) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -85,6 +85,21 @@ public abstract class TsType {
         }
     }
 
+    public static class EnumValueReferenceType extends ReferenceType {
+
+        public EnumValueReferenceType(Symbol symbol) {
+            super(symbol);
+        }
+
+        @Override
+        public java.lang.String format(Settings settings) {
+            String enumTypeName = super.format(settings);
+            String suffix = settings.addEnumValueSuffix;
+            return enumTypeName + suffix;
+        }
+
+    }
+
     public static class BasicArrayType extends TsType {
 
         public final TsType elementType;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
@@ -6,21 +6,28 @@ import java.util.List;
 
 
 public class TsEnumModel extends TsDeclarationModel {
-    
-    private final List<String> values;
 
-    public TsEnumModel(TsType name, List<String> comments, List<String> values) {
+    private final List<String> values;
+    private final TsBeanModel valueModel;
+
+    public TsEnumModel(TsType name, List<String> comments, List<String> values, TsBeanModel valueModel) {
         super(name, comments);
         this.values = values;
+        this.valueModel = valueModel;
     }
 
-    public TsEnumModel(Class<?> origin, TsType name, List<String> comments, List<String> values) {
+    public TsEnumModel(Class<?> origin, TsType name, List<String> comments, List<String> values, TsBeanModel beanModel) {
         super(origin, name, comments);
         this.values = values;
+        this.valueModel = beanModel;
     }
 
     public List<String> getValues() {
         return values;
+    }
+
+    public TsBeanModel getValueModel() {
+        return valueModel;
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
@@ -5,15 +5,18 @@ import java.util.*;
 
 
 public class EnumModel {
-    
+
     private final Class<?> enumClass;
     private final List<String> values;
     private final List<String> comments;
 
-    public EnumModel(Class<?> enumClass, List<String> values, List<String> comments) {
+    private final BeanModel valueModel;
+
+    public EnumModel(Class<?> enumClass, List<String> values, List<String> comments, BeanModel valueModel) {
         this.enumClass = enumClass;
         this.values = values;
         this.comments = comments;
+        this.valueModel = valueModel;
     }
 
     public Class<?> getEnumClass() {
@@ -26,6 +29,10 @@ public class EnumModel {
 
     public List<String> getComments() {
         return comments;
+    }
+
+    public BeanModel getValueModel() {
+        return valueModel;
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -97,7 +97,9 @@ public class Javadoc {
         final Enum dEnum = findJavadocEnum(enumModel.getEnumClass(), dRoots);
         final String enumComment = dEnum != null ? dEnum.getComment() : null;
         final List<TagInfo> tags = dEnum != null ? dEnum.getTag() : null;
-        return new EnumModel(enumModel.getEnumClass(), enumModel.getValues(), concat(getComments(enumComment, tags), enumModel.getComments()));
+        return new EnumModel(enumModel.getEnumClass(), enumModel.getValues(),
+                concat(getComments(enumComment, tags), enumModel.getComments()),
+                enumModel.getValueModel());
     }
 
     // finders

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -23,6 +23,19 @@ public class EnumTest {
     }
 
     @Test
+    public void testRichEnum() {
+        final Settings settings = TestUtils.settings();
+        final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AnotherClass.class));
+        final String expected = ("\n"
+                + "interface AnotherClass {\n"
+                + "    richEnum: RichEnum;\n"
+                + "}\n"
+                + "\n"
+                + "type RichEnum = 'A' | 'B';\n").replace("'", "\"");
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testSingleEnum() {
         final Settings settings = TestUtils.settings();
         final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Direction.class));
@@ -47,15 +60,86 @@ public class EnumTest {
         assertEquals(expected, output);
     }
 
+    @Test
+    public void enumValueModelTest() {
+        final Settings settings = TestUtils.settings();
+        settings.enumValueModel = true;
+        settings.addEnumValueSuffix = "Value";
+        final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
+        final String expected = ("\n"
+                + "interface AClass {\n"
+                + "    direction: Direction;\n"
+                + "}\n"
+                + "\n"
+                + "interface DirectionValue {\n"
+                + "}\n"
+                + "\n"
+                + "type Direction = 'North' | 'East' | 'South' | 'West';\n").replace("'", "\"");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void richEnumValueModelTest() {
+        final Settings settings = TestUtils.settings();
+        settings.enumValueModel = true;
+        settings.addEnumValueSuffix = "Value";
+        final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AnotherClass.class));
+        final String expected = ("\n"
+                + "interface AnotherClass {\n"
+                + "    richEnum: RichEnum;\n"
+                + "}\n"
+                + "\n"
+                + "interface RichEnumValue {\n"
+                + "    name: string;\n"
+                + "    value: number;\n"
+                + "    directions: Direction[];\n"
+                + "}\n"
+                + "\n"
+                + "type RichEnum = 'A' | 'B';\n").replace("'", "\"");
+        assertEquals(expected, actual);
+    }
+
     private static class AClass {
         public Direction direction;
     }
 
+    private static class AnotherClass {
+
+        public RichEnum richEnum;
+    }
+
     enum Direction {
         North,
-        East, 
+        East,
         South,
         West
+    }
+
+    enum RichEnum {
+        A("aaa", 12, Direction.North),
+        B("bqsd", 54, Direction.North, Direction.West);
+        String name;
+        int value;
+        Direction[] directions;
+
+        private RichEnum(String name, int value, Direction... directions) {
+            this.name = name;
+            this.value = value;
+            this.directions = directions;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public Direction[] getDirections() {
+            return directions;
+        }
+
     }
 
 }


### PR DESCRIPTION
This change introduces a new option to allow the creation of an interface for enum constants. This is welcomed in case fields are declared inside the java enum.
As the type name must be suffixed, another option to specify that suffix has been added.