### PR TITLE
Fix generic bean used without type arguments

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/GenericsTypeProcessor.java
@@ -1,52 +1,17 @@
 
 package cz.habarta.typescript.generator;
 
-import cz.habarta.typescript.generator.compiler.Symbol;
 import java.lang.reflect.*;
-import java.util.*;
 
 
+/**
+ * @deprecated now the functionality is part of the core
+ */
+@Deprecated()
 public class GenericsTypeProcessor implements TypeProcessor {
 
     @Override
     public TypeProcessor.Result processType(Type javaType, TypeProcessor.Context context) {
-        if (javaType instanceof TypeVariable) {
-            final TypeVariable<?> typeVariable = (TypeVariable<?>) javaType;
-            return new Result(new TsType.GenericVariableType(typeVariable.getName()));
-        }
-        if (javaType instanceof Class) {
-            final Class<?> javaClass = (Class<?>) javaType;
-            if (javaClass.getTypeParameters().length > 0) {
-                return processGenericClass(javaClass, javaClass.getTypeParameters(), context);
-            }
-        }
-        if (javaType instanceof ParameterizedType) {
-            final ParameterizedType parameterizedType = (ParameterizedType) javaType;
-            if (parameterizedType.getRawType() instanceof Class) {
-                final Class<?> javaClass = (Class<?>) parameterizedType.getRawType();
-                return processGenericClass(javaClass, parameterizedType.getActualTypeArguments(), context);
-            }
-        }
-        return null;
-    }
-
-    private Result processGenericClass(Class<?> rawType, Type[] typeArguments, TypeProcessor.Context context) {
-        if (!Collection.class.isAssignableFrom(rawType) && !Map.class.isAssignableFrom(rawType) && !rawType.getName().equals("java.util.Optional")) {
-            final List<Class<?>> discoveredClasses = new ArrayList<>();
-            // raw type
-            final Symbol rawSymbol = context.getSymbol(rawType);
-            discoveredClasses.add(rawType);
-            // type arguments
-            final List<TsType> tsTypeArguments = new ArrayList<>();
-            for (Type typeArgument : typeArguments) {
-                final TypeProcessor.Result typeArgumentResult = context.processType(typeArgument);
-                tsTypeArguments.add(typeArgumentResult.getTsType());
-                discoveredClasses.addAll(typeArgumentResult.getDiscoveredClasses());
-            }
-            // result
-            final TsType.GenericReferenceType type = new TsType.GenericReferenceType(rawSymbol, tsTypeArguments);
-            return new Result(type, discoveredClasses);
-        }
         return null;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -59,7 +59,6 @@ public class TypeScriptGenerator {
                 processors.add(settings.customTypeProcessor);
             }
             processors.add(new CustomMappingTypeProcessor(settings.customTypeMappings));
-            processors.add(new GenericsTypeProcessor());
             processors.add(new DefaultTypeProcessor());
             typeProcessor = new TypeProcessor.Chain(processors);
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -120,11 +120,12 @@ public class Emitter {
             writeNewLine();
             emitComments(bean.getComments());
             final String declarationType = bean.isClass() ? "class" : "interface";
+            final String typeParameters = bean.getTypeParameters().isEmpty() ? "" : "<" + Utils.join(bean.getTypeParameters(), ", ")+ ">";
             final List<TsType> extendsList = bean.getExtendsList();
             final List<TsType> implementsList = bean.getImplementsList();
             final String extendsClause = extendsList.isEmpty() ? "" : " extends " + Utils.join(extendsList, ", ");
             final String implementsClause = implementsList.isEmpty() ? "" : " implements " + Utils.join(implementsList, ", ");
-            writeIndentedLine(exportKeyword, declarationType + " " + bean.getName() + extendsClause + implementsClause + " {");
+            writeIndentedLine(exportKeyword, declarationType + " " + bean.getName() + typeParameters + extendsClause + implementsClause + " {");
             indent++;
             for (TsPropertyModel property : bean.getProperties()) {
                 emitProperty(property);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.compiler.Symbol;
 import java.util.List;
 
 
@@ -9,12 +10,12 @@ public class TsAliasModel extends TsDeclarationModel {
     
     private final TsType definition;
 
-    public TsAliasModel(TsType name, TsType definition, List<String> comments) {
+    public TsAliasModel(Symbol name, TsType definition, List<String> comments) {
         super(name, comments);
         this.definition = definition;
     }
 
-    public TsAliasModel(Class<?> origin, TsType name, TsType definition, List<String> comments) {
+    public TsAliasModel(Class<?> origin, Symbol name, TsType definition, List<String> comments) {
         super(origin, name, comments);
         this.definition = definition;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.util.Utils;
 import java.util.*;
 
@@ -9,14 +10,16 @@ import java.util.*;
 public class TsBeanModel extends TsDeclarationModel {
 
     private final boolean isClass;
+    private final List<TsType.GenericVariableType> typeParameters;
     private final TsType parent;
     private final List<Class<?>> taggedUnionClasses;
     private final List<TsType> interfaces;
     private final List<TsPropertyModel> properties;
 
-    public TsBeanModel(Class<?> origin, boolean isClass, TsType name, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
+    public TsBeanModel(Class<?> origin, boolean isClass, Symbol name, List<TsType.GenericVariableType> typeParameters, TsType parent, List<Class<?>> taggedUnionClasses, List<TsType> interfaces, List<TsPropertyModel> properties, List<String> comments) {
         super(origin, name, comments);
         this.isClass = isClass;
+        this.typeParameters = typeParameters;
         this.parent = parent;
         this.taggedUnionClasses = taggedUnionClasses;
         this.interfaces = interfaces;
@@ -25,6 +28,10 @@ public class TsBeanModel extends TsDeclarationModel {
 
     public boolean isClass() {
         return isClass;
+    }
+
+    public List<TsType.GenericVariableType> getTypeParameters() {
+        return typeParameters;
     }
 
     public TsType getParent() {
@@ -65,7 +72,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withProperties(List<TsPropertyModel> properties) {
-        return new TsBeanModel(origin, isClass, name, parent, taggedUnionClasses, interfaces, properties, comments);
+        return new TsBeanModel(origin, isClass, name, typeParameters, parent, taggedUnionClasses, interfaces, properties, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsDeclarationModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsDeclarationModel.java
@@ -1,21 +1,21 @@
 
 package cz.habarta.typescript.generator.emitter;
 
-import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.compiler.Symbol;
 import java.util.*;
 
 
 public class TsDeclarationModel implements Comparable<TsDeclarationModel> {
 
     protected final Class<?> origin;
-    protected final TsType name;
+    protected final Symbol name;
     protected final List<String> comments;
 
-    public TsDeclarationModel(TsType name, List<String> comments) {
+    public TsDeclarationModel(Symbol name, List<String> comments) {
         this(null, name, comments);
     }
 
-    public TsDeclarationModel(Class<?> origin, TsType name, List<String> comments) {
+    public TsDeclarationModel(Class<?> origin, Symbol name, List<String> comments) {
         this.origin = origin;
         this.name = name;
         this.comments = comments;
@@ -25,7 +25,7 @@ public class TsDeclarationModel implements Comparable<TsDeclarationModel> {
         return origin;
     }
 
-    public TsType getName() {
+    public Symbol getName() {
         return name;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
@@ -1,9 +1,9 @@
 
 package cz.habarta.typescript.generator.emitter;
 
-import cz.habarta.typescript.generator.TsType;
 import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.parser.EnumModel;
 import java.util.List;
 
@@ -14,13 +14,13 @@ public class TsEnumModel<T> extends TsDeclarationModel {
     private final EnumKind<T> kind;
     private final List<EnumMemberModel<T>> members;
 
-    public TsEnumModel(Class<?> origin, TsType name, EnumKind<T> kind, List<EnumMemberModel<T>> members, List<String> comments) {
+    public TsEnumModel(Class<?> origin, Symbol name, EnumKind<T> kind, List<EnumMemberModel<T>> members, List<String> comments) {
         super(origin, name, comments);
         this.kind = kind;
         this.members = members;
     }
 
-    public static <T> TsEnumModel<T> fromEnumModel(TsType name, EnumModel<T> enumModel) {
+    public static <T> TsEnumModel<T> fromEnumModel(Symbol name, EnumModel<T> enumModel) {
         return new TsEnumModel<>(enumModel.getOrigin(), name, enumModel.getKind(), enumModel.getMembers(), enumModel.getComments());
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
@@ -1,17 +1,13 @@
 package cz.habarta.typescript.generator.ext;
 
-import java.util.*;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TsType;
-import cz.habarta.typescript.generator.TsType.GenericReferenceType;
-import cz.habarta.typescript.generator.compiler.EnumKind;
-import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
 import cz.habarta.typescript.generator.emitter.TsBeanModel;
-import cz.habarta.typescript.generator.emitter.TsEnumModel;
 import cz.habarta.typescript.generator.emitter.TsModel;
 import cz.habarta.typescript.generator.emitter.TsPropertyModel;
+import java.util.*;
 
 /**
  * Emitter which generates type-safe property path getters.
@@ -110,15 +106,8 @@ public class BeanPropertyPathExtension extends EmitterExtension {
         return null;
     }
 
-    /**
-     * return a class name formatted for rendering in code
-     * as part of another class name (so, for generics, strip
-     * the type arguments)
-     */
     private static String getBeanModelClassName(TsBeanModel bean) {
-        return bean.getName() instanceof GenericReferenceType
-            ? ((GenericReferenceType)bean.getName()).symbol.toString()
-            : bean.getName().toString();
+        return bean.getName().toString();
     }
 
     private static void writeBeanProperty(

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SourceType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SourceType.java
@@ -26,4 +26,9 @@ public class SourceType<T extends Type> {
         return (SourceType<Class<?>>) this;
     }
 
+    @Override
+    public String toString() {
+        return type.toString();
+    }
+
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationScannerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationScannerTest.java
@@ -21,7 +21,7 @@ public class JaxrsApplicationScannerTest<T> {
 
     @Test
     public void testReturnedTypes() {
-        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), null);
+        final List<SourceType<Type>> sourceTypes = JaxrsApplicationScanner.scanJaxrsApplication(TestApplication.class.getName(), null);
         List<Type> types = getTypes(sourceTypes);
         final List<Type> expectedTypes = Arrays.asList(
                 A.class,
@@ -75,7 +75,7 @@ public class JaxrsApplicationScannerTest<T> {
         final Predicate<String> excludeFilter = Settings.createExcludeFilter(Arrays.asList(
                 TestResource1.class.getName()
         ), null);
-        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
+        final List<SourceType<Type>> sourceTypes = JaxrsApplicationScanner.scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
         Assert.assertEquals(0, sourceTypes.size());
     }
 
@@ -85,7 +85,7 @@ public class JaxrsApplicationScannerTest<T> {
                 A.class.getName(),
                 J.class.getName()
         ), null);
-        final List<SourceType<Type>> sourceTypes = new JaxrsApplicationScanner().scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
+        final List<SourceType<Type>> sourceTypes = JaxrsApplicationScanner.scanJaxrsApplication(TestApplication.class.getName(), excludeFilter);
         Assert.assertTrue(!getTypes(sourceTypes).contains(A.class));
         Assert.assertTrue(getTypes(sourceTypes).contains(J[].class));
     }


### PR DESCRIPTION
Consider this example:

``` java
class Table<T> {
    public List<T> rows;
}
class Page {
    public Table someTable;  // missing type arguments
}
```

In this example `Table` is generic bean but `someTable` property uses it without type arguments. Typescript-generator now correctly generates property `someTable: Table<any>` in this case.

This change also improves internal model (see `TsDeclarationModel.name` and `TsBeanModel.typeParameters`).