### PR TITLE
bean property path extension: export the Fields class

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
@@ -46,7 +46,7 @@ public class BeanPropertyPathExtension extends EmitterExtension {
 
     private static void emitFieldsClass(Writer writer, Settings settings) {
         List<String> fieldsClassLines = Arrays.asList(
-            "class Fields {",
+            "export class Fields {",
             "    protected $$parent: Fields | undefined;",
             "    protected $$name: string;",
             "    constructor(parent?: Fields, name?: string) {",

--- a/typescript-generator-core/src/test/resources/ext/expected.ts
+++ b/typescript-generator-core/src/test/resources/ext/expected.ts
@@ -1,5 +1,5 @@
 
-class Fields {
+export class Fields {
     protected $$parent: Fields | undefined;
     protected $$name: string;
     constructor(parent?: Fields, name?: string) {


### PR DESCRIPTION
one more change to the extension... exporting the `Fields` class turns out to be useful.

We've had the situation for instance where one DTO was something like that:

```java
public class ExportDto<T> {
  T dto;
  boolean isOk;
  ...
}
```

clearly it's going to be tricky to access it with the bean property path mechanism. What we did is:

```typescript
const getExported = (field: Fields) => ExportDto.dto.get() + "." + field.get();
...
field: getExported(MyProperDto.myProperField);
```

turns out quite clean, and as type-safe as possible. But if we don't export the `Fields` type, `getExported` can only take `any` and it's less safe.