### PR TITLE
don't make a stack overflow when there is a type referring to itself

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
@@ -158,6 +158,10 @@ public class BeanPropertyPathExtension extends EmitterExtension {
         TsPropertyModel property) {
         TsBeanModel fieldBeanModel = getBeanModelByType(model, property.getTsType());
         String fieldClassName = fieldBeanModel != null ? getBeanModelClassName(fieldBeanModel) : "";
+        // if a class has a field of its own type, we get stackoverflow exception
+        if (fieldClassName.equals(bean.getName().toString())) {
+            fieldClassName = "";
+        }
         writer.writeIndentedLine(
             settings.indentString + property.getName() + " = new " + fieldClassName + "Fields(this, \"" + property.getName() + "\");");
     }


### PR DESCRIPTION
sorry, my previous PR was maybe a little too eager. I now noticed this issue, because we now will also link DTOs through List references, like so:

class X { myField: List<X> }

and if we have that, we get a stack overflow in the generated typescript. So with this change I just don't generate the link anymore in case it's a self-reference. Workaround, but it works.

PS: I don't know if you saw that I think we need the generics code that you removed on master => https://github.com/vojtechhabarta/typescript-generator/pull/100#issuecomment-264481195