### PR TITLE
Generate TypeScript 2.4 string enums from Java enums

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DeprecationText.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DeprecationText.java
@@ -1,0 +1,11 @@
+
+package cz.habarta.typescript.generator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeprecationText {
+    String value();
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/EnumMapping.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/EnumMapping.java
@@ -3,5 +3,5 @@ package cz.habarta.typescript.generator;
 
 
 public enum EnumMapping {
-    asUnion, asInlineUnion, asNumberBasedEnum
+    asUnion, asInlineUnion, asEnum, asNumberBasedEnum
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -41,6 +41,7 @@ public class Settings {
     public Map<String, String> customTypeMappings = new LinkedHashMap<>();
     public DateMapping mapDate; // default is DateMapping.asDate
     public EnumMapping mapEnum; // default is EnumMapping.asUnion
+    public boolean nonConstEnums = false;
     public ClassMapping mapClasses; // default is ClassMapping.asInterfaces
     public boolean disableTaggedUnions = false;
     public boolean ignoreSwaggerAnnotations = false;
@@ -64,7 +65,7 @@ public class Settings {
     public String npmName = null;
     public String npmVersion = null;
     public Map<String, String> npmPackageDependencies = new LinkedHashMap<>();
-    public String typescriptVersion = "2.2.2";
+    public String typescriptVersion = "^2.4";
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery = false;
     public ClassLoader classLoader = null;
@@ -141,6 +142,10 @@ public class Settings {
         }
         for (EmitterExtension extension : extensions) {
             final String extensionName = extension.getClass().getSimpleName();
+            final DeprecationText deprecation = extension.getClass().getAnnotation(DeprecationText.class);
+            if (deprecation != null) {
+                System.out.println(String.format("Warning: Extension '%s' is deprecated: %s", extensionName, deprecation.value()));
+            }
             final EmitterExtensionFeatures features = extension.getFeatures();
             if (features.generatesRuntimeCode && outputFileType != TypeScriptFileType.implementationFile) {
                 throw new RuntimeException(String.format("Extension '%s' generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.", extensionName));
@@ -169,6 +174,9 @@ public class Settings {
             if (features.overridesStringEnums) {
                 defaultStringEnumsOverriddenByExtension = true;
             }
+        }
+        if (nonConstEnums && outputFileType != TypeScriptFileType.implementationFile) {
+            throw new RuntimeException("Non-const enums can only be used in implementation files but 'outputFileType' parameter is not set to 'implementationFile'.");
         }
         if (mapClasses == ClassMapping.asClasses && outputFileType != TypeScriptFileType.implementationFile) {
             throw new RuntimeException("'mapClasses' parameter is set to 'asClasses' which generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/EnumKind.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/EnumKind.java
@@ -2,12 +2,8 @@
 package cz.habarta.typescript.generator.compiler;
 
 
-public final class EnumKind<T> {
+public enum EnumKind {
 
-    public static final EnumKind<String> StringBased = new EnumKind<>();
-    public static final EnumKind<Number> NumberBased = new EnumKind<>();
-
-    private EnumKind() {
-    }
+    StringBased, NumberBased
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/EnumMemberModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/EnumMemberModel.java
@@ -4,13 +4,21 @@ package cz.habarta.typescript.generator.compiler;
 import java.util.List;
 
 
-public class EnumMemberModel<T> {
+public class EnumMemberModel {
     
     private final String propertyName;
-    private final T enumValue;
+    private final Object/*String|Number*/ enumValue;
     private final List<String> comments;
 
-    public EnumMemberModel(String propertyName, T enumValue, List<String> comments) {
+    public EnumMemberModel(String propertyName, String enumValue, List<String> comments) {
+        this(propertyName, (Object)enumValue, comments);
+    }
+
+    public EnumMemberModel(String propertyName, Number enumValue, List<String> comments) {
+        this(propertyName, (Object)enumValue, comments);
+    }
+
+    private EnumMemberModel(String propertyName, Object enumValue, List<String> comments) {
         this.propertyName = propertyName;
         this.enumValue = enumValue;
         this.comments = comments;
@@ -20,7 +28,7 @@ public class EnumMemberModel<T> {
         return propertyName;
     }
 
-    public T getEnumValue() {
+    public Object getEnumValue() {
         return enumValue;
     }
 
@@ -28,8 +36,8 @@ public class EnumMemberModel<T> {
         return comments;
     }
 
-    public EnumMemberModel<T> withComments(List<String> comments) {
-        return new EnumMemberModel<>(propertyName, enumValue, comments);
+    public EnumMemberModel withComments(List<String> comments) {
+        return new EnumMemberModel(propertyName, enumValue, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsEnumModel.java
@@ -8,28 +8,31 @@ import cz.habarta.typescript.generator.parser.EnumModel;
 import java.util.List;
 
 
-// T extends String | Number
-public class TsEnumModel<T> extends TsDeclarationModel {
-    
-    private final EnumKind<T> kind;
-    private final List<EnumMemberModel<T>> members;
+public class TsEnumModel extends TsDeclarationModel {
 
-    public TsEnumModel(Class<?> origin, Symbol name, EnumKind<T> kind, List<EnumMemberModel<T>> members, List<String> comments) {
+    private final EnumKind kind;
+    private final List<EnumMemberModel> members;
+
+    public TsEnumModel(Class<?> origin, Symbol name, EnumKind kind, List<EnumMemberModel> members, List<String> comments) {
         super(origin, null, name, comments);
         this.kind = kind;
         this.members = members;
     }
 
-    public static <T> TsEnumModel<T> fromEnumModel(Symbol name, EnumModel<T> enumModel) {
-        return new TsEnumModel<>(enumModel.getOrigin(), name, enumModel.getKind(), enumModel.getMembers(), enumModel.getComments());
+    public static TsEnumModel fromEnumModel(Symbol name, EnumModel enumModel) {
+        return new TsEnumModel(enumModel.getOrigin(), name, enumModel.getKind(), enumModel.getMembers(), enumModel.getComments());
     }
 
-    public EnumKind<T> getKind() {
+    public EnumKind getKind() {
         return kind;
     }
 
-    public List<EnumMemberModel<T>> getMembers() {
+    public List<EnumMemberModel> getMembers() {
         return members;
+    }
+
+    public TsEnumModel withMembers(List<EnumMemberModel> members) {
+        return new TsEnumModel(origin, name, kind, members, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
@@ -2,26 +2,29 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.compiler.EnumKind;
+import cz.habarta.typescript.generator.util.Utils;
 import java.util.*;
 
 
 public class TsModel {
 
     private final List<TsBeanModel> beans;
-    private final List<TsEnumModel<?>> enums;
+    private final List<TsEnumModel> enums;
+    private final List<TsEnumModel> originalStringEnums;
     private final List<TsAliasModel> typeAliases;
     private final List<TsHelper> helpers;
 
     public TsModel() {
-        this (new ArrayList<TsBeanModel>(), new ArrayList<TsEnumModel<?>>(), new ArrayList<TsAliasModel>(), new ArrayList<TsHelper>());
+        this (new ArrayList<TsBeanModel>(), new ArrayList<TsEnumModel>(), new ArrayList<TsEnumModel>(), new ArrayList<TsAliasModel>(), new ArrayList<TsHelper>());
     }
 
-    public TsModel(List<TsBeanModel> beans, List<TsEnumModel<?>> enums, List<TsAliasModel> typeAliases, List<TsHelper> helpers) {
+    public TsModel(List<TsBeanModel> beans, List<TsEnumModel> enums, List<TsEnumModel> originalStringEnums, List<TsAliasModel> typeAliases, List<TsHelper> helpers) {
         if (beans == null) throw new NullPointerException();
         if (enums == null) throw new NullPointerException();
         if (typeAliases == null) throw new NullPointerException();
         this.beans = beans;
         this.enums = enums;
+        this.originalStringEnums = originalStringEnums;
         this.typeAliases = typeAliases;
         this.helpers = helpers;
     }
@@ -41,27 +44,39 @@ public class TsModel {
         return null;
     }
 
-    public TsModel setBeans(List<TsBeanModel> beans) {
-        return new TsModel(beans, enums, typeAliases, helpers);
+    public TsModel withBeans(List<TsBeanModel> beans) {
+        return new TsModel(beans, enums, originalStringEnums, typeAliases, helpers);
     }
 
-    public List<TsEnumModel<?>> getEnums() {
+    public List<TsEnumModel> getEnums() {
         return enums;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> List<TsEnumModel<T>> getEnums(EnumKind<T> enumKind) {
-        final List<TsEnumModel<T>> result = new ArrayList<>();
-        for (TsEnumModel<?> enumModel : enums) {
+    public List<TsEnumModel> getEnums(EnumKind enumKind) {
+        final List<TsEnumModel> result = new ArrayList<>();
+        for (TsEnumModel enumModel : enums) {
             if (enumModel.getKind() == enumKind) {
-                result.add((TsEnumModel<T>) enumModel);
+                result.add(enumModel);
             }
         }
         return result;
     }
 
-    public TsModel setEnums(List<TsEnumModel<?>> enums) {
-        return new TsModel(beans, enums, typeAliases, helpers);
+    public TsModel withEnums(List<TsEnumModel> enums) {
+        return new TsModel(beans, enums, originalStringEnums, typeAliases, helpers);
+    }
+
+    public TsModel withoutEnums(List<TsEnumModel> enums) {
+        return new TsModel(beans, Utils.removeAll(this.enums, enums), originalStringEnums, typeAliases, helpers);
+    }
+
+    public List<TsEnumModel> getOriginalStringEnums() {
+        return originalStringEnums;
+    }
+
+    public TsModel withOriginalStringEnums(List<TsEnumModel> originalStringEnums) {
+        return new TsModel(beans, enums, originalStringEnums, typeAliases, helpers);
     }
 
     public List<TsAliasModel> getTypeAliases() {
@@ -79,8 +94,12 @@ public class TsModel {
         return null;
     }
 
-    public TsModel setTypeAliases(List<TsAliasModel> typeAliases) {
-        return new TsModel(beans, enums, typeAliases, helpers);
+    public TsModel withTypeAliases(List<TsAliasModel> typeAliases) {
+        return new TsModel(beans, enums, originalStringEnums, typeAliases, helpers);
+    }
+
+    public TsModel withoutTypeAliases(List<TsAliasModel> typeAliases) {
+        return new TsModel(beans, enums, originalStringEnums, Utils.removeAll(this.typeAliases, typeAliases), helpers);
     }
 
     public List<TsHelper> getHelpers() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumConstantsExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/EnumConstantsExtension.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.ext;
 
 import cz.habarta.typescript.generator.Settings;
-import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
@@ -10,8 +9,10 @@ import cz.habarta.typescript.generator.emitter.TsEnumModel;
 import cz.habarta.typescript.generator.emitter.TsModel;
 import java.util.Collections;
 import java.util.List;
+import cz.habarta.typescript.generator.DeprecationText;
 
 
+@DeprecationText("Consider using configuration parameter 'mapEnum' with value 'asEnum'")
 public class EnumConstantsExtension extends EmitterExtension {
 
     @Override
@@ -24,12 +25,12 @@ public class EnumConstantsExtension extends EmitterExtension {
     @Override
     public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
         String exportString = exportKeyword ? "export " : "";
-        List<TsEnumModel<String>> enums = model.getEnums(EnumKind.StringBased);
+        List<TsEnumModel> enums = model.getOriginalStringEnums();
         Collections.sort(enums);
-        for (TsEnumModel<String> tsEnum : enums) {
+        for (TsEnumModel tsEnum : enums) {
             writer.writeIndentedLine("");
             writer.writeIndentedLine(exportString + "const " + tsEnum.getName().getSimpleName() + " = {");
-            for (EnumMemberModel<String> member : tsEnum.getMembers()) {
+            for (EnumMemberModel member : tsEnum.getMembers()) {
                 writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ": " + "<" + tsEnum.getName().getSimpleName() + ">\"" + member.getEnumValue() + "\",");
             }
             writer.writeIndentedLine("}");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/NonConstEnumsExtension.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.ext;
 
 import cz.habarta.typescript.generator.Settings;
-import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
@@ -10,8 +9,10 @@ import cz.habarta.typescript.generator.emitter.TsEnumModel;
 import cz.habarta.typescript.generator.emitter.TsModel;
 import java.util.Collections;
 import java.util.List;
+import cz.habarta.typescript.generator.DeprecationText;
 
 
+@DeprecationText("Consider using parameter 'mapEnum' with value 'asEnum' and parameter 'nonConstEnums' with 'true'")
 public class NonConstEnumsExtension extends EmitterExtension {
 
     @Override
@@ -25,12 +26,12 @@ public class NonConstEnumsExtension extends EmitterExtension {
     @Override
     public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
         String exportString = exportKeyword ? "export " : "";
-        List<TsEnumModel<String>> enums = model.getEnums(EnumKind.StringBased);
+        List<TsEnumModel> enums = model.getOriginalStringEnums();
         Collections.sort(enums);
-        for (TsEnumModel<String> tsEnum : enums) {
+        for (TsEnumModel tsEnum : enums) {
             writer.writeIndentedLine("");
             writer.writeIndentedLine(exportString + "enum " + tsEnum.getName().getSimpleName() + " {");
-            for (EnumMemberModel<String> member : tsEnum.getMembers()) {
+            for (EnumMemberModel member : tsEnum.getMembers()) {
                 writer.writeIndentedLine(settings.indentString + member.getPropertyName() + ",");
             }
             writer.writeIndentedLine("}");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
@@ -6,33 +6,32 @@ import cz.habarta.typescript.generator.compiler.EnumKind;
 import java.util.*;
 
 
-// T extends String | Number
-public class EnumModel<T> extends DeclarationModel {
+public class EnumModel extends DeclarationModel {
 
-    private final EnumKind<T> kind;
-    private final List<EnumMemberModel<T>> members;
+    private final EnumKind kind;
+    private final List<EnumMemberModel> members;
 
-    public EnumModel(Class<?> origin, EnumKind<T> kind, List<EnumMemberModel<T>> members, List<String> comments) {
+    public EnumModel(Class<?> origin, EnumKind kind, List<EnumMemberModel> members, List<String> comments) {
         super (origin, comments);
         this.kind = kind;
         this.members = members;
     }
 
-    public EnumKind<T> getKind() {
+    public EnumKind getKind() {
         return kind;
     }
 
-    public List<EnumMemberModel<T>> getMembers() {
+    public List<EnumMemberModel> getMembers() {
         return members;
     }
 
-    public EnumModel<T> withMembers(List<EnumMemberModel<T>> members) {
-        return new EnumModel<>(origin, kind, members, comments);
+    public EnumModel withMembers(List<EnumMemberModel> members) {
+        return new EnumModel(origin, kind, members, comments);
     }
 
     @Override
-    public EnumModel<T> withComments(List<String> comments) {
-        return new EnumModel<>(origin, kind, members, comments);
+    public EnumModel withComments(List<String> comments) {
+        return new EnumModel(origin, kind, members, comments);
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -273,8 +273,7 @@ public class Jackson2Parser extends ModelParser {
                 jsonFormat.shape() == JsonFormat.Shape.NUMBER_FLOAT ||
                 jsonFormat.shape() == JsonFormat.Shape.NUMBER_INT);
 
-        final List<EnumMemberModel<String>> stringMembers = new ArrayList<>();
-        final List<EnumMemberModel<Number>> numberMembers = new ArrayList<>();
+        final List<EnumMemberModel> enumMembers = new ArrayList<>();
         if (sourceClass.type.isEnum()) {
             final Class<?> enumClass = (Class<?>) sourceClass.type;
 
@@ -293,10 +292,10 @@ public class Jackson2Parser extends ModelParser {
                     if (field.isEnumConstant()) {
                         if (isNumberBased) {
                             final Number value = getNumberEnumValue(field, valueMethod, index++);
-                            numberMembers.add(new EnumMemberModel<>(field.getName(), value, null));
+                            enumMembers.add(new EnumMemberModel(field.getName(), value, null));
                         } else {
                             final String value = getStringEnumValue(field, valueMethod);
-                            stringMembers.add(new EnumMemberModel<>(field.getName(), value, null));
+                            enumMembers.add(new EnumMemberModel(field.getName(), value, null));
                         }
                     }
                 }
@@ -306,11 +305,7 @@ public class Jackson2Parser extends ModelParser {
             }
         }
 
-        if (isNumberBased) {
-            return new EnumModel<>(sourceClass.type, EnumKind.NumberBased, numberMembers, null);
-        } else {
-            return new EnumModel<>(sourceClass.type, EnumKind.StringBased, stringMembers, null);
-        }
+        return new EnumModel(sourceClass.type, isNumberBased ? EnumKind.NumberBased : EnumKind.StringBased, enumMembers, null);
     }
 
     private Number getNumberEnumValue(Field field, Method valueMethod, int index) throws Exception {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -41,13 +41,13 @@ public class Javadoc {
 
     public Model enrichModel(Model model) {
         final List<BeanModel> dBeans = new ArrayList<>();
-        final List<EnumModel<?>> dEnums = new ArrayList<>();
+        final List<EnumModel> dEnums = new ArrayList<>();
         for (BeanModel bean : model.getBeans()) {
             final BeanModel dBean = enrichBean(bean);
             dBeans.add(dBean);
         }
-        for (EnumModel<?> enumModel : model.getEnums()) {
-            final EnumModel<?> dEnumModel = enrichEnum(enumModel);
+        for (EnumModel enumModel : model.getEnums()) {
+            final EnumModel dEnumModel = enrichEnum(enumModel);
             dEnums.add(dEnumModel);
         }
         return new Model(dBeans, dEnums, model.getJaxrsApplication());
@@ -96,11 +96,11 @@ public class Javadoc {
         return property.withComments(getComments(propertyComment, tags));
     }
 
-    private <T> EnumModel<T> enrichEnum(EnumModel<T> enumModel) {
+    private EnumModel enrichEnum(EnumModel enumModel) {
         final Enum dEnum = findJavadocEnum(enumModel.getOrigin(), dRoots);
-        final List<EnumMemberModel<T>> enrichedMembers = new ArrayList<>();
-        for (EnumMemberModel<T> member : enumModel.getMembers()) {
-            final EnumMemberModel<T> enrichedMember = enrichEnumMember(member, dEnum);
+        final List<EnumMemberModel> enrichedMembers = new ArrayList<>();
+        for (EnumMemberModel member : enumModel.getMembers()) {
+            final EnumMemberModel enrichedMember = enrichEnumMember(member, dEnum);
             enrichedMembers.add(enrichedMember);
         }
         final String enumComment = dEnum != null ? dEnum.getComment() : null;
@@ -108,7 +108,7 @@ public class Javadoc {
         return enumModel.withMembers(enrichedMembers).withComments(Utils.concat(getComments(enumComment, tags), enumModel.getComments()));
     }
 
-    private <T> EnumMemberModel<T> enrichEnumMember(EnumMemberModel<T> enumMember, Enum dEnum) {
+    private EnumMemberModel enrichEnumMember(EnumMemberModel enumMember, Enum dEnum) {
         final EnumConstant dConstant = findJavadocEnumConstant(enumMember.getPropertyName(), dEnum);
         final List<TagInfo> tags = dConstant != null ? dConstant.getTag(): null;
         final String memberComment = dConstant != null ? dConstant.getComment() : null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
@@ -7,10 +7,10 @@ import java.util.*;
 public class Model {
 
     private final List<BeanModel> beans;
-    private final List<EnumModel<?>> enums;
+    private final List<EnumModel> enums;
     private final JaxrsApplicationModel jaxrsApplication;
 
-    public Model(List<BeanModel> beans, List<EnumModel<?>> enums, JaxrsApplicationModel jaxrsApplication) {
+    public Model(List<BeanModel> beans, List<EnumModel> enums, JaxrsApplicationModel jaxrsApplication) {
         if (beans == null) throw new NullPointerException();
         if (enums == null) throw new NullPointerException();
         this.beans = beans;
@@ -31,7 +31,7 @@ public class Model {
         return null;
     }
 
-    public List<EnumModel<?>> getEnums() {
+    public List<EnumModel> getEnums() {
         return enums;
     }
 
@@ -49,7 +49,7 @@ public class Model {
             sb.append(bean);
             sb.append(String.format("%n"));
         }
-        for (EnumModel<?> enumModel : enums) {
+        for (EnumModel enumModel : enums) {
             sb.append("  ");
             sb.append(enumModel);
             sb.append(String.format("%n"));

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -39,7 +39,7 @@ public abstract class ModelParser {
         final JaxrsApplicationParser jaxrsApplicationParser = new JaxrsApplicationParser(settings);
         final Collection<Type> parsedTypes = new ArrayList<>();  // do not use hashcodes, we can only count on `equals` since we use custom `ParameterizedType`s
         final List<BeanModel> beans = new ArrayList<>();
-        final List<EnumModel<?>> enums = new ArrayList<>();
+        final List<EnumModel> enums = new ArrayList<>();
         SourceType<? extends Type> sourceType;
         while ((sourceType = typeQueue.poll()) != null) {
             if (parsedTypes.contains(sourceType.type)) {
@@ -80,15 +80,15 @@ public abstract class ModelParser {
     protected abstract DeclarationModel parseClass(SourceType<Class<?>> sourceClass);
 
     protected static DeclarationModel parseEnum(SourceType<Class<?>> sourceClass) {
-        final List<EnumMemberModel<String>> values = new ArrayList<>();
+        final List<EnumMemberModel> values = new ArrayList<>();
         if (sourceClass.type.isEnum()) {
             @SuppressWarnings("unchecked")
             final Class<? extends Enum<?>> enumClass = (Class<? extends Enum<?>>) sourceClass.type;
             for (Enum<?> enumConstant : enumClass.getEnumConstants()) {
-                values.add(new EnumMemberModel<>(enumConstant.name(), enumConstant.name(), null));
+                values.add(new EnumMemberModel(enumConstant.name(), enumConstant.name(), null));
             }
         }
-        return new EnumModel<>(sourceClass.type, EnumKind.StringBased, values, null);
+        return new EnumModel(sourceClass.type, EnumKind.StringBased, values, null);
     }
 
     protected void addBeanToQueue(SourceType<? extends Type> sourceType) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -165,6 +165,12 @@ public class Utils {
         return result;
     }
 
+    public static <T> List<T> removeAll(List<T> list, List<T> toBeRemoved) {
+        final ArrayList<T> result = new ArrayList<>(list);
+        result.removeAll(toBeRemoved);
+        return result;
+    }
+
     public static List<String> readLines(InputStream stream) {
         return splitMultiline(readString(stream), false);        
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -76,6 +76,26 @@ public class EnumTest {
     }
 
     @Test
+    public void testEnumAsEnum() {
+        final Settings settings = TestUtils.settings();
+        settings.mapEnum = EnumMapping.asEnum;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
+        final String expected = (
+                "interface AClass {\n" +
+                "    direction: Direction;\n" +
+                "}\n" +
+                "\n" +
+                "declare const enum Direction {\n" +
+                "    North = 'North',\n" +
+                "    East = 'East',\n" +
+                "    South = 'South',\n" +
+                "    West = 'West',\n" +
+                "}"
+                ).replace("'", "\"");
+        assertEquals(expected.trim(), output.trim());
+    }
+
+    @Test
     public void testEnumWithJsonPropertyAnnotations() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonPropertyAnnotations.class));
@@ -120,7 +140,6 @@ public class EnumTest {
     public void testObjectEnum() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(StatusType.class));
-        System.out.println(output);
         final String expected = "" +
                 "interface StatusType {\n" +
                 "    code: number;\n" +

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -29,7 +29,7 @@ public class JavadocTest {
             Assert.assertEquals("Documentation for documentedField.", property1.getComments().get(0));
             final PropertyModel property2 = bean.getProperties().get(1);
             Assert.assertEquals("Documentation for documentedEnumField.", property2.getComments().get(0));
-            final EnumModel<?> enumModel = model.getEnums().get(0);
+            final EnumModel enumModel = model.getEnums().get(0);
             Assert.assertEquals("Documentation for DummyEnum.", enumModel.getComments().get(0));
         }
         {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModulesAndNamespacesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModulesAndNamespacesTest.java
@@ -36,6 +36,7 @@ public class ModulesAndNamespacesTest {
     private static void file(String prefix, String module, String namespace, boolean mapPackagesToNamespaces, TypeScriptOutputKind outputKind, TypeScriptFileType outputFileType, File output) {
         final Settings settings = new Settings();
         settings.jsonLibrary = JsonLibrary.jackson2;
+        settings.mapEnum = EnumMapping.asEnum;
         settings.addTypeNamePrefix = prefix;
         settings.module = module;
         settings.namespace = namespace;
@@ -43,6 +44,7 @@ public class ModulesAndNamespacesTest {
         settings.outputKind = outputKind;
         settings.outputFileType = outputFileType;
         if (outputFileType == TypeScriptFileType.implementationFile) {
+            settings.nonConstEnums = true;
             settings.mapClasses = ClassMapping.asClasses;
         }
         if (outputFileType == TypeScriptFileType.implementationFile && !mapPackagesToNamespaces) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NumberEnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NumberEnumTest.java
@@ -21,11 +21,11 @@ public class NumberEnumTest {
         final ModelParser parser = new TypeScriptGenerator(settings).getModelParser();
         final Model model = parser.parseModel(SomeCode.class);
         Assert.assertEquals(1, model.getEnums().size());
-        final EnumModel<?> enumModel = model.getEnums().get(0);
+        final EnumModel enumModel = model.getEnums().get(0);
         Assert.assertEquals(EnumKind.NumberBased, enumModel.getKind());
         Assert.assertEquals(2, enumModel.getMembers().size());
-        Assert.assertEquals(10, enumModel.getMembers().get(0).getEnumValue());
-        Assert.assertEquals(11, enumModel.getMembers().get(1).getEnumValue());
+        Assert.assertEquals(10, ((Number)enumModel.getMembers().get(0).getEnumValue()).intValue());
+        Assert.assertEquals(11, ((Number)enumModel.getMembers().get(1).getEnumValue()).intValue());
     }
 
     @Test
@@ -34,6 +34,20 @@ public class NumberEnumTest {
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SomeCode.class));
         Assert.assertEquals(
                 "declare const enum SomeCode {\n" +
+                "    VALUE0 = 10,\n" +
+                "    VALUE1 = 11,\n" +
+                "}",
+                output.trim());
+    }
+
+    @Test
+    public void testNonConstEnum() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.nonConstEnums = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SomeCode.class));
+        Assert.assertEquals(
+                "enum SomeCode {\n" +
                 "    VALUE0 = 10,\n" +
                 "    VALUE1 = 11,\n" +
                 "}",

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -40,6 +40,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> customTypeMappings;
     public DateMapping mapDate;
     public EnumMapping mapEnum;
+    public boolean nonConstEnums;
     public ClassMapping mapClasses;
     public boolean disableTaggedUnions;
     public boolean ignoreSwaggerAnnotations;
@@ -111,6 +112,7 @@ public class GenerateTask extends DefaultTask {
         settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
         settings.mapDate = mapDate;
         settings.mapEnum = mapEnum;
+        settings.nonConstEnums = nonConstEnums;
         settings.mapClasses = mapClasses;
         settings.disableTaggedUnions = disableTaggedUnions;
         settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -220,14 +220,22 @@ public class GenerateMojo extends AbstractMojo {
 
     /**
      * Specifies how enums will be mapped.
-     * Supported values are 'asUnion', 'asInlineUnion', 'asNumberBasedEnum'.
+     * Supported values are 'asUnion', 'asInlineUnion', 'asEnum', 'asNumberBasedEnum'.
      * Default value is 'asUnion'.
      * Value 'asUnion' creates type alias to union of string enum values.
      * Value 'asInlineUnion' creates union of enum values on places where the enum is used.
+     * Value 'asEnum' creates string enum. Requires TypeScript 2.4.
      * Value 'asNumberBasedEnum' creates enum of named number values.
      */
     @Parameter
     private EnumMapping mapEnum;
+
+    /**
+     * If true generated enums will not have <code>const</code> keyword.
+     * This can be used only in implementation files.
+     */
+    @Parameter
+    private boolean nonConstEnums;
 
     /**
      * Specifies whether classes will be mapped to classes or interfaces.
@@ -444,6 +452,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.customTypeMappings = Settings.convertToMap(customTypeMappings);
             settings.mapDate = mapDate;
             settings.mapEnum = mapEnum;
+            settings.nonConstEnums = nonConstEnums;
             settings.mapClasses = mapClasses;
             settings.disableTaggedUnions = disableTaggedUnions;
             settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;


### PR DESCRIPTION
This PR adds possibility to generate TypeScript string enums from Java enums. TypeScript enums were originally number-based but [TypeScript 2.4 will allow string members in enums](https://github.com/Microsoft/TypeScript/pull/15486).

Java enum values usually translates to `string`s in JSON and typescript-generator generates by default union of string literals. For example for this Java enum:

``` java
enum Direction {
    Left, Right
}
```

following TypeScript **union type** is generated:

``` typescript
type Direction = "Left" | "Right";
```

This PR adds new possibility to generate following **string enum**:

``` typescript
export const enum Direction {
    Left = "Left",
    Right = "Right",
}
```

#### Configuration

This feature can be used by configuring `mapEnum` parameter to `asEnum` value.
For implementation files (`.ts`) it is also possible to generate enums without `const` keyword by setting `nonConstEnums` parameter to `true`.

#### Number enums

Some Java enums are rendered as numbers in JSON (for example Jackson2 provides `JsonFormat.Shape.NUMBER_INT`). Mapping of those enums are not changed by this PR, they are always treated as TypeScript number-based enums.

#### Deprecated extensions

With this new functionality following extensions are not needed anymore and are deprecated:

- `cz.habarta.typescript.generator.ext.EnumConstantsExtension`
- `cz.habarta.typescript.generator.ext.NonConstEnumsExtension`
