### PR TITLE
Enum support #77 added

### DIFF
--- a/sample-maven/pom.xml
+++ b/sample-maven/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>cz.habarta.typescript-generator</groupId>
                 <artifactId>typescript-generator-maven-plugin</artifactId>
-                <version>1.7-SNAPSHOT</version>
+                <version>1.10-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate</id>
@@ -35,6 +35,7 @@
                             </classes>
                             <outputFile>target/sample.d.ts</outputFile>
                             <outputKind>module</outputKind>
+                            <typescriptEnums>true</typescriptEnums>
                         </configuration>
                     </execution>
                 </executions>

--- a/sample-maven/src/main/java/cz/habarta/typescript/generator/sample/Person.java
+++ b/sample-maven/src/main/java/cz/habarta/typescript/generator/sample/Person.java
@@ -7,9 +7,14 @@ import java.util.*;
 public class Person {
 
     public String name;
+    public Sex sex;
     public int age;
     public boolean hasChildren;
     public List<String> tags;
     public Map<String, String> emails;
 
+}
+
+enum Sex {
+    MALE, FEMALE
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -41,6 +41,7 @@ public class Settings {
     public List<Class<? extends Annotation>> includePropertyAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean experimentalInlineEnums = false;
+    public boolean typescriptEnums = false;
     public boolean displaySerializerWarning = true;
 
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -132,6 +132,36 @@ public abstract class TsType {
 
     }
 
+    public static class CommaSeparatedType extends TsType {
+
+        public final List<TsType> types;
+
+        public CommaSeparatedType(List<? extends TsType> types) {
+            this.types = new ArrayList<>(types);
+        }
+
+        @Override
+        public String format(Settings settings) {
+            return Utils.join(format(types, settings), ", ");
+        }
+
+    }
+
+    public static class LiteralType extends TsType {
+
+        public final String literal;
+
+        public LiteralType(String literal) {
+            this.literal = literal;
+        }
+
+        @Override
+        public String format(Settings settings) {
+            return literal;
+        }
+
+    }
+
     public static class StringLiteralType extends TsType {
 
         public final String literal;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -103,6 +103,7 @@ public class Emitter {
         exportKeyword = exportKeyword || forceExportKeyword;
         emitInterfaces(model, exportKeyword);
         emitTypeAliases(model, exportKeyword);
+        emitEnums(model, exportKeyword);
         emitNumberEnums(model, exportKeyword, declareKeyword);
         for (EmitterExtension emitterExtension : settings.extensions) {
             emitterExtension.emitElements(new EmitterExtension.Writer() {
@@ -176,6 +177,18 @@ public class Emitter {
             writeNewLine();
             emitComments(alias.getComments());
             writeIndentedLine(exportKeyword, "type " + alias.getName() + " = " + alias.getDefinition().format(settings) + ";");
+        }
+    }
+
+    private void emitEnums(TsModel model, boolean exportKeyword) {
+        final ArrayList<TsAliasModel> aliases = new ArrayList<>(model.getTsEnums());
+        if (settings.sortDeclarations || settings.sortTypeDeclarations) {
+            Collections.sort(aliases);
+        }
+        for (TsAliasModel alias : aliases) {
+            writeNewLine();
+            emitComments(alias.getComments());
+            writeIndentedLine(exportKeyword, "enum " + alias.getName() + " { " + alias.getDefinition().format(settings) + " }");
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -188,7 +188,7 @@ public class Emitter {
         for (TsAliasModel alias : aliases) {
             writeNewLine();
             emitComments(alias.getComments());
-            writeIndentedLine(exportKeyword, "enum " + alias.getName() + " { " + alias.getDefinition().format(settings) + " }");
+            writeIndentedLine(exportKeyword, "const enum " + alias.getName() + " { " + alias.getDefinition().format(settings) + " }");
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
@@ -10,18 +10,24 @@ public class TsModel {
     private final List<TsBeanModel> beans;
     private final List<TsEnumModel<?>> enums;
     private final List<TsAliasModel> typeAliases;
+    private final List<TsAliasModel> tsEnums;
 
     public TsModel() {
-        this (new ArrayList<TsBeanModel>(), new ArrayList<TsEnumModel<?>>(), new ArrayList<TsAliasModel>());
+        this (new ArrayList<TsBeanModel>(), new ArrayList<TsEnumModel<?>>(), new ArrayList<TsAliasModel>(), new ArrayList<TsAliasModel>());
     }
 
     public TsModel(List<TsBeanModel> beans, List<TsEnumModel<?>> enums, List<TsAliasModel> typeAliases) {
+        this (beans, enums, typeAliases, new ArrayList<TsAliasModel>());
+    }
+
+    public TsModel(List<TsBeanModel> beans, List<TsEnumModel<?>> enums, List<TsAliasModel> typeAliases, List<TsAliasModel> tsEnums) {
         if (beans == null) throw new NullPointerException();
         if (enums == null) throw new NullPointerException();
         if (typeAliases == null) throw new NullPointerException();
         this.beans = beans;
         this.enums = enums;
         this.typeAliases = typeAliases;
+        this.tsEnums = tsEnums;
     }
 
     public List<TsBeanModel> getBeans() {
@@ -29,7 +35,7 @@ public class TsModel {
     }
 
     public TsModel setBeans(List<TsBeanModel> beans) {
-        return new TsModel(beans, enums, typeAliases);
+        return new TsModel(beans, enums, typeAliases, tsEnums);
     }
 
     public List<TsEnumModel<?>> getEnums() {
@@ -48,7 +54,7 @@ public class TsModel {
     }
 
     public TsModel setEnums(List<TsEnumModel<?>> enums) {
-        return new TsModel(beans, enums, typeAliases);
+        return new TsModel(beans, enums, typeAliases, tsEnums);
     }
 
     public List<TsAliasModel> getTypeAliases() {
@@ -56,7 +62,15 @@ public class TsModel {
     }
 
     public TsModel setTypeAliases(List<TsAliasModel> typeAliases) {
-        return new TsModel(beans, enums, typeAliases);
+        return new TsModel(beans, enums, typeAliases, tsEnums);
+    }
+
+    public List<TsAliasModel> getTsEnums() {
+        return tsEnums;
+    }
+
+    public TsModel setTsEnums(List<TsAliasModel> tsEnums) {
+        return new TsModel(beans, enums, typeAliases, tsEnums);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumExtension.java
@@ -1,0 +1,46 @@
+
+package cz.habarta.typescript.generator.ext;
+
+import java.util.Collections;
+import java.util.List;
+
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.compiler.EnumKind;
+import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.emitter.EmitterExtension;
+import cz.habarta.typescript.generator.emitter.TsEnumModel;
+import cz.habarta.typescript.generator.emitter.TsModel;
+
+/**
+ * For creating real TypeScript enumerations
+ * @author rgevrek
+ * @since 19.08.2016
+ */
+public class EnumExtension extends EmitterExtension {
+
+  @Override
+  public boolean generatesRuntimeCode() {
+    return false;
+  }
+
+  @Override
+  public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
+    String exportString = exportKeyword ? "export " : "";
+    List<TsEnumModel<String>> enums = model.getEnums(EnumKind.StringBased);
+    Collections.sort(enums);
+    for (TsEnumModel<String> tsEnum : enums) {
+      writer.writeIndentedLine("");
+      writer.writeIndentedLine(exportString + "enum " + tsEnum.getName() + " {");
+      int length = tsEnum.getMembers().size();
+      int i=0;
+      for (EnumMemberModel<String> member : tsEnum.getMembers()) {
+        if (++i<length) {
+          writer.writeIndentedLine(settings.indentString + member.getPropertyName()+",");
+        }
+        else
+          writer.writeIndentedLine(settings.indentString + member.getPropertyName());
+      }
+      writer.writeIndentedLine("}");
+    }
+  }
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumExtension.java
@@ -30,7 +30,7 @@ public class EnumExtension extends EmitterExtension {
     Collections.sort(enums);
     for (TsEnumModel<String> tsEnum : enums) {
       writer.writeIndentedLine("");
-      writer.writeIndentedLine(exportString + "enum " + tsEnum.getName() + " {");
+      writer.writeIndentedLine(exportString + "const enum " + tsEnum.getName() + " {");
       int length = tsEnum.getMembers().size();
       int i=0;
       for (EnumMemberModel<String> member : tsEnum.getMembers()) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest {
                 "    direction: Direction;\n" +
                 "}\n" +
                 "\n" +
-                "enum Direction { North, East, South, West }\n";
+                "const enum Direction { North, East, South, West }\n";
         assertEquals(expected, output);
     }
 
@@ -55,7 +55,7 @@ public class EnumTest {
         final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Direction.class));
         final String expected = (
             "\n" +
-                "enum Direction { North, East, South, West }\n"
+                "const enum Direction { North, East, South, West }\n"
         );
         assertEquals(expected, actual);
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -34,6 +34,33 @@ public class EnumTest {
     }
 
     @Test
+    public void typescriptEnumTest() {
+        final Settings settings = TestUtils.settings();
+        settings.typescriptEnums = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
+        final String expected =
+            "\n" +
+                "interface AClass {\n" +
+                "    direction: Direction;\n" +
+                "}\n" +
+                "\n" +
+                "enum Direction { North, East, South, West }\n";
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testSingletypescriptEnum() {
+        final Settings settings = TestUtils.settings();
+        settings.typescriptEnums = true;
+        final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Direction.class));
+        final String expected = (
+            "\n" +
+                "enum Direction { North, East, South, West }\n"
+        );
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void inlineEnumTest() {
         final Settings settings = TestUtils.settings();
         settings.quotes = "'";

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -42,6 +42,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> extensionClasses;
     public List<String> optionalAnnotations;
     public boolean experimentalInlineEnums;
+    public boolean typescriptEnums;
     public boolean displaySerializerWarning = true;
 
     @TaskAction
@@ -96,6 +97,7 @@ public class GenerateTask extends DefaultTask {
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.experimentalInlineEnums = experimentalInlineEnums;
+        settings.typescriptEnums = typescriptEnums;
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.validateFileName(new File(outputFile));
 

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -227,6 +227,8 @@ public class GenerateMojo extends AbstractMojo {
      * List of extensions specified as fully qualified class name.
      * Known extensions:
      * cz.habarta.typescript.generator.ext.TypeGuardsForJackson2PolymorphismExtension
+     * cz.habarta.typescript.generator.ext.EnumConstantsExtension
+     * cz.habarta.typescript.generator.ext.EnumExtension
      */
     @Parameter
     private List<String> extensions;
@@ -246,6 +248,13 @@ public class GenerateMojo extends AbstractMojo {
      */
     @Parameter
     private boolean experimentalInlineEnums;
+
+    /**
+     * Defines enum type on places where the enum is used.
+     * (Without this flag a type is created.)
+     */
+    @Parameter
+    private boolean typescriptEnums;
 
     /**
      * Display warnings when bean serializer is not found.
@@ -297,6 +306,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.experimentalInlineEnums = experimentalInlineEnums;
+            settings.typescriptEnums = typescriptEnums;
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.validateFileName(outputFile);
 


### PR DESCRIPTION
With this change you can get following enum structure:
`enum MyEnum { el1, elem2 }`

by adding following configuration:
`<typescriptEnums>true</typescriptEnums>`

or by adding this extension:
```
<extensions>
<extension>cz.habarta.typescript.generator.ext.EnumExtension</extension>
</extensions>
```