### PR TITLE
Support for Java 8 Optional

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>2.6.3</version>
         </dependency>
+<!--        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.6.3</version>
+        </dependency>-->
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -41,6 +41,9 @@ public class DefaultTypeProcessor implements TypeProcessor {
                     final Result result = context.processType(parameterizedType.getActualTypeArguments()[1]);
                     return new Result(new TsType.IndexedArrayType(TsType.String, result.getTsType()), result.getDiscoveredClasses());
                 }
+                if (javaClass.getName().equals("java.util.Optional")) {
+                    return context.processType(parameterizedType.getActualTypeArguments()[0]);
+                }
                 // consider it structural
                 return new Result(new TsType.ReferenceType(context.getSymbol(javaClass)), javaClass);
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
@@ -11,7 +11,7 @@ public class GenericsTypeProcessor implements TypeProcessor {
     @Override
     public TypeProcessor.Result processType(Type javaType, TypeProcessor.Context context) {
         if (javaType instanceof TypeVariable) {
-            final TypeVariable<?> typeVariable = (TypeVariable) javaType;
+            final TypeVariable<?> typeVariable = (TypeVariable<?>) javaType;
             return new Result(new TsType.GenericVariableType(typeVariable.getName()));
         }
         if (javaType instanceof Class) {
@@ -31,7 +31,7 @@ public class GenericsTypeProcessor implements TypeProcessor {
     }
 
     private Result processGenericClass(Class<?> rawType, Type[] typeArguments, TypeProcessor.Context context) {
-        if (!Collection.class.isAssignableFrom(rawType) && !Map.class.isAssignableFrom(rawType)) {
+        if (!Collection.class.isAssignableFrom(rawType) && !Map.class.isAssignableFrom(rawType) && !rawType.getName().equals("java.util.Optional")) {
             final List<Class<?>> discoveredClasses = new ArrayList<>();
             // raw type
             final Symbol rawSymbol = context.getSymbol(rawType);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
@@ -1,0 +1,99 @@
+
+package cz.habarta.typescript.generator;
+
+//import com.fasterxml.jackson.annotation.JsonInclude;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+//import java.util.Objects;
+//import java.util.Optional;
+//import org.junit.Assert;
+//import org.junit.Test;
+
+
+// Java 8 is required for this test
+// TODO uncomment on Java 8
+
+public class OptionalTest {
+
+//    @Test
+//    public void test() {
+//        final String output = new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(Person.class));
+//        Assert.assertEquals(
+//                "interface Person {\n" +
+//                "    name: string;\n" +
+//                "    email: string;\n" +
+//                "}",
+//                output.trim());
+//    }
+//
+//    @Test
+//    public void testJackson2OptionalSupport() throws Exception {
+//        final ObjectMapper objectMapper = new ObjectMapper()
+//                .registerModule(new Jdk8Module())
+//                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+//
+//        final Person personWithEmail = new Person("afh", Optional.of("af@h.cz"));
+//        final Person personWithEmptyEmail = new Person("afh", Optional.<String>empty());
+//        final Person personWithoutEmail = new Person("afh", null);
+//
+//        final String jsonWithEmail = "{'name':'afh','email':'af@h.cz'}".replace('\'', '\"');
+//        final String jsonWithNullEmail = "{'name':'afh','email':null}".replace('\'', '\"');
+//        final String jsonWithoutEmail = "{'name':'afh'}".replace('\'', '\"');
+//
+//        Assert.assertEquals(jsonWithEmail, objectMapper.writeValueAsString(personWithEmail));
+//        Assert.assertEquals(jsonWithNullEmail, objectMapper.writeValueAsString(personWithEmptyEmail));
+//        Assert.assertEquals(jsonWithoutEmail, objectMapper.writeValueAsString(personWithoutEmail));
+//
+//        Assert.assertEquals(personWithEmail, objectMapper.readValue(jsonWithEmail, Person.class));
+//        Assert.assertEquals(personWithEmptyEmail, objectMapper.readValue(jsonWithNullEmail, Person.class));
+//        Assert.assertEquals(personWithoutEmail, objectMapper.readValue(jsonWithoutEmail, Person.class));
+//    }
+//
+//    private static class Person {
+//        public String name;
+//        public Optional<String> email;
+//
+//        public Person() {
+//        }
+//
+//        public Person(String name, Optional<String> email) {
+//            this.name = name;
+//            this.email = email;
+//        }
+//
+//        @Override
+//        public int hashCode() {
+//            int hash = 7;
+//            hash = 53 * hash + Objects.hashCode(this.name);
+//            hash = 53 * hash + Objects.hashCode(this.email);
+//            return hash;
+//        }
+//
+//        @Override
+//        public boolean equals(Object obj) {
+//            if (this == obj) {
+//                return true;
+//            }
+//            if (obj == null) {
+//                return false;
+//            }
+//            if (getClass() != obj.getClass()) {
+//                return false;
+//            }
+//            final Person other = (Person) obj;
+//            if (!Objects.equals(this.name, other.name)) {
+//                return false;
+//            }
+//            if (!Objects.equals(this.email, other.email)) {
+//                return false;
+//            }
+//            return true;
+//        }
+//
+//        @Override
+//        public String toString() {
+//            return "Person{" + "name=" + name + ", email=" + email + '}';
+//        }
+//    }
+
+}


### PR DESCRIPTION
With this PR typescript-generator recognizes `java.util.Optional` types and maps `Optional<T>` in Java to TypeScript as it was just `T`.

For example for this Java class:

``` java
public class Person {
    public String name;
    public Optional<String> email;
}
```

it generates following TypeScript declaration:

``` typescript
interface Person {
    name: string;
    email: string;
}
```

**Use case** for this feature is to allow Java code to detect whether some JSON property was sent with `null` value or it wasn't send at all (`undefined` in JavaScript).

Normally both cases are represented as `null` value in Java but Jackson2 can be configured to distinguish these two cases using Java 8 `Optional` types:

``` java
ObjectMapper objectMapper = new ObjectMapper()
        .registerModule(new Jdk8Module())
        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
```

To use `Jdk8Module` it is needed to add dependency on `com.fasterxml.jackson.datatype:jackson-datatype-jdk8` artifact.

Jackson2 then serializes/deserializes `Optional` properties as follows:

Java property value | JSON property value
--- | ---
`Optional.of(value)` | `value`
`Optional.empty()` | `null`
`null` | `undefined` (property not sent)
