### PR TITLE
Covariant properties

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CovariantPropertiesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CovariantPropertiesTest.java
@@ -1,0 +1,53 @@
+
+package cz.habarta.typescript.generator;
+
+import java.util.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class CovariantPropertiesTest {
+
+    @Test
+    public void test() {
+        final Settings settings = TestUtils.settings();
+        settings.sortDeclarations = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Dog.class));
+        final String expected =
+                "interface Animal {\n" +
+                "    allFood: Food[];\n" +
+                "    todaysFood: Food;\n" +
+                "}\n" +
+                "\n" +
+                "interface Dog extends Animal {\n" +
+                "    allFood: DogFood[];\n" +
+                "    todaysFood: DogFood;\n" +
+                "}\n" +
+                "\n" +
+                "interface DogFood extends Food {\n" +
+                "}\n" +
+                "\n" +
+                "interface Food {\n" +
+                "}";
+        Assert.assertEquals(expected.replace('\'', '"'), output.trim());
+    }
+
+    private static abstract class Animal {
+        public abstract Food getTodaysFood();
+        public abstract List<? extends Food> getAllFood();
+    }
+
+    private static abstract class Dog extends Animal {
+        @Override
+        public abstract DogFood getTodaysFood();
+        @Override
+        public abstract List<? extends DogFood> getAllFood();
+    }
+
+    private static abstract class Food {
+    }
+
+    private static abstract class DogFood extends Food {
+    }
+
+}


### PR DESCRIPTION
Covariant properties feature was implemented as part of #97, this PR just adds test and is also meant as documentation for release.

Lets see an example. For these Java classes:

``` java
class Animal {
    public Food getFood() {}
}
class Dog extends Animal {
    @Override
    public DogFood getFood() {}
}
class Food {
}
class DogFood extends Food {
}
```

following TypeScript interfaces are generated:

``` typescript
interface Animal {
    food: Food;
}
interface Dog extends Animal {
    food: DogFood;
}
interface Food {
}
interface DogFood extends Food {
}
```

Type of `food` property is changed in `Dog` class from `Food` to derived type (`DogFood`).

This feature takes advantage of Java covariant return types. In the example `Dog.getFood()` has covariant return type - instead of `Food` it returns `DogFood` (which is derived from `Food`).

This also works with generic types:

Type | Java | TypeScript
--- | --- | ---
base | `List<? extends Food>` | `Food[]`
derived | `List<? extends DogFood>` | `DogFood[]`

