### PR TITLE
Default values for `outputFile` parameter

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -136,6 +136,10 @@ public class Settings {
         }
     }
 
+    public String getExtension() {
+        return outputFileType == TypeScriptFileType.implementationFile ? ".ts" : ".d.ts";
+    }
+
     public void validateFileName(File outputFile) {
         if (outputFileType == TypeScriptFileType.declarationFile && !outputFile.getName().endsWith(".d.ts")) {
             throw new RuntimeException("Declaration file must have 'd.ts' extension: " + outputFile);

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -56,8 +56,8 @@ public class GenerateTask extends DefaultTask {
 
     @TaskAction
     public void generate() throws Exception {
-        if (outputFile == null) {
-            throw new RuntimeException("Please specify 'outputFile' property.");
+        if (outputKind == null) {
+            throw new RuntimeException("Please specify 'outputKind' property.");
         }
         if (jsonLibrary == null) {
             throw new RuntimeException("Please specify 'jsonLibrary' property.");
@@ -117,12 +117,15 @@ public class GenerateTask extends DefaultTask {
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
         settings.classLoader = classLoader;
-        settings.validateFileName(new File(outputFile));
+        final File output = outputFile != null
+                ? getProject().file(outputFile)
+                : new File(new File(getProject().getBuildDir(), "typescript-generator"), getProject().getName() + settings.getExtension());
+        settings.validateFileName(output);
 
         // TypeScriptGenerator
         new TypeScriptGenerator(settings).generateTypeScript(
                 Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader),
-                Output.to(getProject().file(outputFile))
+                Output.to(output)
         );
     }
 

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -19,9 +19,8 @@ public class GenerateMojo extends AbstractMojo {
 
     /**
      * Path and name of generated TypeScript file.
-     * Required parameter.
      */
-    @Parameter(required = true)
+    @Parameter
     private File outputFile;
 
     /**
@@ -334,6 +333,9 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
+    @Parameter(defaultValue = "${project.build.directory}", readonly = true, required = true)
+    private String projectBuildDirectory;
+
     @Override
     public void execute() {
         try {
@@ -386,12 +388,15 @@ public class GenerateMojo extends AbstractMojo {
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
             settings.classLoader = classLoader;
-            settings.validateFileName(outputFile);
+            final File output = outputFile != null
+                    ? outputFile
+                    : new File(new File(projectBuildDirectory, "typescript-generator"), project.getArtifactId() + settings.getExtension());
+            settings.validateFileName(output);
 
             // TypeScriptGenerator
             new TypeScriptGenerator(settings).generateTypeScript(
                     Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader),
-                    Output.to(outputFile)
+                    Output.to(output)
             );
 
         } catch (DependencyResolutionRequiredException | IOException e) {


### PR DESCRIPTION
Build plugins `outputFile` parameter is no longer required.

Default value is:
- **Maven**: `${project.build.directory}/typescript-generator/${project.artifactId}${tsExtension}`
- **Gradle**: `${project.buildDir}/typescript-generator/${project.name}${tsExtension}`

where `tsExtension` is `.d.ts` or `.ts`.