### PR TITLE
Generate NPM package.json

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -51,6 +51,9 @@ public class Settings {
     public List<EmitterExtension> extensions = new ArrayList<>();
     public List<Class<? extends Annotation>> includePropertyAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
+    public boolean generateNpmPackageJson = false;
+    public String npmName = null;
+    public String npmVersion = null;
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery = false;
     public ClassLoader classLoader = null;
@@ -134,6 +137,19 @@ public class Settings {
                 throw new RuntimeException("'mapClasses' parameter is set to `asClasses` which generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.");
             }
         }
+        if (generateNpmPackageJson && outputKind != TypeScriptOutputKind.module) {
+            throw new RuntimeException("'generateNpmPackageJson' can only be used when generating proper module ('outputKind' parameter is 'module').");
+        }
+        if (generateNpmPackageJson) {
+            if (npmName == null || npmVersion == null) {
+                throw new RuntimeException("'npmName' and 'npmVersion' must be specified when generating NPM package.json.");
+            }
+        }
+        if (!generateNpmPackageJson) {
+            if (npmName != null || npmVersion != null) {
+                throw new RuntimeException("'npmName' and 'npmVersion' is only applicable when generating NPM package.json.");
+            }
+        }
     }
 
     public String getExtension() {
@@ -147,6 +163,10 @@ public class Settings {
         if (outputFileType == TypeScriptFileType.implementationFile && (!outputFile.getName().endsWith(".ts") || outputFile.getName().endsWith(".d.ts"))) {
             throw new RuntimeException("Implementation file must have 'ts' extension: " + outputFile);
         }
+    }
+
+    public String getDefaultNpmVersion() {
+        return "1.0.0";
     }
 
     public Predicate<String> getExcludeFilter() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJson.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJson.java
@@ -1,0 +1,11 @@
+
+package cz.habarta.typescript.generator.emitter;
+
+
+public class NpmPackageJson {
+
+    public String name;
+    public String version;
+    public String types;
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJsonEmitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJsonEmitter.java
@@ -1,0 +1,44 @@
+
+package cz.habarta.typescript.generator.emitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import cz.habarta.typescript.generator.util.StandardJsonPrettyPrinter;
+import java.io.*;
+
+
+public class NpmPackageJsonEmitter {
+
+    private Writer writer;
+
+    public void emit(NpmPackageJson npmPackageJson, Writer output, String outputName, boolean closeOutput) {
+        this.writer = output;
+        if (outputName != null) {
+            System.out.println("Writing NPM package to: " + outputName);
+        }
+        emitPackageJson(npmPackageJson);
+        if (closeOutput) {
+            close();
+        }
+    }
+
+    private void emitPackageJson(NpmPackageJson npmPackageJson) {
+        try {
+            final ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+            objectMapper.setDefaultPrettyPrinter(new StandardJsonPrettyPrinter("  ", "\n"));
+            objectMapper.writeValue(writer, npmPackageJson);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void close() {
+        try {
+            writer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/StandardJsonPrettyPrinter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/StandardJsonPrettyPrinter.java
@@ -1,0 +1,41 @@
+
+package cz.habarta.typescript.generator.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import java.io.IOException;
+
+
+/**
+ * Jackson2 PrettyPrinter implementation that produces JSON format similar to JSON.stringify() output.
+ */
+public class StandardJsonPrettyPrinter extends DefaultPrettyPrinter {
+    private static final long serialVersionUID = 1;
+
+    private final String indent;
+    private final String eol;
+
+    public StandardJsonPrettyPrinter() {
+        this("    ", String.format("%n"));
+    }
+
+    public StandardJsonPrettyPrinter(String indent, String eol) {
+        this.indent = indent;
+        this.eol = eol;
+        final DefaultIndenter indenter = new DefaultIndenter(indent, eol);
+        this._arrayIndenter = indenter;
+        this._objectIndenter = indenter;
+    }
+
+    @Override
+    public DefaultPrettyPrinter createInstance() {
+        return new StandardJsonPrettyPrinter(indent, eol);
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(JsonGenerator jg) throws IOException {
+        jg.writeRaw(": ");
+    }
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -50,6 +50,9 @@ public class GenerateTask extends DefaultTask {
     public List<File> javadocXmlFiles;
     public List<String> extensionClasses;
     public List<String> optionalAnnotations;
+    public boolean generateNpmPackageJson;
+    public String npmName;
+    public String npmVersion;
     public StringQuotes stringQuotes;
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery;
@@ -113,6 +116,9 @@ public class GenerateTask extends DefaultTask {
         settings.loadExtensions(classLoader, extensionClasses);
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
+        settings.generateNpmPackageJson = generateNpmPackageJson;
+        settings.npmName = npmName != null ? npmName : getProject().getName();
+        settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
         settings.setStringQuotes(stringQuotes);
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -311,6 +311,30 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> optionalAnnotations;
 
     /**
+     * If true NPM package.json will be generated.
+     * Only applicable when 'outputKind' is set to 'module'.
+     * NPM package name and version can be specified using 'npmName' and 'npmVersion' parameters.
+     */
+    @Parameter
+    private boolean generateNpmPackageJson;
+
+    /**
+     * Specifies NPM package name.
+     * Only applicable when 'generateNpmPackageJson' parameter is 'true'.
+     * Default value is <code>${project.artifactId}</code>.
+     */
+    @Parameter
+    private String npmName;
+
+    /**
+     * Specifies NPM package version.
+     * Only applicable when 'generateNpmPackageJson' parameter is 'true'.
+     * Default value is <code>1.0.0</code>.
+     */
+    @Parameter
+    private String npmVersion;
+
+    /**
      * Specifies how strings will be quoted.
      * Supported values are 'doubleQuotes', 'singleQuotes'.
      * Default value is 'doubleQuotes'.
@@ -384,6 +408,9 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadExtensions(classLoader, extensions);
             settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
+            settings.generateNpmPackageJson = generateNpmPackageJson;
+            settings.npmName = npmName != null ? npmName : project.getArtifactId();
+            settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
             settings.setStringQuotes(stringQuotes);
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;


### PR DESCRIPTION
This PR adds possibility to generate NPM **package.json** for modules so output directory contains "complete" NPM module that can be installed using `npm install` command.

This functionality can be turned on using `generateNpmPackageJson` parameter like this:
``` xml
<configuration>
    <outputKind>module</outputKind>
    <generateNpmPackageJson>true</generateNpmPackageJson>
    <npmName>module-name</npmName>
    <npmVersion>1.2.3</npmVersion>
    ...
</configuration>
```
(`npmName` and `npmVersion` parameters are optional)

Then "minimal complete" `package.json` file is generated in the same directory as TypeScript file:
``` json
{
  "name": "module-name",
  "version": "1.2.3",
  "types": "module-name.d.ts"
}
```
