### PR TITLE
Possibility to generate TypeScript classes

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ClassMapping.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ClassMapping.java
@@ -1,0 +1,7 @@
+
+package cz.habarta.typescript.generator;
+
+
+public enum ClassMapping {
+    asInterfaces, asClasses;
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -35,6 +35,7 @@ public class Settings {
     public Map<String, String> customTypeMappings = new LinkedHashMap<>();
     public DateMapping mapDate; // default is DateMapping.asDate
     public EnumMapping mapEnum; // default is EnumMapping.asUnion
+    public ClassMapping mapClasses; // default is ClassMapping.asInterfaces
     public boolean disableTaggedUnions = false;
     public TypeProcessor customTypeProcessor = null;
     public boolean sortDeclarations = false;
@@ -107,6 +108,9 @@ public class Settings {
                     throw new RuntimeException(String.format("Extension '%s' generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.",
                             emitterExtension.getClass().getSimpleName()));
                 }
+            }
+            if (mapClasses == ClassMapping.asClasses) {
+                throw new RuntimeException("'mapClasses' parameter is set to `asClasses` which generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.");
             }
         }
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -2,26 +2,29 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.util.Utils;
 import java.util.*;
 
 
 public class TsBeanModel extends TsDeclarationModel {
 
+    private final boolean isClass;
     private final TsType parent;
     private final List<Class<?>> taggedUnionClasses;
     private final List<TsType> interfaces;
     private final List<TsPropertyModel> properties;
 
-    public TsBeanModel(TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
-        this(null, name, parent, taggedUnionClasses, interfaces, properties, comments);
-    }
-
-    public TsBeanModel(Class<?> origin, TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
+    public TsBeanModel(Class<?> origin, boolean isClass, TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
         super(origin, name, comments);
+        this.isClass = isClass;
         this.parent = parent;
         this.taggedUnionClasses = taggedUnionClasses;
         this.interfaces = interfaces;
         this.properties = properties;
+    }
+
+    public boolean isClass() {
+        return isClass;
     }
 
     public TsType getParent() {
@@ -45,12 +48,24 @@ public class TsBeanModel extends TsDeclarationModel {
         return parents;
     }
 
+    public List<TsType> getExtendsList() {
+        return isClass
+                ? Utils.listFromNullable(parent)
+                : getParentAndInterfaces();
+    }
+
+    public List<TsType> getImplementsList() {
+        return isClass
+                ? interfaces
+                : Collections.<TsType>emptyList();
+    }
+
     public List<TsPropertyModel> getProperties() {
         return properties;
     }
 
     public TsBeanModel withProperties(List<TsPropertyModel> properties) {
-        return new TsBeanModel(origin, name, parent, taggedUnionClasses, interfaces, properties, comments);
+        return new TsBeanModel(origin, isClass, name, parent, taggedUnionClasses, interfaces, properties, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
@@ -28,6 +28,17 @@ public class TsModel {
         return beans;
     }
 
+    public TsBeanModel getBean(Class<?> origin) {
+        if (origin != null) {
+            for (TsBeanModel bean : beans) {
+                if (Objects.equals(bean.getOrigin(), origin)) {
+                    return bean;
+                }
+            }
+        }
+        return null;
+    }
+
     public TsModel setBeans(List<TsBeanModel> beans) {
         return new TsModel(beans, enums, typeAliases);
     }
@@ -53,6 +64,17 @@ public class TsModel {
 
     public List<TsAliasModel> getTypeAliases() {
         return typeAliases;
+    }
+
+    public TsAliasModel getTypeAlias(Class<?> origin) {
+        if (origin != null) {
+            for (TsAliasModel alias : typeAliases) {
+                if (Objects.equals(alias.getOrigin(), origin)) {
+                    return alias;
+                }
+            }
+        }
+        return null;
     }
 
     public TsModel setTypeAliases(List<TsAliasModel> typeAliases) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
@@ -44,7 +44,7 @@ public class BeanModel extends DeclarationModel {
         return interfaces;
     }
 
-    public List<Type> getDirectAncestors() {
+    public List<Type> getParentAndInterfaces() {
         final List<Type> ancestors = new ArrayList<>();
         if (parent != null) {
             ancestors.add(parent);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator.util;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.*;
 
 
 public class Utils {
@@ -35,6 +36,10 @@ public class Utils {
             }
         }
         return null;
+    }
+
+    public static <T> List<T> listFromNullable(T item) {
+        return item != null ? Arrays.asList(item) : Collections.<T>emptyList();
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
@@ -1,0 +1,137 @@
+
+package cz.habarta.typescript.generator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ClassesTest {
+
+    @Test(expected = Exception.class)
+    public void testInvalidSettings() {
+        final Settings settings = TestUtils.settings();
+        settings.mapClasses = ClassMapping.asClasses;
+        new TypeScriptGenerator(settings).generateTypeScript(Input.from());
+    }
+
+    @Test
+    public void testClass() {
+        testOutput(A.class,
+                "class A {\n" +
+                "    a: string;\n" +
+                "}"
+        );
+    }
+
+    @Test
+    public void testInheritedClass() {
+        // A and B order is important
+        testOutput(B.class,
+                "class A {\n" +
+                "    a: string;\n" +
+                "}\n" +
+                "\n" +
+                "class B extends A {\n" +
+                "    b: string;\n" +
+                "}"
+        );
+    }
+
+    @Test
+    public void testClassImplementsInterface() {
+        testOutput(E.class,
+                "class E implements D {\n" +
+                "    c: string;\n" +
+                "    d: string;\n" +
+                "    e: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface D extends C {\n" +
+                "    d: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface C {\n" +
+                "    c: string;\n" +
+                "}"
+        );
+    }
+
+    @Test
+    public void testComplexHierarchy() {
+        // Q3 and Q5 order is important
+        testOutput(Q5.class,
+                "class Q3 implements Q2 {\n" +
+                "    q1: string;\n" +
+                "    q2: string;\n" +
+                "    q3: string;\n" +
+                "}\n" +
+                "\n" +
+                "class Q5 extends Q3 implements Q2, Q4 {\n" +
+                "    q4: string;\n" +
+                "    q5: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface Q2 extends Q1 {\n" +
+                "    q2: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface Q4 {\n" +
+                "    q4: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface Q1 {\n" +
+                "    q1: string;\n" +
+                "}"
+        );
+    }
+
+    private static void testOutput(Class<?> inputClass, String expected) {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(inputClass));
+        Assert.assertEquals(expected.replace('\'', '"'), output.trim());
+    }
+
+    private static abstract class A {
+        public abstract String getA();
+    }
+
+    private static abstract class B extends A {
+        public abstract String getB();
+    }
+
+    private static abstract interface C {
+        public abstract String getC();
+    }
+
+    private static interface D extends C {
+        public abstract String getD();
+    }
+
+    private static abstract class E implements D {
+        public abstract String getE();
+    }
+
+
+    private static interface Q1 {
+        public abstract String getQ1();
+    }
+
+    private static interface Q2 extends Q1 {
+        public abstract String getQ2();
+    }
+
+    private static abstract class Q3 implements Q2 {
+        public abstract String getQ3();
+    }
+
+    private static interface Q4 {
+        public abstract String getQ4();
+    }
+
+    private static abstract class Q5 extends Q3 implements Q2, Q4 {
+        public abstract String getQ5();
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumConstantsExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumConstantsExtensionTest.java
@@ -57,7 +57,7 @@ public class EnumConstantsExtensionTest {
 
     @Test
     public void testSorting() {
-        final Settings settings = new Settings();
+        final Settings settings = TestUtils.settings();
         settings.sortDeclarations = false;
         settings.newline = "\n";
         settings.outputFileType = TypeScriptFileType.implementationFile;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedTypesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedTypesTest.java
@@ -22,7 +22,7 @@ public class SortedTypesTest {
 ""                           + settings.newline +
 "interface A {"              + settings.newline +
 "    x: number;"             + settings.newline +
-"    y: number;"             + settings.newline +
+"    yyy: number;"           + settings.newline +
 "}"                          + settings.newline +
 ""                           + settings.newline +
 "interface B {"              + settings.newline +
@@ -35,7 +35,7 @@ public class SortedTypesTest {
     }
 
     public static class A {
-        public int getY() {
+        public int getYYY() {
             return -1;
         }
         public int getX() {

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -36,6 +36,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> customTypeMappings;
     public DateMapping mapDate;
     public EnumMapping mapEnum;
+    public ClassMapping mapClasses;
     public boolean disableTaggedUnions;
     public String customTypeProcessor;
     public boolean sortDeclarations;
@@ -90,6 +91,7 @@ public class GenerateTask extends DefaultTask {
         settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
         settings.mapDate = mapDate;
         settings.mapEnum = mapEnum;
+        settings.mapClasses = mapClasses;
         settings.disableTaggedUnions = disableTaggedUnions;
         settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
         settings.sortDeclarations = sortDeclarations;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -26,7 +26,7 @@ public class GenerateMojo extends AbstractMojo {
 
     /**
      * Output file format, can be 'declarationFile' (.d.ts) or 'implementationFile' (.ts).
-     * Setting this parameter to 'implementationFile' allows extensions to generate runnable TypeScript code.
+     * Setting this parameter to 'implementationFile' allows to generate runnable TypeScript code.
      * Default value is 'declarationFile'.
      */
     @Parameter
@@ -203,6 +203,15 @@ public class GenerateMojo extends AbstractMojo {
     private EnumMapping mapEnum;
 
     /**
+     * Specifies whether classes will be mapped to classes or interfaces.
+     * Supported values are 'asInterfaces', 'asClasses'.
+     * Default value is 'asInterfaces'.
+     * Value 'asClasses' can only be used in implementation files (.ts).
+     */
+    @Parameter
+    private ClassMapping mapClasses;
+
+    /**
      * If true tagged unions will not be generated for Jackson 2 polymorphic types.
      */
     @Parameter
@@ -305,6 +314,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
             settings.mapDate = mapDate;
             settings.mapEnum = mapEnum;
+            settings.mapClasses = mapClasses;
             settings.disableTaggedUnions = disableTaggedUnions;
             settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
             settings.sortDeclarations = sortDeclarations;


### PR DESCRIPTION
This change adds possibility to generate TypeScript classes. Only Java **classes** but **not interfaces** can be mapped to TypeScript classes. Interfaces cannot be mapped to classes because classes don't support multiple inheritance.

Generated TypeScript classes are reordered so that **base** class is emitted before **derived** class.

It is also possible to combine classes and interfaces like this: `class A extends B implements C {}` and typescript-generator ensures that class `A` contains correct properties.

Classes can only be generated in implementation files (`.ts`) because they are runtime objects. It's not sufficient to declare them in declaration file (`.d.ts`).

(This PR implements functionality proposed in #88 with some modifications.)