### PR TITLE
Using discovered jackson2 modules

### DIFF
--- a/sample-maven/pom.xml
+++ b/sample-maven/pom.xml
@@ -12,7 +12,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.7.4</version>
+            <version>2.8.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-hibernate5</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.2.6.Final</version>
         </dependency>
     </dependencies>
 
@@ -21,7 +31,7 @@
             <plugin>
                 <groupId>cz.habarta.typescript-generator</groupId>
                 <artifactId>typescript-generator-maven-plugin</artifactId>
-                <version>1.10-SNAPSHOT</version>
+                <version>1.15-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate</id>
@@ -31,6 +41,7 @@
                         <phase>process-classes</phase>
                         <configuration>
                             <jsonLibrary>jackson2</jsonLibrary>
+                            <disableJackson2ModuleDiscovery>false</disableJackson2ModuleDiscovery>
                             <classes>
                                 <class>cz.habarta.typescript.generator.sample.Person</class>
                             </classes>

--- a/sample-maven/src/main/java/cz/habarta/typescript/generator/sample/Person.java
+++ b/sample-maven/src/main/java/cz/habarta/typescript/generator/sample/Person.java
@@ -12,4 +12,7 @@ public class Person {
     public List<String> tags;
     public Map<String, String> emails;
 
+    @javax.persistence.Transient
+    public String excluded;
+
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -48,6 +48,8 @@ public class Settings {
     public List<Class<? extends Annotation>> includePropertyAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public boolean displaySerializerWarning = true;
+    public boolean disableJackson2ModuleDiscovery = false;
+    public ClassLoader classLoader = null;
 
 
     public void setStringQuotes(StringQuotes quotes) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -36,6 +36,9 @@ public class Jackson2Parser extends ModelParser {
 
     public Jackson2Parser(Settings settings, TypeProcessor typeProcessor, boolean useJaxbAnnotations) {
         super(settings, typeProcessor);
+        if (!settings.disableJackson2ModuleDiscovery) {
+            objectMapper.registerModules(ObjectMapper.findModules(settings.classLoader));
+        }
         if (useJaxbAnnotations) {
             AnnotationIntrospector introspector = new JaxbAnnotationIntrospector(objectMapper.getTypeFactory());
             objectMapper.setAnnotationIntrospector(introspector);

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -48,6 +48,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> optionalAnnotations;
     public StringQuotes stringQuotes;
     public boolean displaySerializerWarning = true;
+    public boolean disableJackson2ModuleDiscovery;
 
     @TaskAction
     public void generate() throws Exception {
@@ -106,6 +107,8 @@ public class GenerateTask extends DefaultTask {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.setStringQuotes(stringQuotes);
         settings.displaySerializerWarning = displaySerializerWarning;
+        settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+        settings.classLoader = classLoader;
         settings.validateFileName(new File(outputFile));
 
         // TypeScriptGenerator

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -293,6 +293,12 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean displaySerializerWarning;
 
+    /**
+     * Turns off Jackson2 automatic module discovery.
+     */
+    @Parameter
+    private boolean disableJackson2ModuleDiscovery;
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -342,6 +348,8 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.setStringQuotes(stringQuotes);
             settings.displaySerializerWarning = displaySerializerWarning;
+            settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+            settings.classLoader = classLoader;
             settings.validateFileName(outputFile);
 
             // TypeScriptGenerator


### PR DESCRIPTION
This PR fixes #110.

When Jackson2 library is used with some **Jackson modules** typescript-generator reflects automatically these modules. For example project can have this dependency:
``` xml
<dependency>
    <groupId>com.fasterxml.jackson.datatype</groupId>
    <artifactId>jackson-datatype-hibernate5</artifactId>
    <version>2.8.6</version>
</dependency>
```

and in this case bean properties marked with `@javax.persistence.Transient` annotation are ignored by Jackson in runtime and also by typescript-generator when generating declarations.

This functionality can be disabled in configuration:
``` xml
<configuration>
    <jsonLibrary>jackson2</jsonLibrary>
    <disableJackson2ModuleDiscovery>true</disableJackson2ModuleDiscovery>
</configuration>
```

Complete example is in [sample-maven](https://github.com/vojtechhabarta/typescript-generator/tree/jackson-modules/sample-maven).
