### PR TITLE
Add Nashorn support to typescript-generator

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JsonLibrary.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JsonLibrary.java
@@ -3,5 +3,5 @@ package cz.habarta.typescript.generator;
 
 
 public enum JsonLibrary {
-    jackson1, jackson2, jaxb
+    jackson1, jackson2, jaxb, nashorn
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -104,6 +104,8 @@ public class TypeScriptGenerator {
                 return new Jackson2Parser(settings, getTypeProcessor());
             case jaxb:
                 return new Jackson2Parser(settings, getTypeProcessor(), /*useJaxbAnnotations*/ true);
+            case nashorn:
+                return new NashornJavaParser(settings, getTypeProcessor());                
             default:
                 throw new RuntimeException();
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
@@ -13,8 +13,13 @@ public class BeanModel extends DeclarationModel {
     private final String discriminantLiteral;
     private final List<Type> interfaces;
     private final List<PropertyModel> properties;
-
+    private final List<MethodModel> methods;
+    
     public BeanModel(Class<?> origin, Type parent, List<Class<?>> taggedUnionClasses, String discriminantProperty, String discriminantLiteral, List<Type> interfaces, List<PropertyModel> properties, List<String> comments) {
+        this(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, null, comments);
+    }    
+
+    public BeanModel(Class<?> origin, Type parent, List<Class<?>> taggedUnionClasses, String discriminantProperty, String discriminantLiteral, List<Type> interfaces, List<PropertyModel> properties, List<MethodModel> methods, List<String> comments) {
         super(origin, comments);
         this.parent = parent;
         this.taggedUnionClasses = taggedUnionClasses;
@@ -22,6 +27,7 @@ public class BeanModel extends DeclarationModel {
         this.discriminantLiteral = discriminantLiteral;
         this.interfaces = interfaces;
         this.properties = properties;
+        this.methods = methods;
     }
 
     public Type getParent() {
@@ -52,18 +58,22 @@ public class BeanModel extends DeclarationModel {
         ancestors.addAll(interfaces);
         return ancestors;
     }
+    
+    public List<MethodModel> getMethods() {
+        return methods;
+    }    
 
     public List<PropertyModel> getProperties() {
         return properties;
     }
 
     public BeanModel withProperties(List<PropertyModel> properties) {
-        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, methods, comments);
     }
 
     @Override
     public BeanModel withComments(List<String> comments) {
-        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, methods, comments);
     }
 
     @Override

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -102,7 +102,7 @@ public abstract class ModelParser {
         return new PropertyModel(name, type, optional, originalMember, pullProperties, null);
     }
 
-    private List<Class<?>> discoverClassesUsedInType(Type type) {
+    protected List<Class<?>> discoverClassesUsedInType(Type type) {
         final TypeProcessor.Result result = processType(type);
         return result != null ? result.getDiscoveredClasses() : Collections.<Class<?>>emptyList();
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,10 +80,20 @@ public class NashornJavaParser extends ModelParser {
                 addBeanToQueue(new SourceType<>(cls, sourceClass.type, method.getName()));
             }
             
-            List<MethodParameterModel> parameters = new ArrayList<>();        
+            /* parameters and generic parameters */
+            List<MethodParameterModel> parameters = new ArrayList<>();      
             for (Parameter parameter : method.getParameters()) {
-                parameters.add(new MethodParameterModel(parameter.getName(), parameter.getParameterizedType()));
+                Type parameterizedType = parameter.getParameterizedType();
+                parameters.add(new MethodParameterModel(parameter.getName(), parameterizedType));
                 addBeanToQueue(new SourceType<>(parameter.getType(), sourceClass.type, method.getName()));
+                
+                if (parameterizedType instanceof ParameterizedType) {
+                    ParameterizedType aType = (ParameterizedType) parameterizedType;
+                    Type[] parameterArgTypes = aType.getActualTypeArguments();
+                    for(Type parameterArgType : parameterArgTypes){
+                        addBeanToQueue(new SourceType<>(parameterArgType, sourceClass.type, method.getName()));
+                    }
+                }
             }
             methods.add(new MethodModel(sourceClass.type, method.getName(), parameters, returnType, null));            
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
@@ -1,0 +1,159 @@
+package cz.habarta.typescript.generator.parser;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeProcessor;
+
+/* https://wiki.openjdk.java.net/display/Nashorn/Nashorn+Documentation
+ * http://docs.oracle.com/javase/8/docs/technotes/guides/scripting/prog_guide/index.html
+ * https://wiki.openjdk.java.net/display/Nashorn/Nashorn+extensions */
+public class NashornJavaParser extends ModelParser {
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();    
+
+    public NashornJavaParser(Settings settings, TypeProcessor typeProcessor) {
+        super(settings, typeProcessor);
+        objectMapper.registerModules(ObjectMapper.findModules(settings.classLoader));
+    }
+    
+    @Override
+    protected BeanModel parseBean(SourceType<Class<?>> sourceClass) {
+        final List<PropertyModel> properties = new ArrayList<>();
+        final List<MethodModel> methods = new ArrayList<>();
+        
+        for (Field field : sourceClass.type.getDeclaredFields()) {
+            
+            /* only include public fields */
+            if (!Modifier.isPublic(field.getModifiers())) 
+                continue;
+                
+            Type type = field.getGenericType();
+            List<Class<?>> classes = discoverClassesUsedInType(type);
+            for (Class<?> cls : classes) {
+                addBeanToQueue(new SourceType<>(cls, sourceClass.type, field.getName()));
+            }
+            properties.add(new PropertyModel(field.getName(), type, false, field, null, null));
+        }
+        
+        for (Method method : sourceClass.type.getDeclaredMethods()) {
+            
+            /* only include public methods */            
+            if (!Modifier.isPublic(method.getModifiers())) 
+                continue;
+            
+            /* method is a property getter */
+            PropertyModel propertyGetter = parseGetterMethod(sourceClass.type, method);
+            if (propertyGetter != null) {
+                List<Class<?>> classes = discoverClassesUsedInType(propertyGetter.getType());
+                for (Class<?> cls : classes) {
+                    addBeanToQueue(new SourceType<>(cls, sourceClass.type, propertyGetter.getName()));
+                }
+                properties.add(propertyGetter);   
+                continue;
+            }            
+            
+            /* method is a property setter */
+            PropertyModel propertySetter = parseSetterMethod(sourceClass.type, method);
+            if (propertySetter != null) {
+                List<Class<?>> classes = discoverClassesUsedInType(propertySetter.getType());
+                for (Class<?> cls : classes) {
+                    addBeanToQueue(new SourceType<>(cls, sourceClass.type, propertySetter.getName()));
+                }
+                properties.add(propertySetter);    
+                continue;
+            }  
+            
+            /* plain method */
+            Type returnType = method.getGenericReturnType();
+            List<Class<?>> classes = discoverClassesUsedInType(returnType);
+            for (Class<?> cls : classes) {
+                addBeanToQueue(new SourceType<>(cls, sourceClass.type, method.getName()));
+            }
+            
+            List<MethodParameterModel> parameters = new ArrayList<>();        
+            for (Parameter parameter : method.getParameters()) {
+                parameters.add(new MethodParameterModel(parameter.getName(), parameter.getParameterizedType()));
+                addBeanToQueue(new SourceType<>(parameter.getType(), sourceClass.type, method.getName()));
+            }
+            methods.add(new MethodModel(sourceClass.type, method.getName(), parameters, returnType, null));            
+        }
+       
+        final Type superclass = sourceClass.type.getGenericSuperclass() == Object.class ? null : sourceClass.type.getGenericSuperclass();
+        if (superclass != null) {
+            addBeanToQueue(new SourceType<>(superclass, sourceClass.type, "<superClass>"));
+        }
+        final List<Type> interfaces = Arrays.asList(sourceClass.type.getGenericInterfaces());
+        for (Type aInterface : interfaces) {
+            addBeanToQueue(new SourceType<>(aInterface, sourceClass.type, "<interface>"));
+        }
+        return new BeanModel(sourceClass.type, superclass, null, null, null, interfaces, properties, methods, null);
+    }
+    
+    private PropertyModel parseSetterMethod(Class<?> clazz, Method method) {
+        String methodName = method.getName();
+        
+        // setters start with 'set'
+        if (!methodName.startsWith("set"))
+            return null;
+        
+        // setters return 'void'
+        if (!method.getReturnType().equals(Void.TYPE))
+            return null;
+        
+        // setters have a single argument
+        if (method.getParameterCount() != 1)
+            return null;
+        
+        // we have a winner
+        String propertyName = methodName.substring(2).toLowerCase();
+        Type propertyType = method.getParameterTypes()[0];
+        
+        return new PropertyModel(propertyName, propertyType, false, method, null, null);
+    }
+    
+    private PropertyModel parseGetterMethod(Class<?> clazz, Method method) {
+        String methodName = method.getName();
+        
+        // getters start with 'set'
+        if (methodName.equalsIgnoreCase("getClass") || (!methodName.startsWith("get") && !methodName.startsWith("is")))
+            return null;
+        
+        // getters dont return 'void'
+        if (method.getReturnType().equals(Void.TYPE))
+            return null;
+        
+        // getters have no arguments
+        if (method.getParameterCount() != 0)
+            return null;
+        
+        // we might have a winner
+        if (methodName.startsWith("is")) {
+            
+            // 'is' type getters always return a boolean
+            if (!method.getReturnType().equals(boolean.class))
+                return null;
+            
+            Type propertyType = method.getReturnType();
+            String propertyName = methodName.substring(2).toLowerCase();
+            
+            return new PropertyModel(propertyName, propertyType, false, method, null, null);
+        }
+        else if (methodName.startsWith("get")) {
+            
+            Type propertyType = method.getReturnType();
+            String propertyName = methodName.substring(3).toLowerCase();
+            
+            return new PropertyModel(propertyName, propertyType, false, method, null, null);            
+        }
+        return null;
+    }    
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
@@ -42,6 +42,14 @@ public class NashornJavaParser extends ModelParser {
             for (Class<?> cls : classes) {
                 addBeanToQueue(new SourceType<>(cls, sourceClass.type, field.getName()));
             }
+            if (type instanceof ParameterizedType) {
+                ParameterizedType aType = (ParameterizedType) type;
+                Type[] parameterArgTypes = aType.getActualTypeArguments();
+                for(Type parameterArgType : parameterArgTypes){
+                    addBeanToQueue(new SourceType<>(parameterArgType, sourceClass.type, field.getName()));
+                }
+            }
+            
             properties.add(new PropertyModel(field.getName(), type, false, field, null, null));
         }
         
@@ -58,6 +66,14 @@ public class NashornJavaParser extends ModelParser {
                 for (Class<?> cls : classes) {
                     addBeanToQueue(new SourceType<>(cls, sourceClass.type, propertyGetter.getName()));
                 }
+                if (propertyGetter.getType() instanceof ParameterizedType) {
+                    ParameterizedType aType = (ParameterizedType) propertyGetter.getType();
+                    Type[] parameterArgTypes = aType.getActualTypeArguments();
+                    for(Type parameterArgType : parameterArgTypes){
+                        addBeanToQueue(new SourceType<>(parameterArgType, sourceClass.type, propertyGetter.getName()));
+                    }
+                }                
+                
                 properties.add(propertyGetter);   
                 continue;
             }            
@@ -69,6 +85,14 @@ public class NashornJavaParser extends ModelParser {
                 for (Class<?> cls : classes) {
                     addBeanToQueue(new SourceType<>(cls, sourceClass.type, propertySetter.getName()));
                 }
+                if (propertySetter.getType() instanceof ParameterizedType) {
+                    ParameterizedType aType = (ParameterizedType) propertySetter.getType();
+                    Type[] parameterArgTypes = aType.getActualTypeArguments();
+                    for(Type parameterArgType : parameterArgTypes){
+                        addBeanToQueue(new SourceType<>(parameterArgType, sourceClass.type, propertySetter.getName()));
+                    }
+                }                
+                
                 properties.add(propertySetter);    
                 continue;
             }  
@@ -78,7 +102,7 @@ public class NashornJavaParser extends ModelParser {
             List<Class<?>> classes = discoverClassesUsedInType(returnType);
             for (Class<?> cls : classes) {
                 addBeanToQueue(new SourceType<>(cls, sourceClass.type, method.getName()));
-            }
+            }            
             
             /* parameters and generic parameters */
             List<MethodParameterModel> parameters = new ArrayList<>();      
@@ -145,6 +169,10 @@ public class NashornJavaParser extends ModelParser {
             return null;        
         if (methodName.startsWith("is") && methodName.length() < 3)
             return null;
+        
+        // java.util.stream.BaseStream<T, S> has isParallel() and parallel() methods
+        if (methodName.equalsIgnoreCase("isParallel"))
+            return null;        
         
         // getters dont return 'void'
         if (method.getReturnType().equals(Void.TYPE))

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
@@ -114,7 +114,8 @@ public class NashornJavaParser extends ModelParser {
             return null;
         
         // we have a winner
-        String propertyName = methodName.substring(2).toLowerCase();
+        String propertyName = methodName.substring(2);
+        propertyName = propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
         Type propertyType = method.getParameterTypes()[0];
         
         return new PropertyModel(propertyName, propertyType, false, method, null, null);
@@ -143,14 +144,16 @@ public class NashornJavaParser extends ModelParser {
                 return null;
             
             Type propertyType = method.getReturnType();
-            String propertyName = methodName.substring(2).toLowerCase();
+            String propertyName = methodName.substring(2);
+            propertyName = propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
             
             return new PropertyModel(propertyName, propertyType, false, method, null, null);
         }
         else if (methodName.startsWith("get")) {
             
             Type propertyType = method.getReturnType();
-            String propertyName = methodName.substring(3).toLowerCase();
+            String propertyName = methodName.substring(3);
+            propertyName = propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);            
             
             return new PropertyModel(propertyName, propertyType, false, method, null, null);            
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/NashornJavaParser.java
@@ -102,7 +102,7 @@ public class NashornJavaParser extends ModelParser {
         String methodName = method.getName();
         
         // setters start with 'set'
-        if (!methodName.startsWith("set"))
+        if (!methodName.startsWith("set") || methodName.length() < 4)
             return null;
         
         // setters return 'void'
@@ -124,8 +124,15 @@ public class NashornJavaParser extends ModelParser {
     private PropertyModel parseGetterMethod(Class<?> clazz, Method method) {
         String methodName = method.getName();
         
-        // getters start with 'set'
-        if (methodName.equalsIgnoreCase("getClass") || (!methodName.startsWith("get") && !methodName.startsWith("is")))
+        // getters start with 'get'
+        if (methodName.equalsIgnoreCase("getClass"))
+            return null;
+        
+        if (!methodName.startsWith("get") && !methodName.startsWith("is"))
+            return null;
+        if (methodName.startsWith("get") && methodName.length() < 4)
+            return null;        
+        if (methodName.startsWith("is") && methodName.length() < 3)
             return null;
         
         // getters dont return 'void'

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NashornJavaParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NashornJavaParserTest.java
@@ -1,0 +1,125 @@
+package cz.habarta.typescript.generator;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+import cz.habarta.typescript.generator.compiler.ModelCompiler;
+import cz.habarta.typescript.generator.emitter.Emitter;
+import cz.habarta.typescript.generator.emitter.TsModel;
+import cz.habarta.typescript.generator.parser.Model;
+import cz.habarta.typescript.generator.parser.NashornJavaParser;
+
+public class NashornJavaParserTest {
+    
+    public static class MyDummyBeanSuper {
+        
+        public String methodInSuper(String namedArg1, int otherArg) {
+            return "";
+        }
+        
+    }
+    
+    public static class MyDummyBean extends MyDummyBeanSuper {
+        
+        private String privateStringProperty;
+        private boolean privateBooleanProperty;
+        
+        /* Property getter - string */
+        public String getStringProperty() {
+            return privateStringProperty;
+        }
+        
+        /* Property getter - boolean */
+        public boolean isBoolenProperty() {
+            return privateBooleanProperty;
+        }
+        
+        public String someMethod(String nameArg, int someNumArg, List<String> arg3) {
+            return "";
+        }        
+        
+        public Iterator<OtherDummy> getIteratorMethod(String x) {
+            return null;
+        }
+
+        public Iterator<OtherDummy> getIteratorGetter() {
+            return null;
+        }
+        
+        public void callbackMethod(Consumer<String> consumer) {
+            consumer.accept("Hello");
+        }    
+    }
+    
+    public static class OtherDummy {
+        public String getName() {
+            return "Hello";
+        }
+    }
+    
+    @Test
+    public void testMyDummyBean() {
+        final StringWriter stringWriter = new StringWriter();
+        Settings settings = new Settings();        
+        
+        settings.namespace = "Java";
+        settings.outputKind = TypeScriptOutputKind.global;
+        settings.mapPackagesToNamespaces = true;     
+        settings.jsonLibrary = JsonLibrary.nashorn;
+        
+        TypeProcessor typeProcessor = getTypeProcessor(settings);
+        NashornJavaParser parser = new NashornJavaParser(settings, typeProcessor);
+        ModelCompiler modelCompiler = new ModelCompiler(settings, typeProcessor);
+        Emitter emitter = new Emitter(settings);
+        final Class<?> bean = MyDummyBean.class;
+        final Model model = parser.parseModel(bean);
+        final TsModel tsModel = modelCompiler.javaToTypeScript(model);
+        emitter.emit(tsModel, stringWriter, "dummy", true, false, 0);
+
+        System.out.println("model="+model);
+        System.out.println("tsModel="+tsModel);
+        System.out.println(stringWriter.toString());
+    }    
+    
+    @Test
+    public void testArrayList() {
+        final StringWriter stringWriter = new StringWriter();
+        Settings settings = new Settings();        
+        
+        settings.namespace = "Java";
+        settings.outputKind = TypeScriptOutputKind.global;
+        settings.mapPackagesToNamespaces = true;
+        settings.jsonLibrary = JsonLibrary.nashorn;
+        
+        TypeProcessor typeProcessor = getTypeProcessor(settings);
+        NashornJavaParser parser = new NashornJavaParser(settings, typeProcessor);
+        ModelCompiler modelCompiler = new ModelCompiler(settings, typeProcessor);
+        Emitter emitter = new Emitter(settings);
+        final Class<?> bean = ArrayList.class;
+        final Model model = parser.parseModel(bean);
+        final TsModel tsModel = modelCompiler.javaToTypeScript(model);
+        emitter.emit(tsModel, stringWriter, "dummy", true, false, 0);
+
+        System.out.println("model="+model);
+        System.out.println("tsModel="+tsModel);
+        System.out.println(stringWriter.toString());
+    }
+    
+ 
+    private TypeProcessor getTypeProcessor(Settings settings) {
+        final List<TypeProcessor> processors = new ArrayList<>();
+        processors.add(new ExcludingTypeProcessor(settings.getExcludeFilter()));
+        if (settings.customTypeProcessor != null) {
+            processors.add(settings.customTypeProcessor);
+        }
+        processors.add(new CustomMappingTypeProcessor(settings.customTypeMappings));
+        processors.add(new DefaultTypeProcessor());
+        return new TypeProcessor.Chain(processors);
+    }    
+    
+}


### PR DESCRIPTION
Includes improvements for handling generic return/field/parameter types.

To use locally

1. git clone https://github.com/dmdeklerk/typescript-generator.git
2. cd typescript-generator
3. mvn install (installs to local maven repo)

Now in build.gradle add:

```
buildscript {
  repositories {
    mavenLocal() 
  }
  dependencies {
    classpath group: 'cz.habarta.typescript-generator', name: 'typescript-generator-gradle-plugin', version: '1.24-SNAPSHOT'
  }
}
...
apply plugin: 'cz.habarta.typescript-generator'
...
generateTypeScript {
  outputFile = 'build/java.typings.d.ts'  
  classPatterns = [
    'com.your.local.Class'
  ]
  excludeClassPatterns = [
    'java.util.stream.Stream',
    'java.lang.Class',
    'java.lang.Object',
    'java.util.stream.IntStream',
    'java.lang.Enum',
    'java.util.stream.LongStream',
    'java.util.stream.DoubleStream',
    'java.util.Spliterator'    
  ]
  jsonLibrary = 'nashorn'
  outputKind = 'global'
  namespace = 'Java';
  mapPackagesToNamespaces = true
}
```
