### PR TITLE
Class exclude patterns

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
@@ -1,25 +1,23 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.util.Predicate;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
-import java.util.*;
 
 
 public class ExcludingTypeProcessor implements TypeProcessor {
 
-    private final Set<String> excludedClassNames = new LinkedHashSet<>();
+    private final Predicate<String> excludeFilter;
 
-    public ExcludingTypeProcessor(List<String> excludedClassNames) {
-        if (excludedClassNames != null) {
-            this.excludedClassNames.addAll(excludedClassNames);
-        }
+    public ExcludingTypeProcessor(Predicate<String> excludeFilter) {
+        this.excludeFilter = excludeFilter;
     }
 
     @Override
     public Result processType(Type javaType, Context context) {
         final Class<?> rawClass = Utils.getRawClassOrNull(javaType);
-        if (rawClass != null && excludedClassNames.contains(rawClass.getName())) {
+        if (rawClass != null && excludeFilter.test(rawClass.getName())) {
             return new Result(TsType.Any);
         }
         return null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -54,7 +54,7 @@ public class TypeScriptGenerator {
     public TypeProcessor getTypeProcessor() {
         if (typeProcessor == null) {
             final List<TypeProcessor> processors = new ArrayList<>();
-            processors.add(new ExcludingTypeProcessor(settings.excludedClassNames));
+            processors.add(new ExcludingTypeProcessor(settings.getExcludeFilter()));
             if (settings.customTypeProcessor != null) {
                 processors.add(settings.customTypeProcessor);
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -126,7 +126,7 @@ public class Jackson2Parser extends ModelParser {
         }
         parents.addAll(Arrays.asList(cls.getInterfaces()));
         for (Class<?> parent : parents) {
-            if (settings.excludedClassNames == null || !settings.excludedClassNames.contains(parent.getName())) {
+            if (!settings.getExcludeFilter().test(parent.getName())) {
                 final BeanHelper beanHelper = getBeanHelper(parent);
                 if (beanHelper != null) {
                     for (BeanPropertyWriter beanPropertyWriter : beanHelper.getProperties()) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
@@ -94,7 +94,7 @@ public class GenericsTest {
         final Settings settings = TestUtils.settings();
         settings.customTypeProcessor = new GenericsTypeProcessor();
         settings.sortDeclarations = true;
-        settings.excludedClassNames = Arrays.asList(Comparable.class.getName());
+        settings.setExcludeFilter(Arrays.asList(Comparable.class.getName()), null);
 
         final StringWriter stringWriter = new StringWriter();
         new TypeScriptGenerator(settings).generateEmbeddableTypeScript(Input.from(IA.class), Output.to(stringWriter), true, 0);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationScannerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationScannerTest.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.core.type.*;
 import cz.habarta.typescript.generator.parser.*;
+import cz.habarta.typescript.generator.util.Predicate;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;
@@ -71,16 +72,20 @@ public class JaxrsApplicationScannerTest<T> {
 
     @Test
     public void testExcludedResource() {
-        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), Arrays.asList(TestResource1.class.getName()));
+        final Predicate<String> excludeFilter = Settings.createExcludeFilter(Arrays.asList(
+                TestResource1.class.getName()
+        ), null);
+        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
         Assert.assertEquals(0, sourceTypes.size());
     }
 
     @Test
     public void testExcludedType() {
-        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), Arrays.asList(
+        final Predicate<String> excludeFilter = Settings.createExcludeFilter(Arrays.asList(
                 A.class.getName(),
                 J.class.getName()
-        ));
+        ), null);
+        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
         Assert.assertTrue(!getTypes(sourceTypes).contains(A.class));
         Assert.assertTrue(getTypes(sourceTypes).contains(J[].class));
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
@@ -29,10 +29,18 @@ public class ModelCompilerTest {
         Assert.assertEquals("{ [index: string]: any }[]", TestUtils.compileType(settings, javaType).toString());
     }
 
+    @Test
+    public void testExclusionPattern() throws Exception {
+        final Settings settings = TestUtils.settings();
+        settings.setExcludeFilter(null, Arrays.asList("**Direction"));
+        final Type javaType = A.class.getField("directions").getGenericType();
+        Assert.assertEquals("{ [index: string]: any }[]", TestUtils.compileType(settings, javaType).toString());
+    }
+
     private static Settings getTestSettings(String... excludedClassNames) {
         final Settings settings = TestUtils.settings();
         settings.mapDate = DateMapping.asString;
-        settings.excludedClassNames = Arrays.asList(excludedClassNames);
+        settings.setExcludeFilter(Arrays.asList(excludedClassNames), null);
         return settings;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelParserTest.java
@@ -61,9 +61,9 @@ public class ModelParserTest {
 
     private Model parseModel(Type type, String... excludedClassNames) {
         final Settings settings = new Settings();
-        settings.excludedClassNames = Arrays.asList(excludedClassNames);
+        settings.setExcludeFilter(Arrays.asList(excludedClassNames), null);
         final ModelParser parser = new Jackson2Parser(settings, new TypeProcessor.Chain(
-                new ExcludingTypeProcessor(settings.excludedClassNames),
+                new ExcludingTypeProcessor(settings.getExcludeFilter()),
                 new DefaultTypeProcessor()
         ));
         final Model model = parser.parseModel(type);

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -22,6 +22,7 @@ public class GenerateTask extends DefaultTask {
     public String classesFromJaxrsApplication;
     public boolean classesFromAutomaticJaxrsApplication;
     public List<String> excludeClasses;
+    public List<String> excludeClassPatterns;
     public List<String> includePropertyAnnotations;
     public JsonLibrary jsonLibrary;
     public boolean declarePropertiesAsOptional;
@@ -76,7 +77,7 @@ public class GenerateTask extends DefaultTask {
         settings.outputKind = outputKind;
         settings.module = module;
         settings.namespace = namespace;
-        settings.excludedClassNames = excludeClasses;
+        settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
         settings.jsonLibrary = jsonLibrary;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
         settings.removeTypeNamePrefix = removeTypeNamePrefix;
@@ -103,7 +104,7 @@ public class GenerateTask extends DefaultTask {
 
         // TypeScriptGenerator
         new TypeScriptGenerator(settings).generateTypeScript(
-                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, excludeClasses, classLoader),
+                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader),
                 Output.to(getProject().file(outputFile))
         );
     }

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -63,7 +63,7 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> classes;
 
     /**
-     * JSON classes to process specified using glob pattern
+     * JSON classes to process specified using glob patterns
      * so it is possible to specify package or class name suffix.
      * Glob patterns support two wildcards:
      * Single "*" wildcard matches any character except for "." and "$".
@@ -93,6 +93,12 @@ public class GenerateMojo extends AbstractMojo {
      */
     @Parameter
     private List<String> excludeClasses;
+
+    /**
+     * Excluded classes specified using glob patterns.
+     */
+    @Parameter
+    private List<String> excludeClassPatterns;
 
     /**
      * If this list is not empty then TypeScript will only be generated for
@@ -286,7 +292,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.outputKind = outputKind;
             settings.module = module;
             settings.namespace = namespace;
-            settings.excludedClassNames = excludeClasses;
+            settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
             settings.jsonLibrary = jsonLibrary;
             settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
             settings.removeTypeNamePrefix = removeTypeNamePrefix;
@@ -313,7 +319,7 @@ public class GenerateMojo extends AbstractMojo {
 
             // TypeScriptGenerator
             new TypeScriptGenerator(settings).generateTypeScript(
-                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, excludeClasses, classLoader),
+                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader),
                     Output.to(outputFile)
             );
 


### PR DESCRIPTION
This PR implements class exclusion patterns as requested in #82.
Exclusion patterns have same syntax as patterns for class inclusion (https://github.com/vojtechhabarta/typescript-generator/wiki/Class-Names-Glob-Patterns#globbing-syntax).

Example Maven configuration snippet:
``` xml
<excludeClassPatterns>
    <pattern>com.example.**</pattern>
</excludeClassPatterns>
```