### PR TITLE
JAX-RS application client - Axios implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ release.properties
 /sample-gradle/.nb-gradle/
 /sample-gradle/build/
 
+# npm
+node_modules
+
 # NetBeans
 nbactions.xml
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -7,6 +7,7 @@ import cz.habarta.typescript.generator.parser.*;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.*;
 import java.util.*;
+import javax.ws.rs.core.Application;
 
 
 /**
@@ -298,7 +299,7 @@ public class ModelCompiler {
     private TsModel createJaxrsInterface(SymbolTable symbolTable, TsModel tsModel, JaxrsApplicationModel jaxrsApplication, Symbol responseSymbol, TsType optionsType) {
         final List<TsMethodModel> methods = processJaxrsMethods(jaxrsApplication, symbolTable, responseSymbol, optionsType, false);
         final String applicationName = getApplicationName(jaxrsApplication);
-        final TsBeanModel interfaceModel = new TsBeanModel(null, false, symbolTable.getSyntheticSymbol(applicationName), null, null, null, null, null, null, methods, null);
+        final TsBeanModel interfaceModel = new TsBeanModel(Application.class, false, symbolTable.getSyntheticSymbol(applicationName), null, null, null, null, null, null, methods, null);
         tsModel.getBeans().add(interfaceModel);
         return tsModel;
     }
@@ -329,7 +330,7 @@ public class ModelCompiler {
         final String applicationName = getApplicationName(jaxrsApplication);
         final String applicationClientName = applicationName + "Client";
         final TsType interfaceType = settings.generateJaxrsApplicationInterface ? new TsType.ReferenceType(symbolTable.getSyntheticSymbol(applicationName)) : null;
-        final TsBeanModel clientModel = new TsBeanModel(null, true, symbolTable.getSyntheticSymbol(applicationClientName), null, null, null, Utils.listFromNullable(interfaceType), null, constructor, methods, null);
+        final TsBeanModel clientModel = new TsBeanModel(Application.class, true, symbolTable.getSyntheticSymbol(applicationClientName), null, null, null, Utils.listFromNullable(interfaceType), null, constructor, methods, null);
         tsModel.getBeans().add(clientModel);
         return tsModel;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
@@ -5,6 +5,10 @@ package cz.habarta.typescript.generator.emitter;
 public class EmitterExtensionFeatures {
 
     public boolean generatesRuntimeCode = false;
+    public boolean generatesModuleCode = false;
+    public boolean generatesJaxrsApplicationClient = false;
+    public String restResponseType = null;
+    public String restOptionsType = null;
     public boolean overridesStringEnums = false;
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AbstractClientExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AbstractClientExtension.java
@@ -1,0 +1,64 @@
+
+package cz.habarta.typescript.generator.ext;
+
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.emitter.EmitterExtension;
+import cz.habarta.typescript.generator.emitter.TsBeanModel;
+import cz.habarta.typescript.generator.emitter.TsModel;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
+import javax.ws.rs.core.Application;
+
+
+public abstract class AbstractClientExtension extends EmitterExtension {
+
+    @Override
+    public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
+        final TsBeanModel applicationBean = getJaxrsApplicationClientBean(model);
+        if (applicationBean != null) {
+            final String appName = applicationBean.getName().toString();
+            emitClient(writer, settings, exportKeyword, appName);
+        }
+    }
+
+    private static TsBeanModel getJaxrsApplicationClientBean(TsModel model) {
+        for (TsBeanModel bean : model.getBeans()) {
+            if (bean.getOrigin() != null && bean.getOrigin().equals(Application.class) && bean.isClass()) {
+                return bean;
+            }
+        }
+        return null;
+    }
+
+    protected abstract void emitClient(Writer writer, Settings settings, boolean exportKeyword, String appName);
+    
+    protected void emitTemplate(Writer writer, Settings settings, String templateName, Map<String, String> replacements) {
+        final List<String> template = readAllLines(getClass().getResource(templateName));
+        for (String line : template) {
+            for (Map.Entry<String, String> entry : replacements.entrySet()) {
+                line = line.replaceAll(Pattern.quote(entry.getKey()), entry.getValue());
+            }
+            writer.writeIndentedLine(line);
+        }
+    }
+
+    private static List<String> readAllLines(URL resource) {
+        try {
+            final List<String> lines = new ArrayList<>();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+            return lines;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
@@ -1,0 +1,32 @@
+
+package cz.habarta.typescript.generator.ext;
+
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
+import java.util.*;
+
+
+public class AxiosClientExtension extends AbstractClientExtension {
+
+    @Override
+    public EmitterExtensionFeatures getFeatures() {
+        final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+        features.generatesRuntimeCode = true;
+        features.generatesModuleCode = true;
+        features.generatesJaxrsApplicationClient = true;
+        features.restResponseType = "Axios.Promise<Axios.GenericAxiosResponse<R>>";
+        features.restOptionsType = "Axios.AxiosRequestConfig";
+        return features;
+    }
+
+    @Override
+    protected void emitClient(Writer writer, Settings settings, boolean exportKeyword, String appName) {
+        final Map<String, String> replacements = new LinkedHashMap<>();
+        replacements.put("\"", settings.quotes);
+        replacements.put("/*export*/ ", exportKeyword ? "export " : "");
+        replacements.put("$$RestApplicationClient$$", appName);
+        replacements.put("$$AxiosRestApplicationClient$$", "Axios" + appName);
+        emitTemplate(writer, settings, "AxiosClientExtension.template.ts", replacements);
+    }
+
+}

