### PR TITLE
Fixed npmName and npmVersion parameters default values

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -142,12 +142,12 @@ public class Settings {
         }
         if (generateNpmPackageJson) {
             if (npmName == null || npmVersion == null) {
-                throw new RuntimeException("'npmName' and 'npmVersion' must be specified when generating NPM package.json.");
+                throw new RuntimeException("'npmName' and 'npmVersion' must be specified when generating NPM 'package.json'.");
             }
         }
         if (!generateNpmPackageJson) {
             if (npmName != null || npmVersion != null) {
-                throw new RuntimeException("'npmName' and 'npmVersion' is only applicable when generating NPM package.json.");
+                throw new RuntimeException("'npmName' and 'npmVersion' is only applicable when generating NPM 'package.json'.");
             }
         }
     }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -117,8 +117,8 @@ public class GenerateTask extends DefaultTask {
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.generateNpmPackageJson = generateNpmPackageJson;
-        settings.npmName = npmName != null ? npmName : getProject().getName();
-        settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
+        settings.npmName = npmName != null && generateNpmPackageJson ? getProject().getName() : npmName;
+        settings.npmVersion = npmVersion != null && generateNpmPackageJson ? settings.getDefaultNpmVersion() : npmVersion;
         settings.setStringQuotes(stringQuotes);
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -409,8 +409,8 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
             settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
             settings.generateNpmPackageJson = generateNpmPackageJson;
-            settings.npmName = npmName != null ? npmName : project.getArtifactId();
-            settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
+            settings.npmName = npmName == null && generateNpmPackageJson ? project.getArtifactId() : npmName;
+            settings.npmVersion = npmVersion == null && generateNpmPackageJson ? settings.getDefaultNpmVersion() : npmVersion;
             settings.setStringQuotes(stringQuotes);
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;


### PR DESCRIPTION
This PR fixes following incorrectly reported error:
```
'npmName' and 'npmVersion' is only applicable when generating NPM package.json.
```

This error was caused by always applying default values for `npmName` and `npmVersion` parameters. They should only be applied when `generateNpmPackageJson` is `true`.