### PR TITLE
Tagged unions

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
 import java.util.*;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
 import java.util.*;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
@@ -12,7 +12,7 @@ public class GenericsTypeProcessor implements TypeProcessor {
     public TypeProcessor.Result processType(Type javaType, TypeProcessor.Context context) {
         if (javaType instanceof TypeVariable) {
             final TypeVariable<?> typeVariable = (TypeVariable) javaType;
-            return new Result(new GenericVariableType(typeVariable.getName()));
+            return new Result(new TsType.GenericVariableType(typeVariable.getName()));
         }
         if (javaType instanceof Class) {
             final Class<?> javaClass = (Class<?>) javaType;
@@ -44,33 +44,10 @@ public class GenericsTypeProcessor implements TypeProcessor {
                 discoveredClasses.addAll(typeArgumentResult.getDiscoveredClasses());
             }
             // result
-            final GenericReferenceType type = new GenericReferenceType(rawSymbol, tsTypeArguments);
+            final TsType.GenericReferenceType type = new TsType.GenericReferenceType(rawSymbol, tsTypeArguments);
             return new Result(type, discoveredClasses);
         }
         return null;
-    }
-
-    private static class GenericReferenceType extends TsType.ReferenceType {
-
-        public final List<TsType> typeArguments;
-
-        public GenericReferenceType(Symbol symbol, List<TsType> typeArguments) {
-            super(symbol);
-            this.typeArguments = typeArguments;
-        }
-
-        @Override
-        public String format(Settings settings) {
-            return symbol + "<" + Utils.join(format(typeArguments, settings), ", ") + ">";
-        }
-    }
-    
-    private static class GenericVariableType extends TsType.BasicType {
-
-        public GenericVariableType(String name) {
-            super(name);
-        }
-
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.parser.*;
+import cz.habarta.typescript.generator.util.Utils;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import java.lang.annotation.*;
 import java.lang.reflect.*;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -31,8 +31,9 @@ public class Settings {
     public List<String> referencedFiles = new ArrayList<>();
     public List<String> importDeclarations = new ArrayList<>();
     public Map<String, String> customTypeMappings = new LinkedHashMap<>();
-    public DateMapping mapDate = DateMapping.asDate;
-    public EnumMapping mapEnum = EnumMapping.asUnion;
+    public DateMapping mapDate; // default is DateMapping.asDate
+    public EnumMapping mapEnum; // default is EnumMapping.asUnion
+    public boolean disableTaggedUnions = false;
     public TypeProcessor customTypeProcessor = null;
     public boolean sortDeclarations = false;
     public boolean sortTypeDeclarations = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.compiler.Symbol;
+import cz.habarta.typescript.generator.util.Utils;
 import java.util.*;
 
 
@@ -75,6 +76,29 @@ public abstract class TsType {
         @Override
         public String format(Settings settings) {
             return symbol.toString();
+        }
+
+    }
+
+    public static class GenericReferenceType extends TsType.ReferenceType {
+
+        public final List<TsType> typeArguments;
+
+        public GenericReferenceType(Symbol symbol, List<TsType> typeArguments) {
+            super(symbol);
+            this.typeArguments = typeArguments;
+        }
+
+        @Override
+        public String format(Settings settings) {
+            return symbol + "<" + Utils.join(format(typeArguments, settings), ", ") + ">";
+        }
+    }
+    
+    public static class GenericVariableType extends TsType.BasicType {
+
+        public GenericVariableType(String name) {
+            super(name);
         }
 
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -41,28 +41,37 @@ public class ModelCompiler {
     public TsModel javaToTypeScript(Model model) {
         final SymbolTable symbolTable = new SymbolTable(settings);
         TsModel tsModel = processModel(symbolTable, model);
+
+        // dates
         tsModel = transformDates(symbolTable, tsModel);
-        if (settings.mapEnum == EnumMapping.asUnion || settings.mapEnum == EnumMapping.asInlineUnion) {
+
+        // enums
+        if (settings.mapEnum == null || settings.mapEnum == EnumMapping.asUnion || settings.mapEnum == EnumMapping.asInlineUnion) {
             tsModel = transformEnumsToUnions(tsModel);
         }
         if (settings.mapEnum == EnumMapping.asInlineUnion) {
             tsModel = inlineEnums(tsModel, symbolTable);
         }
-        symbolTable.resolveSymbolNames(settings);
+
+        // tagged unions
+        tsModel = createAndUseTaggedUnions(symbolTable, tsModel);
+
+        symbolTable.resolveSymbolNames();
         return tsModel;
     }
 
     public TsType javaToTypeScript(Type type) {
-        final BeanModel beanModel = new BeanModel(Object.class, Object.class, Collections.<Type>emptyList(), Collections.singletonList(new PropertyModel("property", type, false, null, null)));
+        final BeanModel beanModel = new BeanModel(Object.class, Object.class, null, null, null, Collections.<Type>emptyList(), Collections.singletonList(new PropertyModel("property", type, false, null, null)), null);
         final Model model = new Model(Collections.singletonList(beanModel), Collections.<EnumModel<?>>emptyList());
         final TsModel tsModel = javaToTypeScript(model);
         return tsModel.getBeans().get(0).getProperties().get(0).getTsType();
     }
 
     private TsModel processModel(SymbolTable symbolTable, Model model) {
+        final Map<Type, List<BeanModel>> children = createChildrenMap(model);
         final List<TsBeanModel> beans = new ArrayList<>();
         for (BeanModel bean : model.getBeans()) {
-            beans.add(processBean(symbolTable, bean));
+            beans.add(processBean(symbolTable, children, bean));
         }
         final List<TsEnumModel<?>> enums = new ArrayList<>();
         for (EnumModel<?> enumModel : model.getEnums()) {
@@ -72,7 +81,21 @@ public class ModelCompiler {
         return new TsModel(beans, enums, typeAliases);
     }
 
-    private TsBeanModel processBean(SymbolTable symbolTable, BeanModel bean) {
+    private Map<Type, List<BeanModel>> createChildrenMap(Model model) {
+        final Map<Type, List<BeanModel>> children = new LinkedHashMap<>();
+        for (BeanModel bean : model.getBeans()) {
+            final Type parent = bean.getParent();
+            if (parent != null) {
+                if (!children.containsKey(parent)) {
+                    children.put(parent, new ArrayList<BeanModel>());
+                }
+                children.get(parent).add(bean);
+            }
+        }
+        return children;
+    }
+
+    private TsBeanModel processBean(SymbolTable symbolTable, Map<Type, List<BeanModel>> children, BeanModel bean) {
         final TsType beanType = typeFromJava(symbolTable, bean.getOrigin());
         TsType parentType = typeFromJava(symbolTable, bean.getParent());
         if (parentType != null && parentType.equals(TsType.Any)) {
@@ -89,7 +112,43 @@ public class ModelCompiler {
         for (PropertyModel property : bean.getProperties()) {
             properties.add(processProperty(symbolTable, bean, property));
         }
-        return new TsBeanModel(bean.getOrigin(), beanType, parentType, interfaces, properties, bean.getComments());
+
+        if (bean.getDiscriminantProperty() != null && !containsProperty(properties, bean.getDiscriminantProperty())) {
+            final List<BeanModel> selfAndDescendants = getSelfAndDescendants(bean, children);
+            final List<TsType.StringLiteralType> literals = new ArrayList<>();
+            for (BeanModel descendant : selfAndDescendants) {
+                if (descendant.getDiscriminantLiteral() != null) {
+                    literals.add(new TsType.StringLiteralType(descendant.getDiscriminantLiteral()));
+                }
+            }
+            final TsType discriminantType = literals.isEmpty()
+                    ? TsType.String
+                    : new TsType.UnionType(literals);
+            properties.add(0, new TsPropertyModel(bean.getDiscriminantProperty(), discriminantType, null));
+        }
+
+        return new TsBeanModel(bean.getOrigin(), beanType, parentType, bean.getTaggedUnionClasses(), interfaces, properties, bean.getComments());
+    }
+
+    private static List<BeanModel> getSelfAndDescendants(BeanModel bean, Map<Type, List<BeanModel>> children) {
+        final List<BeanModel> descendants = new ArrayList<>();
+        descendants.add(bean);
+        final List<BeanModel> directDescendants = children.get(bean.getOrigin());
+        if (directDescendants != null) {
+            for (BeanModel descendant : directDescendants) {
+                descendants.addAll(getSelfAndDescendants(descendant, children));
+            }
+        }
+        return descendants;
+    }
+
+    private static boolean containsProperty(List<TsPropertyModel> properties, String propertyName) {
+        for (TsPropertyModel property : properties) {
+            if (property.getName().equals(propertyName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private TsPropertyModel processProperty(SymbolTable symbolTable, BeanModel bean, PropertyModel property) {
@@ -187,6 +246,46 @@ public class ModelCompiler {
         return newTsModel.setTypeAliases(aliases);
     }
 
+    private TsModel createAndUseTaggedUnions(final SymbolTable symbolTable, TsModel tsModel) {
+        if (settings.disableTaggedUnions) {
+            return tsModel;
+        }
+        // create tagged unions
+        final LinkedHashSet<TsAliasModel> typeAliases = new LinkedHashSet<>(tsModel.getTypeAliases());
+        for (TsBeanModel bean : tsModel.getBeans()) {
+            if (bean.getTaggedUnionClasses() != null) {
+                if (bean.getName() instanceof TsType.ReferenceType) {
+                    final TsType.ReferenceType unionName = new TsType.ReferenceType(symbolTable.getSymbol(bean.getOrigin(), "Union"));
+                    final List<TsType> unionTypes = new ArrayList<>();
+                    for (Class<?> cls : bean.getTaggedUnionClasses()) {
+                        final TsType type = new TsType.ReferenceType(symbolTable.getSymbol(cls));
+                        unionTypes.add(type);
+                    }
+                    final TsType.UnionType union = new TsType.UnionType(unionTypes);
+                    typeAliases.add(new TsAliasModel(bean.getOrigin(), unionName, union, null));
+                }
+            }
+        }
+        // use tagged unions
+        final TsModel model = transformBeanPropertyTypes(tsModel, new TsType.Transformer() {
+            @Override
+            public TsType transform(TsType tsType) {
+                if (tsType instanceof TsType.ReferenceType) {
+                    final TsType.ReferenceType referenceType = (TsType.ReferenceType) tsType;
+                    if (!(referenceType instanceof TsType.GenericReferenceType)) {
+                        final Class<?> cls = symbolTable.getSymbolClass(referenceType.symbol);
+                        final Symbol unionSymbol = symbolTable.hasSymbol(cls, "Union");
+                        if (unionSymbol != null) {
+                            return new TsType.ReferenceType(unionSymbol);
+                        }
+                    }
+                }
+                return tsType;
+            }
+        });
+        return model.setTypeAliases(new ArrayList<>(typeAliases));
+    }
+
     private static TsModel transformBeanPropertyTypes(TsModel tsModel, TsType.Transformer transformer) {
         final List<TsBeanModel> newBeans = new ArrayList<>();
         for (TsBeanModel bean : tsModel.getBeans()) {
@@ -195,7 +294,7 @@ public class ModelCompiler {
                 final TsType newType = TsType.transformTsType(property.getTsType(), transformer);
                 newProperties.add(property.setTsType(newType));
             }
-            newBeans.add(bean.setProperties(newProperties));
+            newBeans.add(bean.withProperties(newProperties));
         }
         return tsModel.setBeans(newBeans);
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.*;
 import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.util.Utils;
 import java.io.*;
 import java.text.*;
 import java.util.*;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -8,22 +8,28 @@ import java.util.*;
 public class TsBeanModel extends TsDeclarationModel {
 
     private final TsType parent;
+    private final List<Class<?>> taggedUnionClasses;
     private final List<TsType> interfaces;
     private final List<TsPropertyModel> properties;
 
-    public TsBeanModel(TsType name, TsType parent, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
-        this(null, name, parent, interfaces, properties, comments);
+    public TsBeanModel(TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
+        this(null, name, parent, taggedUnionClasses, interfaces, properties, comments);
     }
 
-    public TsBeanModel(Class<?> origin, TsType name, TsType parent, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
+    public TsBeanModel(Class<?> origin, TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
         super(origin, name, comments);
         this.parent = parent;
+        this.taggedUnionClasses = taggedUnionClasses;
         this.interfaces = interfaces;
         this.properties = properties;
     }
 
     public TsType getParent() {
         return parent;
+    }
+
+    public List<Class<?>> getTaggedUnionClasses() {
+        return taggedUnionClasses;
     }
 
     public List<TsType> getInterfaces() {
@@ -43,8 +49,8 @@ public class TsBeanModel extends TsDeclarationModel {
         return properties;
     }
 
-    public TsBeanModel setProperties(List<TsPropertyModel> properties) {
-        return new TsBeanModel(origin, name, parent, interfaces, properties, comments);
+    public TsBeanModel withProperties(List<TsPropertyModel> properties) {
+        return new TsBeanModel(origin, name, parent, taggedUnionClasses, interfaces, properties, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
@@ -8,22 +8,36 @@ import java.util.List;
 public class BeanModel extends DeclarationModel {
 
     private final Type parent;
+    private final List<Class<?>> taggedUnionClasses;
+    private final String discriminantProperty;
+    private final String discriminantLiteral;
     private final List<Type> interfaces;
     private final List<PropertyModel> properties;
 
-    public BeanModel(Class<?> origin, Type parent, List<Type> interfaces, List<PropertyModel> properties) {
-        this(origin, parent, interfaces, properties, null);
-    }
-
-    public BeanModel(Class<?> origin, Type parent, List<Type> interfaces, List<PropertyModel> properties, List<String> comments) {
-        super (origin, comments);
+    public BeanModel(Class<?> origin, Type parent, List<Class<?>> taggedUnionClasses, String discriminantProperty, String discriminantLiteral, List<Type> interfaces, List<PropertyModel> properties, List<String> comments) {
+        super(origin, comments);
         this.parent = parent;
+        this.taggedUnionClasses = taggedUnionClasses;
+        this.discriminantProperty = discriminantProperty;
+        this.discriminantLiteral = discriminantLiteral;
         this.interfaces = interfaces;
         this.properties = properties;
     }
 
     public Type getParent() {
         return parent;
+    }
+
+    public List<Class<?>> getTaggedUnionClasses() {
+        return taggedUnionClasses;
+    }
+
+    public String getDiscriminantProperty() {
+        return discriminantProperty;
+    }
+
+    public String getDiscriminantLiteral() {
+        return discriminantLiteral;
     }
 
     public List<Type> getInterfaces() {
@@ -35,12 +49,12 @@ public class BeanModel extends DeclarationModel {
     }
 
     public BeanModel withProperties(List<PropertyModel> properties) {
-        return new BeanModel(origin, parent, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
     }
 
     @Override
     public BeanModel withComments(List<String> comments) {
-        return new BeanModel(origin, parent, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
     }
 
     @Override

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -92,7 +92,7 @@ public class Jackson1Parser extends ModelParser {
         for (Type aInterface : interfaces) {
             addBeanToQueue(new SourceType<>(aInterface, sourceClass.type, "<interface>"));
         }
-        return new BeanModel(sourceClass.type, superclass, interfaces, properties);
+        return new BeanModel(sourceClass.type, superclass, null, null, null, interfaces, properties, null);
     }
 
     private boolean isParentProperty(String property, Class<?> cls) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
@@ -20,6 +20,15 @@ public class Model {
         return beans;
     }
 
+    public BeanModel getBean(Class<?> beanClass) {
+        for (BeanModel bean : beans) {
+            if (bean.getOrigin().equals(beanClass)) {
+                return bean;
+            }
+        }
+        return null;
+    }
+
     public List<EnumModel<?>> getEnums() {
         return enums;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Pair.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Pair.java
@@ -1,0 +1,58 @@
+
+package cz.habarta.typescript.generator.util;
+
+import java.util.Objects;
+
+
+public class Pair<T1, T2> {
+
+    private final T1 value1;
+    private final T2 value2;
+
+    private Pair(T1 value1, T2 value2) {
+        this.value1 = value1;
+        this.value2 = value2;
+    }
+
+    public static <T1, T2> Pair<T1, T2> of(T1 value1, T2 value2) {
+        return new Pair<>(value1, value2);
+    }
+
+    public T1 getValue1() {
+        return value1;
+    }
+
+    public T2 getValue2() {
+        return value2;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 53 * hash + Objects.hashCode(this.value1);
+        hash = 53 * hash + Objects.hashCode(this.value2);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Pair<?, ?> other = (Pair<?, ?>) obj;
+        if (!Objects.equals(this.value1, other.value1)) {
+            return false;
+        }
+        if (!Objects.equals(this.value2, other.value2)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Predicate.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Predicate.java
@@ -1,0 +1,9 @@
+
+package cz.habarta.typescript.generator.util;
+
+
+public interface Predicate<T> {
+
+    boolean test(T value);
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -1,5 +1,5 @@
 
-package cz.habarta.typescript.generator;
+package cz.habarta.typescript.generator.util;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
@@ -102,6 +102,7 @@ public class GenericsTest {
         final String nl = settings.newline;
         final String expected =
                 "export interface IA extends IB<string> {" + nl +
+                "    type: \"GenericsTest$IA\";" + nl +
                 "}" + nl +
                 "" + nl +
                 "export interface IB<T> {" + nl +

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -41,6 +41,25 @@ public class Jackson2ParserTest {
         Assert.assertEquals(1, beanModel.getProperties().size());
     }
 
+    @Test
+    public void testTaggedUnion() {
+        final Jackson2Parser jacksonParser = getJackson2Parser();
+        final Model model = jacksonParser.parseModel(SubTypeDiscriminatedByName1.class);
+        Assert.assertEquals(4, model.getBeans().size());
+        final BeanModel bean0 = model.getBean(ParentWithNameDiscriminant.class);
+        final BeanModel bean1 = model.getBean(SubTypeDiscriminatedByName1.class);
+        final BeanModel bean2 = model.getBean(SubTypeDiscriminatedByName2.class);
+        final BeanModel bean3 = model.getBean(SubTypeDiscriminatedByName3.class);
+        Assert.assertEquals(3, bean0.getTaggedUnionClasses().size());
+        Assert.assertNull(bean1.getTaggedUnionClasses());
+        Assert.assertNull(bean2.getTaggedUnionClasses());
+        Assert.assertNull(bean3.getTaggedUnionClasses());
+        Assert.assertEquals("kind", bean0.getDiscriminantProperty());
+        Assert.assertEquals("explicit-name1", bean1.getDiscriminantLiteral());
+        Assert.assertEquals("SubType2", bean2.getDiscriminantLiteral());
+        Assert.assertEquals("Jackson2ParserTest$SubTypeDiscriminatedByName3", bean3.getDiscriminantLiteral());
+    }
+
     static Jackson2Parser getJackson2Parser() {
         final Settings settings = new Settings();
         return new Jackson2Parser(settings, new DefaultTypeProcessor());
@@ -56,6 +75,23 @@ public class Jackson2ParserTest {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
     public class InheritedClass {
         public String type;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = SubTypeDiscriminatedByName1.class),
+        @JsonSubTypes.Type(value = SubTypeDiscriminatedByName2.class, name = "SubType2"),
+        @JsonSubTypes.Type(value = SubTypeDiscriminatedByName3.class),
+    })
+    private static interface ParentWithNameDiscriminant {
+    }
+
+    @JsonTypeName("explicit-name1")
+    private static class SubTypeDiscriminatedByName1 implements ParentWithNameDiscriminant {
+    }
+    private static class SubTypeDiscriminatedByName2 implements ParentWithNameDiscriminant {
+    }
+    private static class SubTypeDiscriminatedByName3 implements ParentWithNameDiscriminant {
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -1,0 +1,114 @@
+
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TaggedUnionsTest {
+
+    private static class Geometry {
+        public List<Shape> shapes;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(Square.class),
+        @JsonSubTypes.Type(Rectangle.class),
+        @JsonSubTypes.Type(Circle.class),
+    })
+    private static class Shape {
+    }
+
+    @JsonTypeName("square")
+    private static class Square extends Shape {
+        public double size;
+    }
+
+    @JsonTypeName("rectangle")
+    private static class Rectangle extends Shape {
+        public double width;
+        public double height;
+    }
+
+    @JsonTypeName("circle")
+    private static class Circle extends Shape {
+        public double radius;
+    }
+
+    @Test
+    public void testTaggedUnions() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry.class));
+        final String expected = (
+                "\n" +
+                "interface Geometry {\n" +
+                "    shapes: ShapeUnion[];\n" +
+                "}\n" +
+                "\n" +
+                "interface Shape {\n" +
+                "    kind: 'square' | 'rectangle' | 'circle';\n" +
+                "}\n" +
+                "\n" +
+                "interface Square extends Shape {\n" +
+                "    kind: 'square';\n" +
+                "    size: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Rectangle extends Shape {\n" +
+                "    kind: 'rectangle';\n" +
+                "    width: number;\n" +
+                "    height: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Circle extends Shape {\n" +
+                "    kind: 'circle';\n" +
+                "    radius: number;\n" +
+                "}\n" +
+                "\n" +
+                "type ShapeUnion = Square | Rectangle | Circle;\n" +
+                ""
+                ).replace('\'', '"');
+        Assert.assertEquals(expected, output);
+    }
+
+    @Test
+    public void testTaggedUnionsDisabled() {
+        final Settings settings = TestUtils.settings();
+        settings.disableTaggedUnions = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry.class));
+        final String expected = (
+                "\n" +
+                "interface Geometry {\n" +
+                "    shapes: Shape[];\n" +
+                "}\n" +
+                "\n" +
+                "interface Shape {\n" +
+                "    kind: 'square' | 'rectangle' | 'circle';\n" +
+                "}\n" +
+                "\n" +
+                "interface Square extends Shape {\n" +
+                "    kind: 'square';\n" +
+                "    size: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Rectangle extends Shape {\n" +
+                "    kind: 'rectangle';\n" +
+                "    width: number;\n" +
+                "    height: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Circle extends Shape {\n" +
+                "    kind: 'circle';\n" +
+                "    radius: number;\n" +
+                "}\n" +
+                ""
+                ).replace('\'', '"');
+        Assert.assertEquals(expected, output);
+    }
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -35,6 +35,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> customTypeMappings;
     public DateMapping mapDate;
     public EnumMapping mapEnum;
+    public boolean disableTaggedUnions;
     public String customTypeProcessor;
     public boolean sortDeclarations;
     public boolean sortTypeDeclarations;
@@ -88,6 +89,7 @@ public class GenerateTask extends DefaultTask {
         settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
         settings.mapDate = mapDate;
         settings.mapEnum = mapEnum;
+        settings.disableTaggedUnions = disableTaggedUnions;
         settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
         settings.sortDeclarations = sortDeclarations;
         settings.sortTypeDeclarations = sortTypeDeclarations;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -197,6 +197,12 @@ public class GenerateMojo extends AbstractMojo {
     private EnumMapping mapEnum;
 
     /**
+     * If true tagged unions will not be generated for Jackson 2 polymorphic types.
+     */
+    @Parameter
+    private boolean disableTaggedUnions;
+
+    /**
      * Specifies custom class implementing {@link cz.habarta.typescript.generator.TypeProcessor}.
      * This allows to customize how Java types are mapped to TypeScript.
      * For example it is possible to implement TypeProcessor
@@ -293,6 +299,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
             settings.mapDate = mapDate;
             settings.mapEnum = mapEnum;
+            settings.disableTaggedUnions = disableTaggedUnions;
             settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
             settings.sortDeclarations = sortDeclarations;
             settings.sortTypeDeclarations = sortTypeDeclarations;


### PR DESCRIPTION
> This feature takes advantage of TypeScript 2.0 [tagged union types](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#tagged-union-types) but generated declarations are also valid in TypeScript 1.8.

This PR implements tagged (or discriminated) unions for Jackson 2 polymophic types. Jackson library allows to define  additional property which marks particular subclasses so that when reading JSON data it is possible to distinguish several subclasses.

In following example Jackson uses `kind` property with defined value for each subclass
``` java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
@JsonSubTypes({
    @JsonSubTypes.Type(Square.class),
    @JsonSubTypes.Type(Rectangle.class),
})
public abstract class Shape {
}

@JsonTypeName("square")
public class Square extends Shape {
    public double size;
}

@JsonTypeName("rectangle")
public class Rectangle extends Shape {
    public double width;
    public double height;
}
```

Example JSON array of shapes generated using such classes
``` json
[
    {
        "kind": "square",
        "size": 4.0
    },
    {
        "kind": "rectangle",
        "width": 5.0,
        "height": 3.0
    }
]
```

To simplify processing of such data typescript-generator generates `ShapeUnion` (tagged union type) with `kind` discriminant property
``` typescript
type ShapeUnion = Square | Rectangle;

interface Square extends Shape {
    kind: "square";
    size: number;
}

interface Rectangle extends Shape {
    kind: "rectangle";
    width: number;
    height: number;
}

interface Shape {
    kind: "square" | "rectangle";
}
```

So it is possible to test if shape is for example square
``` typescript
let shape: ShapeUnion;

if (shape.kind === "square") {
    // here TypeScript 2.0 knows that shape is Square
    console.log("Square size: " + shape.size);

    // this cast is needed in TypeScript 1.8
    let square = <Square>shape;
    console.log("Square size: " + square.size);
}
```

This feature can be suppressed in typescript-generator using `disableTaggedUnions` parameter.
