### PR TITLE
Custom type names specified using JavaScript function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
                 <version>2.18.1</version>
                 <configuration>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
             <plugin>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -32,6 +32,7 @@ public class Settings {
     public String addTypeNamePrefix = null;
     public String addTypeNameSuffix = null;
     public Map<String, String> customTypeNaming = new LinkedHashMap<>();
+    public String customTypeNamingFunction = null;
     public List<String> referencedFiles = new ArrayList<>();
     public List<String> importDeclarations = new ArrayList<>();
     public Map<String, String> customTypeMappings = new LinkedHashMap<>();

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
@@ -8,7 +8,6 @@ import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
 
 
 /**
@@ -102,7 +101,7 @@ public class SymbolTable {
             try {
                 final CustomTypeNamingFunction function = getCustomTypeNamingFunction();
                 final Object getNameResult = function.getName(cls.getName(), cls.getSimpleName());
-                if (getNameResult != null && !ScriptObjectMirror.isUndefined(getNameResult)) {
+                if (getNameResult != null && !isUndefined(getNameResult)) {
                     return (String) getNameResult;
                 }
             } catch (ScriptException e) {
@@ -123,6 +122,16 @@ public class SymbolTable {
             name = name + settings.addTypeNameSuffix;
         }
         return name;
+    }
+
+    private static boolean isUndefined(Object variable) {
+        // Java 8
+//        return ScriptObjectMirror.isUndefined(variable);
+
+        // Hack for Java 7, it should match both:
+        // org.mozilla.javascript.Undefined (Java 7)
+        // jdk.nashorn.internal.runtime.Undefined (Java 8)
+        return variable != null && variable.getClass().getSimpleName().equals("Undefined");
     }
 
     private CustomTypeNamingFunction getCustomTypeNamingFunction() throws ScriptException {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -38,7 +38,7 @@ public class Jackson2Parser extends ModelParser {
         super(settings, typeProcessor);
         if (!settings.disableJackson2ModuleDiscovery) {
             objectMapper.registerModules(ObjectMapper.findModules(settings.classLoader));
-            }
+        }
         if (useJaxbAnnotations) {
             AnnotationIntrospector introspector = new JaxbAnnotationIntrospector(objectMapper.getTypeFactory());
             objectMapper.setAnnotationIntrospector(introspector);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
@@ -38,4 +38,22 @@ public class NamingTest {
         }
     }
 
+    @Test
+    public void testTypeNamingFunction() {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeNamingFunction = "function(name, simpleName) { if (name.startsWith('cz.')) return 'Test' + simpleName; }";
+        final SymbolTable symbolTable = new SymbolTable(settings);
+        final String name = symbolTable.getMappedName(A.class);
+        Assert.assertEquals("TestA", name);
+    }
+
+    @Test
+    public void testTypeNamingFunctionReturnsUndefined() {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeNamingFunction = "function() {}";
+        final SymbolTable symbolTable = new SymbolTable(settings);
+        final String name = symbolTable.getMappedName(A.class);
+        Assert.assertEquals("A", name);
+    }
+
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
@@ -41,7 +41,7 @@ public class NamingTest {
     @Test
     public void testTypeNamingFunction() {
         final Settings settings = TestUtils.settings();
-        settings.customTypeNamingFunction = "function(name, simpleName) { if (name.startsWith('cz.')) return 'Test' + simpleName; }";
+        settings.customTypeNamingFunction = "function(name, simpleName) { if (name.indexOf('cz.') === 0) return 'Test' + simpleName; }";
         final SymbolTable symbolTable = new SymbolTable(settings);
         final String name = symbolTable.getMappedName(A.class);
         Assert.assertEquals("TestA", name);

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -32,6 +32,7 @@ public class GenerateTask extends DefaultTask {
     public String addTypeNamePrefix;
     public String addTypeNameSuffix;
     public List<String> customTypeNaming;
+    public String customTypeNamingFunction;
     public List<String> referencedFiles;
     public List<String> importDeclarations;
     public List<String> customTypeMappings;
@@ -90,6 +91,7 @@ public class GenerateTask extends DefaultTask {
         settings.addTypeNamePrefix = addTypeNamePrefix;
         settings.addTypeNameSuffix = addTypeNameSuffix;
         settings.customTypeNaming = Settings.convertToMap(customTypeNaming);
+        settings.customTypeNamingFunction = customTypeNamingFunction;
         settings.referencedFiles = referencedFiles;
         settings.importDeclarations = importDeclarations;
         settings.customTypeMappings = Settings.convertToMap(customTypeMappings);

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -160,12 +160,21 @@ public class GenerateMojo extends AbstractMojo {
     private String addTypeNameSuffix;
 
     /**
-     * Specifies custom TypeScript name for Java classes.
+     * Specifies custom TypeScript names for Java classes.
      * Multiple mappings can be specified, each using this format: "javaClassName:typescriptName".
      * This takes precedence over other naming settings.
      */
     @Parameter
     private List<String> customTypeNaming;
+
+    /**
+     * Specifies JavaScript function for getting custom TypeScript names for Java classes.
+     * Function can return undefined if default name should be used.
+     * Function signature: <code>function getName(className: string, classSimpleName: string): string | null | undefined;</code>
+     * Example function: <code>function(name, simpleName) { if (name.startsWith('cz.')) return 'Test' + simpleName; }</code>
+     */
+    @Parameter
+    private String customTypeNamingFunction;
 
     /**
      * List of files which will be referenced using triple-slash directive: /// &lt;reference path="file" />.
@@ -331,6 +340,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.addTypeNamePrefix = addTypeNamePrefix;
             settings.addTypeNameSuffix = addTypeNameSuffix;
             settings.customTypeNaming = Settings.convertToMap(customTypeNaming);
+            settings.customTypeNamingFunction = customTypeNamingFunction;
             settings.referencedFiles = referencedFiles;
             settings.importDeclarations = importDeclarations;
             settings.customTypeMappings = Settings.convertToMap(customTypeMappings);


### PR DESCRIPTION
This PR adds `customTypeNamingFunction` configuration parameter which allow to specify custom type names using JavaScript function.

In addition to this new parameter it was already possible to configure naming using these parameters:
- `customTypeNaming`
- `removeTypeNamePrefix`
- `removeTypeNameSuffix`
- `addTypeNamePrefix`
- `addTypeNameSuffix`

New `customTypeNamingFunction` parameter provides greater flexibility in naming (for the price of harder configuration).

Function signature is:
``` typescript
function getName(className: string, classSimpleName: string): string | null | undefined;
```

Example usage is to add some prefix based on package name like this:
``` xml
<configuration>
    <customTypeNamingFunction>
        function(name, simpleName) {
            if (name.indexOf('cz.') === 0) return 'Test' + simpleName;
        }
    </customTypeNamingFunction>
</configuration>
```


