### PR TITLE
Add annotationFilters and displaySerializerWarning settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ release.properties
 **.classpath
 **.project
 **.settings
+
+# JetBrain IntelliJ
+.idea/
+**.iml

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -38,8 +38,10 @@ public class Settings {
     public boolean noFileComment = false;
     public List<File> javadocXmlFiles = null;
     public List<EmitterExtension> extensions = new ArrayList<>();
+    public List<Class<? extends Annotation>> annotationFilters = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean experimentalInlineEnums = false;
+    public boolean displaySerializerWarning = true;
 
 
     public void loadCustomTypeProcessor(ClassLoader classLoader, String customTypeProcessor) {
@@ -51,6 +53,12 @@ public class Settings {
     public void loadExtensions(ClassLoader classLoader, List<String> extensions) {
         if (extensions != null) {
             this.extensions = loadInstances(classLoader, extensions, EmitterExtension.class);
+        }
+    }
+
+    public void loadAnnotationFilters(ClassLoader classLoader, List<String> annotationFilters) {
+        if (annotationFilters != null) {
+            this.annotationFilters = loadClasses(classLoader, annotationFilters, Annotation.class);
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -38,7 +38,7 @@ public class Settings {
     public boolean noFileComment = false;
     public List<File> javadocXmlFiles = null;
     public List<EmitterExtension> extensions = new ArrayList<>();
-    public List<Class<? extends Annotation>> annotationFilters = new ArrayList<>();
+    public List<Class<? extends Annotation>> includePropertyAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean experimentalInlineEnums = false;
     public boolean displaySerializerWarning = true;
@@ -56,9 +56,9 @@ public class Settings {
         }
     }
 
-    public void loadAnnotationFilters(ClassLoader classLoader, List<String> annotationFilters) {
-        if (annotationFilters != null) {
-            this.annotationFilters = loadClasses(classLoader, annotationFilters, Annotation.class);
+    public void loadIncludePropertyAnnotations(ClassLoader classLoader, List<String> includePropertyAnnotations) {
+        if (includePropertyAnnotations != null) {
+            this.includePropertyAnnotations = loadClasses(classLoader, includePropertyAnnotations, Annotation.class);
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -45,6 +45,19 @@ public class Jackson1Parser extends ModelParser {
                     if (propertyType == JsonNode.class) {
                         propertyType = Object.class;
                     }
+                    boolean isInAnnotationFilter = settings.annotationFilters.isEmpty();
+                    if (!isInAnnotationFilter) {
+                        for (Class<? extends Annotation> optionalAnnotation : settings.annotationFilters) {
+                            if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
+                                isInAnnotationFilter = true;
+                                break;
+                            }
+                        }
+                        if (!isInAnnotationFilter) {
+                            System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from annotationFilters!");
+                            continue;
+                        }
+                    }
                     boolean optional = false;
                     for (Class<? extends Annotation> optionalAnnotation : settings.optionalAnnotations) {
                         if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -45,16 +45,16 @@ public class Jackson1Parser extends ModelParser {
                     if (propertyType == JsonNode.class) {
                         propertyType = Object.class;
                     }
-                    boolean isInAnnotationFilter = settings.annotationFilters.isEmpty();
+                    boolean isInAnnotationFilter = settings.includePropertyAnnotations.isEmpty();
                     if (!isInAnnotationFilter) {
-                        for (Class<? extends Annotation> optionalAnnotation : settings.annotationFilters) {
+                        for (Class<? extends Annotation> optionalAnnotation : settings.includePropertyAnnotations) {
                             if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
                                 isInAnnotationFilter = true;
                                 break;
                             }
                         }
                         if (!isInAnnotationFilter) {
-                            System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from annotationFilters!");
+                            System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
                             continue;
                         }
                     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -32,16 +32,16 @@ public class Jackson2Parser extends ModelParser {
                     if (propertyType == JsonNode.class) {
                         propertyType = Object.class;
                     }
-                    boolean isInAnnotationFilter = settings.annotationFilters.isEmpty();
+                    boolean isInAnnotationFilter = settings.includePropertyAnnotations.isEmpty();
                     if (!isInAnnotationFilter) {
-                        for (Class<? extends Annotation> optionalAnnotation : settings.annotationFilters) {
+                        for (Class<? extends Annotation> optionalAnnotation : settings.includePropertyAnnotations) {
                             if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
                                 isInAnnotationFilter = true;
                                 break;
                             }
                         }
                         if (!isInAnnotationFilter) {
-                            System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from annotationFilters!");
+                            System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
                             continue;
                         }
                     }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -22,6 +22,7 @@ public class GenerateTask extends DefaultTask {
     public String classesFromJaxrsApplication;
     public boolean classesFromAutomaticJaxrsApplication;
     public List<String> excludeClasses;
+    public List<String> annotationFilters;
     public JsonLibrary jsonLibrary;
     public boolean declarePropertiesAsOptional;
     public String removeTypeNamePrefix;
@@ -41,6 +42,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> extensionClasses;
     public List<String> optionalAnnotations;
     public boolean experimentalInlineEnums;
+    public boolean displaySerializerWarning = true;
 
     @TaskAction
     public void generate() throws Exception {
@@ -91,8 +93,10 @@ public class GenerateTask extends DefaultTask {
         settings.noFileComment = noFileComment;
         settings.javadocXmlFiles = javadocXmlFiles;
         settings.loadExtensions(classLoader, extensionClasses);
+        settings.loadAnnotationFilters(classLoader, annotationFilters);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.experimentalInlineEnums = experimentalInlineEnums;
+        settings.displaySerializerWarning = displaySerializerWarning;
         settings.validateFileName(new File(outputFile));
 
         // TypeScriptGenerator

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -22,7 +22,7 @@ public class GenerateTask extends DefaultTask {
     public String classesFromJaxrsApplication;
     public boolean classesFromAutomaticJaxrsApplication;
     public List<String> excludeClasses;
-    public List<String> annotationFilters;
+    public List<String> includePropertyAnnotations;
     public JsonLibrary jsonLibrary;
     public boolean declarePropertiesAsOptional;
     public String removeTypeNamePrefix;
@@ -93,7 +93,7 @@ public class GenerateTask extends DefaultTask {
         settings.noFileComment = noFileComment;
         settings.javadocXmlFiles = javadocXmlFiles;
         settings.loadExtensions(classLoader, extensionClasses);
-        settings.loadAnnotationFilters(classLoader, annotationFilters);
+        settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.experimentalInlineEnums = experimentalInlineEnums;
         settings.displaySerializerWarning = displaySerializerWarning;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -99,7 +99,7 @@ public class GenerateMojo extends AbstractMojo {
      * methods with one of the annotations defined in this list
      */
     @Parameter
-    private List<String> annotationFilters;
+    private List<String> includePropertyAnnotations;
 
     /**
      * Library used in JSON classes.
@@ -291,7 +291,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.noFileComment = noFileComment;
             settings.javadocXmlFiles = javadocXmlFiles;
             settings.loadExtensions(classLoader, extensions);
-            settings.loadAnnotationFilters(classLoader, annotationFilters);
+            settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.experimentalInlineEnums = experimentalInlineEnums;
             settings.displaySerializerWarning = displaySerializerWarning;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -95,6 +95,13 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> excludeClasses;
 
     /**
+     * If this list is not empty then TypeScript will only be generated for
+     * methods with one of the annotations defined in this list
+     */
+    @Parameter
+    private List<String> annotationFilters;
+
+    /**
      * Library used in JSON classes.
      * Supported values are 'jackson1', 'jackson2'.
      * Required parameter, recommended value is 'jackson2'.
@@ -237,6 +244,12 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter
     private boolean experimentalInlineEnums;
 
+    /**
+     * Display warnings when bean serializer is not found.
+     */
+    @Parameter(defaultValue = "true")
+    private boolean displaySerializerWarning;
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -278,8 +291,10 @@ public class GenerateMojo extends AbstractMojo {
             settings.noFileComment = noFileComment;
             settings.javadocXmlFiles = javadocXmlFiles;
             settings.loadExtensions(classLoader, extensions);
+            settings.loadAnnotationFilters(classLoader, annotationFilters);
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.experimentalInlineEnums = experimentalInlineEnums;
+            settings.displaySerializerWarning = displaySerializerWarning;
             settings.validateFileName(outputFile);
 
             // TypeScriptGenerator


### PR DESCRIPTION
Add the ability to do two things:
- Filter the methods generated by requiring an annotation to be present.
- Add the ability to disable the "Warning: Unknown serializer" messages.

Method filtering does not yet happen in the JaxrsApplicationScanner but should probably be added.