### PR TITLE
Mapping Java packages to TypeScript namespaces

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -24,6 +24,7 @@ public class Settings {
     public TypeScriptOutputKind outputKind = null;
     public String module = null;
     public String namespace = null;
+    public boolean mapPackagesToNamespaces = false;
     public String umdNamespace = null;
     public JsonLibrary jsonLibrary = null;
     private Predicate<String> excludeFilter = null;
@@ -146,6 +147,9 @@ public class Settings {
             }
             if (features.generatesModuleCode && outputKind != TypeScriptOutputKind.module) {
                 throw new RuntimeException(String.format("Extension '%s' generates code as module but 'outputKind' parameter is not set to 'module'.", extensionName));
+            }
+            if (!features.worksWithPackagesMappedToNamespaces && mapPackagesToNamespaces) {
+                throw new RuntimeException(String.format("Extension '%s' doesn't work with 'mapPackagesToNamespaces' parameter.", extensionName));
             }
             if (features.generatesJaxrsApplicationClient) {
                 reportConfigurationChange(extensionName, "generateJaxrsApplicationClient", "true");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -89,7 +89,7 @@ public abstract class TsType {
 
         @Override
         public String format(Settings settings) {
-            return symbol.toString();
+            return symbol.getFullName();
         }
 
     }
@@ -109,7 +109,7 @@ public abstract class TsType {
 
         @Override
         public String format(Settings settings) {
-            return symbol + "<" + Utils.join(format(typeArguments, settings), ", ") + ">";
+            return symbol.getFullName() + "<" + Utils.join(format(typeArguments, settings), ", ") + ">";
         }
     }
     

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/Symbol.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/Symbol.java
@@ -4,15 +4,34 @@ package cz.habarta.typescript.generator.compiler;
 
 public class Symbol {
 
-    protected String name;
+    private String namespace;
+    private String simpleName;
 
-    public Symbol(String name) {
-        this.name = name;
+    public Symbol(String temporaryName) {
+        this.simpleName = temporaryName;
     }
 
-    @Override
-    public String toString() {
-        return name;
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    public String getFullName() {
+        return namespace != null ? namespace + "." + simpleName : simpleName;
+    }
+
+    public void setFullName(String fullName) {
+        final int index = fullName.lastIndexOf('.');
+        if (index == -1) {
+            namespace = null;
+            simpleName = fullName;
+        } else {
+            namespace = fullName.substring(0, index);
+            simpleName = fullName.substring(index + 1);
+        }
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
@@ -6,12 +6,16 @@ import java.util.Map;
 
 public class EmitterExtensionFeatures {
 
+    // declared abilities
     public boolean generatesRuntimeCode = false;
     public boolean generatesModuleCode = false;
+    public boolean worksWithPackagesMappedToNamespaces = false;
+    public boolean overridesStringEnums = false;
+
+    // overridden settings
     public boolean generatesJaxrsApplicationClient = false;
     public String restResponseType = null;
     public String restOptionsType = null;
     public Map<String, String> npmPackageDependencies = null;
-    public boolean overridesStringEnums = false;
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsDeclarationModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsDeclarationModel.java
@@ -41,7 +41,7 @@ public class TsDeclarationModel implements Comparable<TsDeclarationModel> {
         if (categoryResult != 0) {
             return categoryResult;
         }
-        final int nameResult = compare(this.name.toString(), o.name.toString());
+        final int nameResult = compare(this.name.getFullName(), o.name.getFullName());
         if (nameResult != 0) {
             return nameResult;
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
@@ -18,6 +18,7 @@ public class AxiosClientExtension extends EmitterExtension {
         final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
         features.generatesRuntimeCode = true;
         features.generatesModuleCode = true;
+        features.worksWithPackagesMappedToNamespaces = true;
         features.generatesJaxrsApplicationClient = true;
         features.restResponseType = "Promise<Axios.GenericAxiosResponse<R>>";
         features.restOptionsType = "<O>";
@@ -30,7 +31,7 @@ public class AxiosClientExtension extends EmitterExtension {
         emitSharedPart(writer, settings);
         for (TsBeanModel bean : model.getBeans()) {
             if (bean.isJaxrsApplicationClientBean()) {
-                final String clientName = bean.getName().toString();
+                final String clientName = bean.getName().getSimpleName();
                 emitClient(writer, settings, exportKeyword, clientName);
             }
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
@@ -155,7 +155,7 @@ public class BeanPropertyPathExtension extends EmitterExtension {
     }
 
     private static String getBeanModelClassName(TsBeanModel bean) {
-        return bean.getName().toString();
+        return bean.getName().getSimpleName();
     }
 
     private static void writeBeanProperty(
@@ -164,7 +164,7 @@ public class BeanPropertyPathExtension extends EmitterExtension {
         TsBeanModel fieldBeanModel = getBeanModelByType(model, property.getTsType());
         String fieldClassName = fieldBeanModel != null ? getBeanModelClassName(fieldBeanModel) : "";
         // if a class has a field of its own type, we get stackoverflow exception
-        if (fieldClassName.equals(bean.getName().toString())) {
+        if (fieldClassName.equals(bean.getName().getSimpleName())) {
             fieldClassName = "";
         }
         writer.writeIndentedLine(

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumConstantsExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumConstantsExtension.java
@@ -28,9 +28,9 @@ public class EnumConstantsExtension extends EmitterExtension {
         Collections.sort(enums);
         for (TsEnumModel<String> tsEnum : enums) {
             writer.writeIndentedLine("");
-            writer.writeIndentedLine(exportString + "const " + tsEnum.getName() + " = {");
+            writer.writeIndentedLine(exportString + "const " + tsEnum.getName().getSimpleName() + " = {");
             for (EnumMemberModel<String> member : tsEnum.getMembers()) {
-                writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ": " + "<" + tsEnum.getName() + ">\"" + member.getEnumValue() + "\",");
+                writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ": " + "<" + tsEnum.getName().getSimpleName() + ">\"" + member.getEnumValue() + "\",");
             }
             writer.writeIndentedLine("}");
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
@@ -29,7 +29,7 @@ public class NonConstEnumsExtension extends EmitterExtension {
         Collections.sort(enums);
         for (TsEnumModel<String> tsEnum : enums) {
             writer.writeIndentedLine("");
-            writer.writeIndentedLine(exportString + "enum " + tsEnum.getName() + " {");
+            writer.writeIndentedLine(exportString + "enum " + tsEnum.getName().getSimpleName() + " {");
             for (EnumMemberModel<String> member : tsEnum.getMembers()) {
                 writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ",");
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
@@ -37,7 +37,7 @@ public class TypeGuardsForJackson2PolymorphismExtension extends EmitterExtension
                             }
                         }
                         if (propertyValue != null) {
-                            final String baseTypeName = tsBean.getName().toString();
+                            final String baseTypeName = tsBean.getName().getSimpleName();
                             final String subTypeName = findTypeName(subType.value(), model);
                             if (baseTypeName != null && subTypeName != null) {
                                 writer.writeIndentedLine("");
@@ -53,7 +53,7 @@ public class TypeGuardsForJackson2PolymorphismExtension extends EmitterExtension
     static String findTypeName(Class<?> beanClass, TsModel model) {
         for (TsBeanModel bean : model.getBeans()) {
             if (bean.getOrigin().equals(beanClass)) {
-                return bean.getName().toString();
+                return bean.getName().getSimpleName();
             }
         }
         return null;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
@@ -12,8 +12,8 @@ public class DefaultTypeProcessorTest {
     public void testTypeConversion() {
         TypeProcessor converter = new DefaultTypeProcessor();
         final TypeProcessor.Context context = getTestContext(converter);
-        assertEquals(context.getSymbol(A.class).toString(), converter.processType(A.class, context).getTsType().toString());
-        assertEquals(context.getSymbol(B.class).toString(), converter.processType(B.class, context).getTsType().toString());
+        assertEquals(context.getSymbol(A.class).getFullName(), converter.processType(A.class, context).getTsType().toString());
+        assertEquals(context.getSymbol(B.class).getFullName(), converter.processType(B.class, context).getTsType().toString());
         assertEquals(TsType.Void, converter.processType(void.class, context).getTsType());
         assertEquals(TsType.Number, converter.processType(BigDecimal.class, context).getTsType());
         assertEquals(TsType.String, converter.processType(UUID.class, context).getTsType());

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/FullyQualifiedNamesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/FullyQualifiedNamesTest.java
@@ -1,0 +1,96 @@
+
+package cz.habarta.typescript.generator;
+
+import cz.habarta.typescript.generator.p2.D;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class FullyQualifiedNamesTest {
+
+    @Test
+    public void test() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.mapPackagesToNamespaces = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(D.class));
+        final String expected = ""
+                + "namespace cz.habarta.typescript.generator.p2 {\n"
+                + "\n"
+                + "    export class D {\n"
+                + "        a: cz.habarta.typescript.generator.p1.A;\n"
+                + "        b: cz.habarta.typescript.generator.p2.B;\n"
+                + "        c: cz.habarta.typescript.generator.p1.C;\n"
+                + "        e: cz.habarta.typescript.generator.p1.E;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "namespace cz.habarta.typescript.generator.p1 {\n"
+                + "\n"
+                + "    export class A {\n"
+                + "        sa: string;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "namespace cz.habarta.typescript.generator.p2 {\n"
+                + "\n"
+                + "    export class B extends cz.habarta.typescript.generator.p1.A {\n"
+                + "        sb: string;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "namespace cz.habarta.typescript.generator.p1 {\n"
+                + "\n"
+                + "    export class C extends cz.habarta.typescript.generator.p2.B {\n"
+                + "        sc: string;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "namespace cz.habarta.typescript.generator.p1 {\n"
+                + "\n"
+                + "    export type E = \"Left\" | \"Right\";\n"
+                + "\n"
+                + "}";
+        Assert.assertEquals(expected.trim(), output.trim());
+    }
+
+    @Test
+    public void testNested() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.mapPackagesToNamespaces = true;
+        settings.sortTypeDeclarations = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Outer.Inner.class, Outer.class));
+        final String expected = ""
+                + "namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest {\n"
+                + "\n"
+                + "    export class Outer {\n"
+                + "        outer: string;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest.Outer {\n"
+                + "\n"
+                + "    export class Inner {\n"
+                + "        inner: string;\n"
+                + "    }\n"
+                + "\n"
+                + "}\n";
+        Assert.assertEquals(expected.trim(), output.trim());
+    }
+
+    private static class Outer {
+        public String outer;
+        private static class Inner {
+            public String inner;
+        }
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
@@ -26,6 +26,15 @@ public class NamingTest {
         Assert.assertTrue(output.contains("B$ConflictingClass"));
     }
 
+    @Test
+    public void testConflictPrevented() {
+        final Settings settings = TestUtils.settings();
+        settings.mapPackagesToNamespaces = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(A.ConflictingClass.class, B.ConflictingClass.class));
+        Assert.assertTrue(output.contains("namespace cz.habarta.typescript.generator.NamingTest.A {"));
+        Assert.assertTrue(output.contains("namespace cz.habarta.typescript.generator.NamingTest.B {"));
+    }
+
     private static class A {
         private static class ConflictingClass {
             public String conflictingProperty;
@@ -43,7 +52,7 @@ public class NamingTest {
         final Settings settings = TestUtils.settings();
         settings.customTypeNamingFunction = "function(name, simpleName) { if (name.indexOf('cz.') === 0) return 'Test' + simpleName; }";
         final SymbolTable symbolTable = new SymbolTable(settings);
-        final String name = symbolTable.getMappedName(A.class);
+        final String name = symbolTable.getMappedFullName(A.class);
         Assert.assertEquals("TestA", name);
     }
 
@@ -52,7 +61,7 @@ public class NamingTest {
         final Settings settings = TestUtils.settings();
         settings.customTypeNamingFunction = "function() {}";
         final SymbolTable symbolTable = new SymbolTable(settings);
-        final String name = symbolTable.getMappedName(A.class);
+        final String name = symbolTable.getMappedFullName(A.class);
         Assert.assertEquals("A", name);
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/A.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/A.java
@@ -1,0 +1,9 @@
+
+package cz.habarta.typescript.generator.p1;
+
+
+public class A {
+
+    public String sa;
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/C.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/C.java
@@ -1,0 +1,11 @@
+
+package cz.habarta.typescript.generator.p1;
+
+import cz.habarta.typescript.generator.p2.B;
+
+
+public class C extends B {
+
+    public String sc;
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/E.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/E.java
@@ -1,0 +1,6 @@
+
+package cz.habarta.typescript.generator.p1;
+
+public enum E {
+    Left, Right
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/B.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/B.java
@@ -1,0 +1,11 @@
+
+package cz.habarta.typescript.generator.p2;
+
+import cz.habarta.typescript.generator.p1.A;
+
+
+public class B extends A {
+
+    public String sb;
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/D.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/D.java
@@ -1,0 +1,14 @@
+
+package cz.habarta.typescript.generator.p2;
+
+import cz.habarta.typescript.generator.p1.*;
+
+
+public class D {
+
+    public A a;
+    public B b;
+    public C c;
+    public E e;
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -17,6 +17,7 @@ public class GenerateTask extends DefaultTask {
     public TypeScriptOutputKind outputKind;
     public String module;
     public String namespace;
+    public boolean mapPackagesToNamespaces;
     public String umdNamespace;
     public List<String> classes;
     public List<String> classPatterns;
@@ -93,6 +94,7 @@ public class GenerateTask extends DefaultTask {
         settings.outputKind = outputKind;
         settings.module = module;
         settings.namespace = namespace;
+        settings.mapPackagesToNamespaces = mapPackagesToNamespaces;
         settings.umdNamespace = umdNamespace;
         settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
         settings.jsonLibrary = jsonLibrary;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -56,6 +56,12 @@ public class GenerateMojo extends AbstractMojo {
     private String namespace;
 
     /**
+     * Generates TypeScript namespaces from Java packages. Default is false.
+     */
+    @Parameter
+    private boolean mapPackagesToNamespaces;
+
+    /**
      * Turns proper module into UMD (Universal Module Definition) with specified namespace.
      * Only applicable to declaration files.
      */
@@ -421,6 +427,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.outputKind = outputKind;
             settings.module = module;
             settings.namespace = namespace;
+            settings.mapPackagesToNamespaces = mapPackagesToNamespaces;
             settings.umdNamespace = umdNamespace;
             settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
             settings.jsonLibrary = jsonLibrary;


### PR DESCRIPTION
Based on #69 and #99 this PR adds support for mapping Java packages to TypeScript namespaces which can prevent name conflicts when multiple classes with the same simple name exist in different packages.

The feature can be turned on using `mapPackagesToNamespaces` parameter.

Example: for this Java code

``` java
package com.p1;
class A {}
```

following output is generated

``` typescript
namespace com.p1 {
    interface A {}
}
```

For nested Java classes generated TypeScript namespace contains outer class name, for example like this

``` typescript
namespace com.p1.OuterClass {
    interface InnerClass {}
}
```

### Limitations

1. Most extensions in `cz.habarta.typescript.generator.ext` package do not support this feature.

2. When generating TypeScript classes (not interfaces) for Java inner class and also its outer class the **outer class** must appear **before inner class** in generated output. This is not ensured by typescript-generator and order must be specified manually or declarations must be sorted using `sortTypeDeclarations` parameter.
