### PR TITLE
UMD modules (export as namespace)

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.emitter.Emitter;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import cz.habarta.typescript.generator.util.Predicate;
 import java.io.File;
@@ -22,6 +23,7 @@ public class Settings {
     public TypeScriptOutputKind outputKind = null;
     public String module = null;
     public String namespace = null;
+    public String umdNamespace = null;
     public JsonLibrary jsonLibrary = null;
     private Predicate<String> excludeFilter = null;
     public boolean declarePropertiesAsOptional = false;
@@ -102,6 +104,15 @@ public class Settings {
         }
         if (outputKind == TypeScriptOutputKind.ambientModule && outputFileType == TypeScriptFileType.implementationFile) {
             throw new RuntimeException("Ambient modules are not supported in implementation files. " + seeLink());
+        }
+        if (outputKind != TypeScriptOutputKind.module && umdNamespace != null) {
+            throw new RuntimeException("'umdNamespace' parameter is only applicable to modules. " + seeLink());
+        }
+        if (outputFileType == TypeScriptFileType.implementationFile && umdNamespace != null) {
+            throw new RuntimeException("'umdNamespace' parameter is not applicable to implementation files. " + seeLink());
+        }
+        if (umdNamespace != null && !Emitter.isValidIdentifierName(umdNamespace)) {
+            throw new RuntimeException("Value of 'umdNamespace' parameter is not valid identifier: " + umdNamespace + ". " + seeLink());
         }
         if (jsonLibrary == null) {
             throw new RuntimeException("Required 'jsonLibrary' parameter is not configured.");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -32,6 +32,7 @@ public class Emitter {
         emitReferences();
         emitImports();
         emitModule(model);
+        emitUmdNamespace();
         if (closeOutput) {
             close();
         }
@@ -148,7 +149,7 @@ public class Emitter {
 
     // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#2.2.2
     // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-names-and-keywords
-    private static boolean isValidIdentifierName(String name) {
+    public static boolean isValidIdentifierName(String name) {
         if (name == null || name.isEmpty()) {
             return false;
         }
@@ -190,6 +191,13 @@ public class Emitter {
             }
             indent--;
             writeIndentedLine("}");
+        }
+    }
+
+    private void emitUmdNamespace() {
+        if (settings.umdNamespace != null) {
+            writeNewLine();
+            writeIndentedLine("export as namespace " + settings.umdNamespace + ";");
         }
     }
 

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -17,6 +17,7 @@ public class GenerateTask extends DefaultTask {
     public TypeScriptOutputKind outputKind;
     public String module;
     public String namespace;
+    public String umdNamespace;
     public List<String> classes;
     public List<String> classPatterns;
     public String classesFromJaxrsApplication;
@@ -79,6 +80,7 @@ public class GenerateTask extends DefaultTask {
         settings.outputKind = outputKind;
         settings.module = module;
         settings.namespace = namespace;
+        settings.umdNamespace = umdNamespace;
         settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
         settings.jsonLibrary = jsonLibrary;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -57,6 +57,13 @@ public class GenerateMojo extends AbstractMojo {
     private String namespace;
 
     /**
+     * Turns proper module into UMD (Universal Module Definition) with specified namespace.
+     * Only applicable to declaration files.
+     */
+    @Parameter
+    private String umdNamespace;
+
+    /**
      * JSON classes to process.
      */
     @Parameter
@@ -309,6 +316,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.outputKind = outputKind;
             settings.module = module;
             settings.namespace = namespace;
+            settings.umdNamespace = umdNamespace;
             settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
             settings.jsonLibrary = jsonLibrary;
             settings.declarePropertiesAsOptional = declarePropertiesAsOptional;


### PR DESCRIPTION
This PR adds support for declaration files in UMD format ([TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/modules.html#umd-modules)).

This feature is only useful when one generated **declaration file** should be used in two ways: as a module or globally with namespace.

To generate UMD declaration file set these parameters:
``` xml
<outputKind>module</outputKind>
<umdNamespace>SomeNamespace</umdNamespace>
```

Typescript-generator then adds following declaration to `.d.ts` file:
``` typescript
export as namespace SomeNamespace;
```