### PR TITLE
Adding optional support for joda-time's DateTime class

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -73,7 +73,13 @@
             <artifactId>swagger-annotations</artifactId>
             <version>1.5.10</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.9.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -120,6 +120,14 @@ public class DefaultTypeProcessor implements TypeProcessor {
         knownTypes.put(BigInteger.class, TsType.Number);
         knownTypes.put(Date.class, TsType.Date);
         knownTypes.put(UUID.class, TsType.String);
+
+        // joda time (if present)
+        try {
+            final Class<?> jodaTimeClass = Class.forName("org.joda.time.DateTime");
+            knownTypes.put(jodaTimeClass, TsType.Date);
+        } catch (ClassNotFoundException e) {
+            // ignore if joda time is not present
+        }
         return knownTypes;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
@@ -1,16 +1,18 @@
 
 package cz.habarta.typescript.generator;
 
-import java.io.*;
 import java.util.*;
+
+import org.joda.time.DateTime;
 import org.junit.*;
 
 
 public class DateTest {
 
     @Test
-    public void testDate() {
-        final String dts = new TypeScriptGenerator(settings(DateMapping.asDate, "AsDate")).generateTypeScript(Input.from(Dates.class));
+    public void testDate_forJavaUtilDate() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asDate, "AsDate"))
+                .generateTypeScript(Input.from(Dates.class));
         Assert.assertTrue(dts.contains("date: Date;"));
         Assert.assertTrue(dts.contains("dateList: Date[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
@@ -18,8 +20,19 @@ public class DateTest {
     }
 
     @Test
-    public void testDateAsNumber() {
-        final String dts = new TypeScriptGenerator(settings(DateMapping.asNumber, "AsNumber")).generateTypeScript(Input.from(Dates.class));
+    public void testDate_forJodaDateTime() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asDate, "AsDate"))
+                .generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: Date;"));
+        Assert.assertTrue(dts.contains("dateList: Date[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
+        Assert.assertTrue(dts.contains("dates: Date[];"));
+    }
+
+    @Test
+    public void testDateAsNumber_forJavaUtilDate() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asNumber, "AsNumber"))
+                .generateTypeScript(Input.from(Dates.class));
         Assert.assertTrue(dts.contains("date: DateAsNumber;"));
         Assert.assertTrue(dts.contains("dateList: DateAsNumber[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsNumber[] };"));
@@ -28,8 +41,31 @@ public class DateTest {
     }
 
     @Test
-    public void testDateAsString() {
-        final String dts = new TypeScriptGenerator(settings(DateMapping.asString, "AsString")).generateTypeScript(Input.from(Dates.class));
+    public void testDateAsNumber_forJodaDateTime() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asNumber, "AsNumber"))
+                .generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: DateAsNumber;"));
+        Assert.assertTrue(dts.contains("dateList: DateAsNumber[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsNumber[] };"));
+        Assert.assertTrue(dts.contains("dates: DateAsNumber[];"));
+        Assert.assertTrue(dts.contains("type DateAsNumber = number;"));
+    }
+
+    @Test
+    public void testDateAsString_forJavaUtilDate() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asString, "AsString"))
+                .generateTypeScript(Input.from(Dates.class));
+        Assert.assertTrue(dts.contains("date: DateAsString;"));
+        Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
+        Assert.assertTrue(dts.contains("dates: DateAsString[];"));
+        Assert.assertTrue(dts.contains("type DateAsString = string;"));
+    }
+
+    @Test
+    public void testDateAsString_forJodaDateTime() {
+        final String dts = new TypeScriptGenerator(settings(DateMapping.asString, "AsString"))
+                .generateTypeScript(Input.from(JodaDates.class));
         Assert.assertTrue(dts.contains("date: DateAsString;"));
         Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
@@ -51,4 +87,11 @@ class Dates {
     public List<Date> dateList;
     public Map<String, List<Date>> datesMap;
     public Date[] dates;
+}
+
+class JodaDates {
+    public DateTime date;
+    public List<DateTime> dateList;
+    public Map<String, List<DateTime>> datesMap;
+    public DateTime[] dates;
 }


### PR DESCRIPTION
- we check, if JavaTime is available in class path
- if it is, we handle it exactly like java.util.Date