### PR TITLE
Extension for enums without const keyword

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -101,7 +101,7 @@ public class Settings {
         }
         if (outputFileType != TypeScriptFileType.implementationFile) {
             for (EmitterExtension emitterExtension : extensions) {
-                if (emitterExtension.generatesRuntimeCode()) {
+                if (emitterExtension.getFeatures().generatesRuntimeCode) {
                     throw new RuntimeException(String.format("Extension '%s' generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.",
                             emitterExtension.getClass().getSimpleName()));
                 }
@@ -116,6 +116,15 @@ public class Settings {
         if (outputFileType == TypeScriptFileType.implementationFile && (!outputFile.getName().endsWith(".ts") || outputFile.getName().endsWith(".d.ts"))) {
             throw new RuntimeException("Implementation file must have 'ts' extension: " + outputFile);
         }
+    }
+
+    public boolean areDefaultStringEnumsOverriddenByExtension() {
+        for (EmitterExtension extension : extensions) {
+            if (extension.getFeatures().overridesStringEnums) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String seeLink() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -46,11 +46,13 @@ public class ModelCompiler {
         tsModel = transformDates(symbolTable, tsModel);
 
         // enums
-        if (settings.mapEnum == null || settings.mapEnum == EnumMapping.asUnion || settings.mapEnum == EnumMapping.asInlineUnion) {
-            tsModel = transformEnumsToUnions(tsModel);
-        }
-        if (settings.mapEnum == EnumMapping.asInlineUnion) {
-            tsModel = inlineEnums(tsModel, symbolTable);
+        if (!settings.areDefaultStringEnumsOverriddenByExtension()) {
+            if (settings.mapEnum == null || settings.mapEnum == EnumMapping.asUnion || settings.mapEnum == EnumMapping.asInlineUnion) {
+                tsModel = transformEnumsToUnions(tsModel);
+            }
+            if (settings.mapEnum == EnumMapping.asInlineUnion) {
+                tsModel = inlineEnums(tsModel, symbolTable);
+            }
         }
 
         // tagged unions

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtension.java
@@ -6,7 +6,7 @@ import cz.habarta.typescript.generator.Settings;
 
 public abstract class EmitterExtension {
 
-    public abstract boolean generatesRuntimeCode();
+    public abstract EmitterExtensionFeatures getFeatures();
 
     public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
@@ -1,0 +1,10 @@
+
+package cz.habarta.typescript.generator.emitter;
+
+
+public class EmitterExtensionFeatures {
+
+    public boolean generatesRuntimeCode = false;
+    public boolean overridesStringEnums = false;
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
@@ -12,12 +12,13 @@ import java.util.Collections;
 import java.util.List;
 
 
-public class EnumConstantsExtension extends EmitterExtension {
+public class NonConstEnumsExtension extends EmitterExtension {
 
     @Override
     public EmitterExtensionFeatures getFeatures() {
         final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
         features.generatesRuntimeCode = true;
+        features.overridesStringEnums = true;
         return features;
     }
 
@@ -28,9 +29,9 @@ public class EnumConstantsExtension extends EmitterExtension {
         Collections.sort(enums);
         for (TsEnumModel<String> tsEnum : enums) {
             writer.writeIndentedLine("");
-            writer.writeIndentedLine(exportString + "const " + tsEnum.getName() + " = {");
+            writer.writeIndentedLine(exportString + "enum " + tsEnum.getName() + " {");
             for (EnumMemberModel<String> member : tsEnum.getMembers()) {
-                writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ": " + "<" + tsEnum.getName() + ">\"" + member.getEnumValue() + "\",");
+                writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ",");
             }
             writer.writeIndentedLine("}");
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
@@ -9,8 +9,10 @@ import cz.habarta.typescript.generator.emitter.*;
 public class TypeGuardsForJackson2PolymorphismExtension extends EmitterExtension {
 
     @Override
-    public boolean generatesRuntimeCode() {
-        return true;
+    public EmitterExtensionFeatures getFeatures() {
+        final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+        features.generatesRuntimeCode = true;
+        return features;
     }
 
     @Override

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModulesAndNamespacesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModulesAndNamespacesTest.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
+import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
 import cz.habarta.typescript.generator.emitter.TsModel;
 import java.io.File;
 import org.junit.Test;
@@ -61,8 +62,10 @@ public class ModulesAndNamespacesTest {
     private static class TestFunctionExtention extends EmitterExtension {
 
         @Override
-        public boolean generatesRuntimeCode() {
-            return true;
+        public EmitterExtensionFeatures getFeatures() {
+            final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+            features.generatesRuntimeCode = true;
+            return features;
         }
 
         @Override


### PR DESCRIPTION
Based on discussion in #77 this PR implements extension which from Java enums generates TypeScript enums without `const` keyword.
This extension is implemented in `cz.habarta.typescript.generator.ext.NonConstEnumsExtension` class.

By default typescript-generator generates string literal unions like this
``` typescript
type Direction = "Left" | "Right";
```
which exactly describes JSON data and works well, especially in TypeScript 2.0.

In some cases it might be useful to generate non-const enums using this extension (instead of string unions) like this:
``` typescript
enum Direction {
    Left,
    Right,
}
```

These enums only work in implementation files (`.ts`) because they are real objects that exist at runtime, it is not sufficient to put them into declaration file (`.d.ts`).

> Note: Java enums are sent in JSON as **string** values while TypeScript enums are **number** based. So this extension should only be used if there is a good reason.

More information about TypeScript enums can be found in Handbook - https://www.typescriptlang.org/docs/handbook/enums.html.