--- a/typescript-generator-core/src/main/resources/cz/habarta/typescript/generator/ext/AxiosClientExtension.template.ts
+++ b/typescript-generator-core/src/main/resources/cz/habarta/typescript/generator/ext/AxiosClientExtension.template.ts
@@ -1,0 +1,47 @@
+
+
+import axios from "axios";
+import * as Axios from "axios";
+
+declare module "axios" {
+    export interface GenericAxiosResponse<R> extends Axios.AxiosResponse {
+        data: R;
+    }
+}
+
+class AxiosHttpClient implements HttpClient {
+
+    constructor(private axios: Axios.AxiosInstance) {
+    }
+
+    request(requestConfig: { method: string; url: string; queryParams?: any; data?: any; options?: Axios.AxiosRequestConfig; }): RestResponse<any> {
+        function assign(target: any, source?: any) {
+            if (source != undefined) {
+                for (const key in source) {
+                    if (source.hasOwnProperty(key)) {
+                        target[key] = source[key];
+                    }
+                }
+            }
+            return target;
+        }
+
+        const config: Axios.AxiosRequestConfig = {};
+        config.method = requestConfig.method;
+        config.url = requestConfig.url;
+        config.params = requestConfig.queryParams;
+        config.data = requestConfig.data;
+        assign(config, requestConfig.options);
+
+        const axiosResponse = this.axios.request(config);
+        return axiosResponse;
+    }
+}
+
+/*export*/ class $$AxiosRestApplicationClient$$ extends $$RestApplicationClient$$ {
+
+    constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create()) {
+        axiosInstance.defaults.baseURL = baseURL;
+        super(new AxiosHttpClient(axiosInstance));
+    }
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationTest.java
@@ -384,7 +384,7 @@ public class JaxrsApplicationTest {
     }
 
     @Path("people/{personId}")
-    private static class PersonResource {
+    public static class PersonResource {
         @PathParam("personId")
         protected long personId;
         @GET

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
@@ -1,0 +1,36 @@
+
+package cz.habarta.typescript.generator.ext;
+
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.JaxrsApplicationTest;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TestUtils;
+import cz.habarta.typescript.generator.TypeScriptFileType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class AxiosClientExtensionTest {
+
+    @Test
+    public void test() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.outputKind = TypeScriptOutputKind.module;
+        settings.generateJaxrsApplicationClient = true;
+        settings.extensions.add(new AxiosClientExtension());
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JaxrsApplicationTest.PersonResource.class));
+        final String errorMessage = "Unexpected output: " + output;
+        Assert.assertTrue(errorMessage, output.contains("interface Person"));
+        Assert.assertTrue(errorMessage, output.contains("interface HttpClient"));
+        Assert.assertTrue(errorMessage, output.contains("class RestApplicationClient"));
+        Assert.assertTrue(errorMessage, output.contains("type RestResponse<R> = Axios.Promise<Axios.GenericAxiosResponse<R>>"));
+        Assert.assertTrue(errorMessage, output.contains("class AxiosHttpClient implements HttpClient"));
+        Assert.assertTrue(errorMessage, output.contains("request(requestConfig: { method: string; url: string; queryParams?: any; data?: any; options?: Axios.AxiosRequestConfig; }): RestResponse<any>"));
+        Assert.assertTrue(errorMessage, output.contains("class AxiosRestApplicationClient extends RestApplicationClient"));
+        Assert.assertTrue(errorMessage, output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"));
+    }
+
+}


### PR DESCRIPTION
This PR adds `cz.habarta.typescript.generator.ext.AxiosClientExtension` extension which generates complete **service client** using **Axios library**.

- This extension turns on `generateJaxrsApplicationClient` configuration parameter to produce generic client and then implements `HttpClient` interface.
- It adds `options` parameter typed `Axios.AxiosRequestConfig` to methods.
- Method return types are `Axios.Promise<Axios.GenericAxiosResponse<R>>`.

Here is example Maven configuration:

``` xml
<configuration>
    <outputFileType>implementationFile</outputFileType>
    <outputKind>module</outputKind>
    <classesFromAutomaticJaxrsApplication>true</classesFromAutomaticJaxrsApplication>
    <extensions>
        <extension>cz.habarta.typescript.generator.ext.AxiosClientExtension</extension>
    </extensions>
</configuration>
```
