### PR TITLE
Fix NPE in JaxrsApplicationScanner#isExcluded

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
@@ -128,7 +128,7 @@ public class JaxrsApplicationScanner {
     private boolean isExcluded(Type type) {
         final Class<?> cls = Utils.getRawClassOrNull(type);
         if (cls == null) {
-            return true;
+            return false;
         }
         if (isClassNameExcluded != null && isClassNameExcluded.test(cls.getName())) {
             return true;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
@@ -127,12 +127,16 @@ public class JaxrsApplicationScanner {
 
     private boolean isExcluded(Type type) {
         final Class<?> cls = Utils.getRawClassOrNull(type);
-        if (cls != null && isClassNameExcluded != null && isClassNameExcluded.test(cls.getName())) {
+        if (cls == null) {
             return true;
         }
-        if (cls != null && defaultExcludes.contains(cls.getName())) {
+        if (isClassNameExcluded != null && isClassNameExcluded.test(cls.getName())) {
             return true;
         }
+        if (defaultExcludes.contains(cls.getName())) {
+            return true;
+        }
+
         for (Class<?> standardEntityClass : getStandardEntityClasses()) {
             if (standardEntityClass.isAssignableFrom(cls)) {
                 return true;


### PR DESCRIPTION
I was getting an NPE in the for loop in `JaxrsApplicationScanner.isExcluded` at `standardEntityClass.isAssignableFrom(cls)`

Is there ever a case where `cls` is null, and we want to _include_ it?
