### PR TITLE
Enum values specified using @JsonProperty annotation

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -155,7 +155,9 @@ public abstract class TsType {
 
         @Override
         public String format(Settings settings) {
-            return Utils.join(format(types, settings), " | ");
+            return types.isEmpty()
+                    ? "never"
+                    : Utils.join(format(types, settings), " | ");
         }
 
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -1,6 +1,8 @@
 
 package cz.habarta.typescript.generator;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -69,6 +71,39 @@ public class EnumTest {
         assertEquals(expected, output);
     }
 
+    @Test
+    public void testEnumWithJsonPropertyAnnotations() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonPropertyAnnotations.class));
+        final String expected = (
+                "\n" +
+                "type SideWithJsonPropertyAnnotations = 'left-side' | 'right-side';\n"
+                ).replace("'", "\"");
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testEnumWithJsonValueAnnotation() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueAnnotations.class));
+        final String expected = (
+                "\n" +
+                "type SideWithJsonValueAnnotations = 'left-side' | 'right-side';\n"
+                ).replace("'", "\"");
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testEmptyEnum() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(EmptyEnum.class));
+        final String expected = (
+                "\n" +
+                "type EmptyEnum = never;\n"
+                ).replace("'", "\"");
+        assertEquals(expected, output);
+    }
+
     private static class AClass {
         public Direction direction;
     }
@@ -78,6 +113,34 @@ public class EnumTest {
         East, 
         South,
         West
+    }
+
+    enum SideWithJsonPropertyAnnotations {
+        @JsonProperty("left-side")
+        Left,
+        @JsonProperty("right-side")
+        Right
+    }
+
+    enum SideWithJsonValueAnnotations {
+        @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
+        Left("left-side"),
+        @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
+        Right("right-side");
+
+        private final String jsonValue;
+
+        private SideWithJsonValueAnnotations(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        @JsonValue
+        public Object getJsonValue() {
+            return jsonValue;
+        }
+    }
+
+    enum EmptyEnum {
     }
 
 }


### PR DESCRIPTION
Jackson allows customizing enum values using `@JsonValue` and `@JsonCreator` annotations like this:
``` java
enum Side {

    Left("left-side"),
    Right("right-side");

    private final String jsonValue;

    private Side(String jsonValue) {
        this.jsonValue = jsonValue;
    }

    @JsonValue
    public String serialize() {
        return jsonValue;
    }

    @JsonCreator
    public static Side deserialize(String value) {
        for (Side enumValue : values()) {
            if (enumValue.jsonValue.equals(value)) {
                return enumValue;
            }
        }
        throw new IllegalArgumentException(value);
    }

}
```
Typescript-generator already supported this but only for enums serialized to _number_ values.
 
From **version 2.6** Jackson also supports more concise and convenient way how to specify serialized enum values:
``` java
enum Side {
    @JsonProperty("left-side")
    Left,
    @JsonProperty("right-side")
    Right
}
```

This PR adds support for both ways how to specify serialized enum values.
