### PR TITLE
Added an option allowing generating the Java types as 'classes' 

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ClassType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ClassType.java
@@ -1,0 +1,16 @@
+package cz.habarta.typescript.generator;
+
+public enum ClassType {
+
+    asInterface("interface"), asClass("class");
+
+    public final String keyword;
+
+    ClassType(String keyword) {
+        this.keyword = keyword;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -45,7 +45,7 @@ public class Settings {
     public List<Class<? extends Annotation>> includePropertyAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean displaySerializerWarning = true;
-
+    public ClassType classType = null;
 
     public void loadCustomTypeProcessor(ClassLoader classLoader, String customTypeProcessor) {
         if (customTypeProcessor != null) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -125,7 +125,7 @@ public class Emitter {
             emitComments(bean.getComments());
             final List<TsType> parents = bean.getParentAndInterfaces();
             final String extendsClause = parents.isEmpty() ? "" : " extends " + Utils.join(parents, ", ");
-            writeIndentedLine(exportKeyword, "interface " + bean.getName() + extendsClause + " {");
+            writeIndentedLine(exportKeyword, (settings.classType != null ? settings.classType.getKeyword() : "interface") + " " + bean.getName() + extendsClause + " {");
             indent++;
             final List<TsPropertyModel> properties = bean.getProperties();
             if (settings.sortDeclarations) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassTest.java
@@ -1,0 +1,30 @@
+
+package cz.habarta.typescript.generator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ClassTest {
+
+    @Test
+    public void test() {
+        final Settings settings = TestUtils.settings();
+        settings.classType = ClassType.asClass;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Book.class));
+        Assert.assertTrue(output.contains("class Book"));
+        Assert.assertTrue(output.contains("title: string;"));
+        Assert.assertTrue(output.contains("class Author"));
+    }
+
+    static interface Book {
+        Author getAuthor();
+
+        String getTitle();
+    }
+
+    static interface Author {
+        String getName();
+    }
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -45,6 +45,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> extensionClasses;
     public List<String> optionalAnnotations;
     public boolean displaySerializerWarning = true;
+    public ClassType classType;
 
     @TaskAction
     public void generate() throws Exception {
@@ -101,6 +102,7 @@ public class GenerateTask extends DefaultTask {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.validateFileName(new File(outputFile));
+        settings.classType = classType;
 
         // TypeScriptGenerator
         new TypeScriptGenerator(settings).generateTypeScript(

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -264,6 +264,14 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> optionalAnnotations;
 
     /**
+     * Generate Java type as class if set to 'asClass', or as interface is set to 'asInterface').
+     * Default behaviour (if parameter not set) is to generate types as classes.
+     */
+    @Parameter(required = false)
+    private ClassType classType;
+
+
+    /**
      * Display warnings when bean serializer is not found.
      */
     @Parameter(defaultValue = "true")
@@ -316,6 +324,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.validateFileName(outputFile);
+            settings.classType = classType;
 
             // TypeScriptGenerator
             new TypeScriptGenerator(settings).generateTypeScript(


### PR DESCRIPTION
Hi Vojtěch!

Thanks for this great plugin. I'm using it to generate declaration for Angular, and need to have 'class' instead of 'interface'. 

I added an option **classType** to select between _class_ or _interface_.

Feel free to merge into your code base.

Best,
O.
