### PR TITLE
Swagger annotations

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -68,6 +68,12 @@
             <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>        
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.5.10</version>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 
     <build>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -42,6 +42,7 @@ public class Settings {
     public EnumMapping mapEnum; // default is EnumMapping.asUnion
     public ClassMapping mapClasses; // default is ClassMapping.asInterfaces
     public boolean disableTaggedUnions = false;
+    public boolean ignoreSwaggerAnnotations = false;
     public boolean generateJaxrsApplicationInterface = false;
     public boolean generateJaxrsApplicationClient = false;
     public String restResponseType = null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -385,9 +385,10 @@ public class ModelCompiler {
     private TsMethodModel processJaxrsMethod(SymbolTable symbolTable, String pathPrefix, Symbol responseSymbol, JaxrsMethodModel method, boolean createLongName, TsType optionsType, boolean implement) {
         final String path = Utils.joinPath(pathPrefix, method.getPath());
         final PathTemplate pathTemplate = PathTemplate.parse(path);
-        final List<String> comments = new ArrayList<>();
-        comments.add("HTTP " + method.getHttpMethod() + " /" + path);
-        comments.add("Java method: " + method.getOriginClass().getName() + "." + method.getName());
+        final List<String> comments = Utils.concat(method.getComments(), Arrays.asList(
+            "HTTP " + method.getHttpMethod() + " /" + path,
+            "Java method: " + method.getOriginClass().getName() + "." + method.getName()
+        ));
         final List<TsParameterModel> parameters = new ArrayList<>();
         // path params
         for (MethodParameterModel parameter : method.getPathParams()) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.util.Utils;
 import cz.habarta.typescript.generator.xmldoclet.Class;
 import cz.habarta.typescript.generator.xmldoclet.Enum;
 import cz.habarta.typescript.generator.xmldoclet.EnumConstant;
@@ -73,7 +74,7 @@ public class Javadoc {
             final PropertyModel enrichedProperty = enrichProperty(property, dFields, dMethods);
             enrichedProperties.add(enrichedProperty);
         }
-        return bean.withProperties(enrichedProperties).withComments(concat(getComments(beanComment, tags), bean.getComments()));
+        return bean.withProperties(enrichedProperties).withComments(Utils.concat(getComments(beanComment, tags), bean.getComments()));
     }
 
     private PropertyModel enrichProperty(PropertyModel property, List<Field> dFields, List<Method> dMethods) {
@@ -104,7 +105,7 @@ public class Javadoc {
         }
         final String enumComment = dEnum != null ? dEnum.getComment() : null;
         final List<TagInfo> tags = dEnum != null ? dEnum.getTag() : null;
-        return enumModel.withMembers(enrichedMembers).withComments(concat(getComments(enumComment, tags), enumModel.getComments()));
+        return enumModel.withMembers(enrichedMembers).withComments(Utils.concat(getComments(enumComment, tags), enumModel.getComments()));
     }
 
     private <T> EnumMemberModel<T> enrichEnumMember(EnumMemberModel<T> enumMember, Enum dEnum) {
@@ -216,13 +217,4 @@ public class Javadoc {
         return result;
     }
 
-    private static <T> List<T> concat(List<? extends T> list1, List<? extends T> list2) {
-        if (list1 == null && list2 == null) {
-            return null;
-        }
-        final List<T> result = new ArrayList<>();
-        if (list1 != null) result.addAll(list1);
-        if (list2 != null) result.addAll(list2);
-        return result;
-    }
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -130,8 +130,10 @@ public class JaxrsApplicationParser {
                     ? new SwaggerOperation()
                     : Swagger.parseSwaggerAnnotations(method);
             if (swaggerOperation.possibleResponses != null) {
-                for (Type response : swaggerOperation.possibleResponses) {
-                    foundType(result, response, resourceClass, method.getName());
+                for (SwaggerResponse response : swaggerOperation.possibleResponses) {
+                    if (response.responseType != null) {
+                        foundType(result, response.responseType, resourceClass, method.getName());
+                    }
                 }
             }
             if (swaggerOperation.hidden) {
@@ -168,8 +170,8 @@ public class JaxrsApplicationParser {
             if (returnType == void.class) {
                 modelReturnType = returnType;
             } else if (returnType == Response.class) {
-                if (swaggerOperation.response != null) {
-                    modelReturnType = swaggerOperation.response;
+                if (swaggerOperation.responseType != null) {
+                    modelReturnType = swaggerOperation.responseType;
                     foundType(result, modelReturnType, resourceClass, method.getName());
                 } else {
                     modelReturnType = Object.class;
@@ -182,8 +184,10 @@ public class JaxrsApplicationParser {
                 modelReturnType = genericReturnType;
                 foundType(result, modelReturnType, resourceClass, method.getName());
             }
+            // comments
+            final List<String> comments = Swagger.getOperationComments(swaggerOperation);
             // create method
-            model.getMethods().add(new JaxrsMethodModel(resourceClass, method.getName(), modelReturnType, httpMethod.value(), context.path, pathParams, queryParams, entityParameter));
+            model.getMethods().add(new JaxrsMethodModel(resourceClass, method.getName(), modelReturnType, httpMethod.value(), context.path, pathParams, queryParams, entityParameter, comments));
         }
         // JAX-RS specification - 3.4.1 Sub Resources
         if (pathAnnotation != null && httpMethod == null) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsMethodModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsMethodModel.java
@@ -14,8 +14,9 @@ public class JaxrsMethodModel extends MethodModel {
     private final MethodParameterModel entityParam;
 
     public JaxrsMethodModel(Class<?> originClass, String name, Type returnType,
-            String httpMethod, String path, List<MethodParameterModel> pathParams, List<MethodParameterModel> queryParams, MethodParameterModel entityParam) {
-        super(originClass, name, null, returnType);
+            String httpMethod, String path, List<MethodParameterModel> pathParams, List<MethodParameterModel> queryParams, MethodParameterModel entityParam,
+            List<String> comments) {
+        super(originClass, name, null, returnType, comments);
         this.httpMethod = httpMethod;
         this.path = path;
         this.pathParams = pathParams;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodModel.java
@@ -12,12 +12,14 @@ public class MethodModel {
     private final String name;
     private final List<MethodParameterModel> parameters;
     private final Type returnType;
+    private final List<String> comments;
 
-    public MethodModel(Class<?> originClass, String name, List<MethodParameterModel> parameters, Type returnType) {
+    public MethodModel(Class<?> originClass, String name, List<MethodParameterModel> parameters, Type returnType, List<String> comments) {
         this.originClass = originClass;
         this.name = name;
         this.parameters = parameters != null ? parameters : Collections.<MethodParameterModel>emptyList();
         this.returnType = returnType;
+        this.comments = comments;
     }
 
     public Class<?> getOriginClass() {
@@ -34,6 +36,10 @@ public class MethodModel {
 
     public Type getReturnType() {
         return returnType;
+    }
+
+    public List<String> getComments() {
+        return comments;
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -35,8 +35,8 @@ public abstract class ModelParser {
     }
 
     private Model parseQueue() {
-        final JaxrsApplicationParser jaxrsApplicationParser = new JaxrsApplicationParser(settings.getExcludeFilter());
-        final Set<Type> parsedTypes = new LinkedHashSet<>();
+        final JaxrsApplicationParser jaxrsApplicationParser = new JaxrsApplicationParser(settings);
+        final Collection<Type> parsedTypes = new ArrayList<>();  // do not use hashcodes, we can only count on `equals` since we use custom `ParameterizedType`s
         final List<BeanModel> beans = new ArrayList<>();
         final List<EnumModel<?>> enums = new ArrayList<>();
         SourceType<? extends Type> sourceType;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -30,7 +30,8 @@ public abstract class ModelParser {
     public Model parseModel(List<SourceType<Type>> types) {
         typeQueue.addAll(types);
         final Model model = parseQueue();
-        final Model modelWithJavadoc = javadoc.enrichModel(model);
+        final Model modelWithSwaggerDoc = Swagger.enrichModel(model);
+        final Model modelWithJavadoc = javadoc.enrichModel(modelWithSwaggerDoc);
         return modelWithJavadoc;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.util.Utils;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -17,21 +18,23 @@ public class Swagger {
                 final Class<?> response = Utils.getAnnotationElementValue(apiOperation, "response", Class.class);
                 final String responseContainer = Utils.getAnnotationElementValue(apiOperation, "responseContainer", String.class);
                 if (responseContainer == null || responseContainer.isEmpty()) {
-                    swaggerOperation.response = response;
+                    swaggerOperation.responseType = response;
                 } else {
                     switch (responseContainer) {
                         case "List":
-                            swaggerOperation.response = Utils.createParameterizedType(List.class, response);
+                            swaggerOperation.responseType = Utils.createParameterizedType(List.class, response);
                             break;
                         case "Set":
-                            swaggerOperation.response = Utils.createParameterizedType(Set.class, response);
+                            swaggerOperation.responseType = Utils.createParameterizedType(Set.class, response);
                             break;
                         case "Map":
-                            swaggerOperation.response = Utils.createParameterizedType(Map.class, String.class, response);
+                            swaggerOperation.responseType = Utils.createParameterizedType(Map.class, String.class, response);
                             break;
                     }
                 }
                 swaggerOperation.hidden = Utils.getAnnotationElementValue(apiOperation, "hidden", Boolean.class);
+                swaggerOperation.comment = Utils.getAnnotationElementValue(apiOperation, "value", String.class);
+                swaggerOperation.comment = swaggerOperation.comment.isEmpty() ? null : swaggerOperation.comment;
             }
         }
         // @ApiResponses
@@ -40,11 +43,59 @@ public class Swagger {
             if (apiResponses != null) {
                 swaggerOperation.possibleResponses = new ArrayList<>();
                 for (Object apiResponse : apiResponses) {
-                    swaggerOperation.possibleResponses.add(Utils.getAnnotationElementValue(apiResponse, "response", Class.class));
+                    final SwaggerResponse response = new SwaggerResponse();
+                    response.code = Utils.getAnnotationElementValue(apiResponse, "code", Integer.class);
+                    response.comment = Utils.getAnnotationElementValue(apiResponse, "message", String.class);
+                    response.responseType = Utils.getAnnotationElementValue(apiResponse, "response", Class.class);
+                    swaggerOperation.possibleResponses.add(response);
                 }
             }
         }
         return swaggerOperation;
+    }
+
+    static List<String> getOperationComments(SwaggerOperation operation) {
+        final List<String> comments = new ArrayList<>();
+        if (operation.comment != null) {
+            comments.add(operation.comment);
+        }
+        if (operation.possibleResponses != null) {
+            for (SwaggerResponse response : operation.possibleResponses) {
+                comments.add(String.format("Response code %s - %s", response.code, response.comment));
+            }
+        }
+        return comments.isEmpty() ? null : comments;
+    }
+
+    public static Model enrichModel(Model model) {
+        final List<BeanModel> dBeans = new ArrayList<>();
+        for (BeanModel bean : model.getBeans()) {
+            final BeanModel dBean = enrichBean(bean);
+            dBeans.add(dBean);
+        }
+        return new Model(dBeans, model.getEnums(), model.getJaxrsApplication());
+    }
+
+    private static BeanModel enrichBean(BeanModel bean) {
+        final List<PropertyModel> enrichedProperties = new ArrayList<>();
+        for (PropertyModel property : bean.getProperties()) {
+            final PropertyModel enrichedProperty = enrichProperty(property);
+            enrichedProperties.add(enrichedProperty);
+        }
+        final String comment = Utils.getAnnotationElementValue(bean.getOrigin(), "io.swagger.annotations.ApiModel", "description", String.class);
+        final List<String> comments = comment != null && !comment.isEmpty() ? Arrays.asList(comment) : null;
+        return bean.withProperties(enrichedProperties).withComments(Utils.concat(comments, bean.getComments()));
+    }
+
+    private static PropertyModel enrichProperty(PropertyModel property) {
+        if (property.getOriginalMember() instanceof AnnotatedElement) {
+            final AnnotatedElement annotatedElement = (AnnotatedElement) property.getOriginalMember();
+            final String comment = Utils.getAnnotationElementValue(annotatedElement, "io.swagger.annotations.ApiModelProperty", "value", String.class);
+            final List<String> comments = comment != null && !comment.isEmpty() ? Arrays.asList(comment) : null;
+            return property.withComments(Utils.concat(comments, property.getComments()));
+        } else {
+            return property;
+        }
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
@@ -1,0 +1,50 @@
+
+package cz.habarta.typescript.generator.parser;
+
+import cz.habarta.typescript.generator.util.Utils;
+import java.lang.reflect.Method;
+import java.util.*;
+
+
+public class Swagger {
+
+    static SwaggerOperation parseSwaggerAnnotations(Method method) {
+        final SwaggerOperation swaggerOperation = new SwaggerOperation();
+        // @ApiOperation
+        {
+            final Object apiOperation = Utils.getAnnotation(method, "io.swagger.annotations.ApiOperation");
+            if (apiOperation != null) {
+                final Class<?> response = Utils.getAnnotationElementValue(apiOperation, "response", Class.class);
+                final String responseContainer = Utils.getAnnotationElementValue(apiOperation, "responseContainer", String.class);
+                if (responseContainer == null || responseContainer.isEmpty()) {
+                    swaggerOperation.response = response;
+                } else {
+                    switch (responseContainer) {
+                        case "List":
+                            swaggerOperation.response = Utils.createParameterizedType(List.class, response);
+                            break;
+                        case "Set":
+                            swaggerOperation.response = Utils.createParameterizedType(Set.class, response);
+                            break;
+                        case "Map":
+                            swaggerOperation.response = Utils.createParameterizedType(Map.class, String.class, response);
+                            break;
+                    }
+                }
+                swaggerOperation.hidden = Utils.getAnnotationElementValue(apiOperation, "hidden", Boolean.class);
+            }
+        }
+        // @ApiResponses
+        {
+            final Object[] apiResponses = Utils.getAnnotationElementValue(method, "io.swagger.annotations.ApiResponses", "value", Object[].class);
+            if (apiResponses != null) {
+                swaggerOperation.possibleResponses = new ArrayList<>();
+                for (Object apiResponse : apiResponses) {
+                    swaggerOperation.possibleResponses.add(Utils.getAnnotationElementValue(apiResponse, "response", Class.class));
+                }
+            }
+        }
+        return swaggerOperation;
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerOperation.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerOperation.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 
 public class SwaggerOperation {
-    public Type response;
-    public List<Type> possibleResponses;
+    public Type responseType;
+    public List<SwaggerResponse> possibleResponses;
     public boolean hidden;
+    public String comment;
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerOperation.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerOperation.java
@@ -1,0 +1,12 @@
+
+package cz.habarta.typescript.generator.parser;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+
+public class SwaggerOperation {
+    public Type response;
+    public List<Type> possibleResponses;
+    public boolean hidden;
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerResponse.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SwaggerResponse.java
@@ -1,0 +1,11 @@
+
+package cz.habarta.typescript.generator.parser;
+
+import java.lang.reflect.Type;
+
+
+public class SwaggerResponse {
+    public int code;
+    public String comment;
+    public Type responseType;
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -71,9 +71,11 @@ public class Utils {
     }
 
     public static Object getAnnotation(AnnotatedElement annotatedElement, String annotationClassName) {
-        for (Annotation annotation : annotatedElement.getAnnotations()) {
-            if (annotation.annotationType().getName().equals(annotationClassName)) {
-                return annotation;
+        if (annotatedElement != null) {
+            for (Annotation annotation : annotatedElement.getAnnotations()) {
+                if (annotation.annotationType().getName().equals(annotationClassName)) {
+                    return annotation;
+                }
             }
         }
         return null;
@@ -137,6 +139,16 @@ public class Utils {
                 return Objects.hash(ownerType, rawType, actualTypeArguments);
             }
         };
+    }
+
+    public static <T> List<T> concat(List<? extends T> list1, List<? extends T> list2) {
+        if (list1 == null && list2 == null) {
+            return null;
+        }
+        final List<T> result = new ArrayList<>();
+        if (list1 != null) result.addAll(list1);
+        if (list2 != null) result.addAll(list2);
+        return result;
     }
 
     public static <T> List<T> listFromNullable(T item) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsApplicationTest.java
@@ -35,7 +35,7 @@ public class JaxrsApplicationTest {
 
     @Test
     public void testReturnedTypesFromResource() {
-        final JaxrsApplicationParser.Result result = new JaxrsApplicationParser(null).tryParse(new SourceType<>(TestResource1.class));
+        final JaxrsApplicationParser.Result result = new JaxrsApplicationParser(TestUtils.settings()).tryParse(new SourceType<>(TestResource1.class));
         Assert.assertNotNull(result);
         List<Type> types = getTypes(result.discoveredTypes);
         final List<Type> expectedTypes = Arrays.asList(
@@ -109,7 +109,7 @@ public class JaxrsApplicationTest {
                 A.class.getName(),
                 J.class.getName()
         ), null);
-        final JaxrsApplicationParser jaxrsApplicationParser = new JaxrsApplicationParser(settings.getExcludeFilter());
+        final JaxrsApplicationParser jaxrsApplicationParser = new JaxrsApplicationParser(settings);
         final JaxrsApplicationParser.Result result = jaxrsApplicationParser.tryParse(new SourceType<>(TestResource1.class));
         Assert.assertNotNull(result);
         Assert.assertTrue(!getTypes(result.discoveredTypes).contains(A.class));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
@@ -1,0 +1,89 @@
+
+package cz.habarta.typescript.generator;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class SwaggerTest {
+
+    @Test
+    public void test() {
+        final Settings settings = TestUtils.settings();
+        settings.generateJaxrsApplicationInterface = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(TestApplication.class));
+        Assert.assertTrue(output.contains("interface TestResponse"));
+        Assert.assertTrue(output.contains("interface TestError"));
+        Assert.assertTrue(output.contains("testOperationError(): RestResponse<any>;"));
+        Assert.assertTrue(output.contains("testOperation1(): RestResponse<TestResponse>;"));
+        Assert.assertTrue(output.contains("testOperation2(): RestResponse<TestResponse[]>;"));
+        Assert.assertTrue(output.contains("testOperation3(): RestResponse<TestResponse[]>;"));
+        Assert.assertTrue(output.contains("testOperation4(): RestResponse<{ [index: string]: TestResponse }>;"));
+        Assert.assertTrue(!output.contains("testHiddenOperation"));
+    }
+
+    private static class TestApplication extends Application {
+        @Override
+        public Set<Class<?>> getClasses() {
+            return new LinkedHashSet<>(Arrays.<Class<?>>asList(TestResource.class));
+        }
+    }
+
+    @Path("test")
+    private static class TestResource {
+
+        @ApiOperation(value = "", response = TestResponse.class)
+        @GET
+        public Response testOperation1() {
+            return Response.ok(new TestResponse()).build();
+        }
+
+        @ApiOperation(value = "", responseContainer = "List", response = TestResponse.class)
+        @GET
+        public Response testOperation2() {
+            return Response.ok(new TestResponse()).build();
+        }
+
+        @ApiOperation(value = "", responseContainer = "Set", response = TestResponse.class)
+        @GET
+        public Response testOperation3() {
+            return Response.ok(new TestResponse()).build();
+        }
+
+        @ApiOperation(value = "", responseContainer = "Map", response = TestResponse.class)
+        @GET
+        public Response testOperation4() {
+            return Response.ok(new TestResponse()).build();
+        }
+
+        @ApiResponses({@ApiResponse(code = 400, message = "", response = TestError.class)})
+        @GET
+        public Response testOperationError() {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        @ApiOperation(value = "", hidden = true)
+        @GET
+        public Response testHiddenOperation() {
+            return null;
+        }
+
+    }
+
+    private static class TestResponse {
+    }
+
+    private static class TestError {
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
@@ -1,6 +1,8 @@
 
 package cz.habarta.typescript.generator;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -30,6 +32,18 @@ public class SwaggerTest {
         Assert.assertTrue(output.contains("testOperation3(): RestResponse<TestResponse[]>;"));
         Assert.assertTrue(output.contains("testOperation4(): RestResponse<{ [index: string]: TestResponse }>;"));
         Assert.assertTrue(!output.contains("testHiddenOperation"));
+    }
+
+    @Test
+    public void testDocumentation() {
+        final Settings settings = TestUtils.settings();
+        settings.generateJaxrsApplicationInterface = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DocumentedApplication.class));
+        Assert.assertTrue(output.contains("Documentation for operation 1."));
+        Assert.assertTrue(output.contains("Bad Request"));
+        Assert.assertTrue(output.contains("Not Found"));
+        Assert.assertTrue(output.contains("Documentation for the bean."));
+        Assert.assertTrue(output.contains("Documentation for property 1."));
     }
 
     private static class TestApplication extends Application {
@@ -84,6 +98,36 @@ public class SwaggerTest {
     }
 
     private static class TestError {
+    }
+
+
+    private static class DocumentedApplication extends Application {
+        @Override
+        public Set<Class<?>> getClasses() {
+            return new LinkedHashSet<>(Arrays.<Class<?>>asList(DocumentedResource.class));
+        }
+    }
+
+    @Path("test")
+    private static class DocumentedResource {
+
+        @ApiOperation("Documentation for operation 1.")
+        @ApiResponses({
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 404, message = "Not Found"),
+        })
+        @GET
+        public DocumentedBean documentedOperation1() {
+            return null;
+        }
+
+    }
+
+    @ApiModel(description = "Documentation for the bean.")
+    private static class DocumentedBean {
+
+        @ApiModelProperty("Documentation for property 1.")
+        public String property1;
     }
 
 }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -41,6 +41,7 @@ public class GenerateTask extends DefaultTask {
     public EnumMapping mapEnum;
     public ClassMapping mapClasses;
     public boolean disableTaggedUnions;
+    public boolean ignoreSwaggerAnnotations;
     public boolean generateJaxrsApplicationInterface;
     public boolean generateJaxrsApplicationClient;
     public String restResponseType;
@@ -108,6 +109,7 @@ public class GenerateTask extends DefaultTask {
         settings.mapEnum = mapEnum;
         settings.mapClasses = mapClasses;
         settings.disableTaggedUnions = disableTaggedUnions;
+        settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;
         settings.generateJaxrsApplicationInterface = generateJaxrsApplicationInterface;
         settings.generateJaxrsApplicationClient = generateJaxrsApplicationClient;
         settings.restResponseType = restResponseType;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -239,6 +239,12 @@ public class GenerateMojo extends AbstractMojo {
     private boolean disableTaggedUnions;
 
     /**
+     * If true Swagger annotations will not be used.
+     */
+    @Parameter
+    private boolean ignoreSwaggerAnnotations;
+
+    /**
      * If true interface for JAX-RS REST application will be generated.
      */
     @Parameter
@@ -410,6 +416,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.mapEnum = mapEnum;
             settings.mapClasses = mapClasses;
             settings.disableTaggedUnions = disableTaggedUnions;
+            settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;
             settings.generateJaxrsApplicationInterface = generateJaxrsApplicationInterface;
             settings.generateJaxrsApplicationClient = generateJaxrsApplicationClient;
             settings.restResponseType = restResponseType;


### PR DESCRIPTION
This PR adds support for Swagger annotations for these purposes:

1. JAX-RS method return types (when method returns `Response`)
2. Documentation (alternative to Javadoc comments)

For more information see [Swagger Annotations](https://github.com/vojtechhabarta/typescript-generator/wiki/Swagger-Annotations) Wiki page.