### PR TITLE
Allow JsonSubTypes to be interfaces/abstract classes

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -51,6 +51,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.5.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>3.0.1u2</version>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -113,7 +113,7 @@ public class Jackson2Parser extends ModelParser {
             // this is parent
             discriminantProperty = getDiscriminantPropertyName(jsonTypeInfo);
             discriminantLiteral = null;
-        } else if (!sourceClass.type.isInterface() && !Modifier.isAbstract(sourceClass.type.getModifiers()) && isSupported(parentJsonTypeInfo = getAnnotationRecursive(sourceClass.type, JsonTypeInfo.class))) {
+        } else if (isSupported(parentJsonTypeInfo = getAnnotationRecursive(sourceClass.type, JsonTypeInfo.class))) {
             // this is child class
             discriminantProperty = getDiscriminantPropertyName(parentJsonTypeInfo);
             discriminantLiteral = getTypeName(sourceClass.type);
@@ -186,8 +186,11 @@ public class Jackson2Parser extends ModelParser {
                 return jsonSubType.name();
             }
         }
-        // use simplified class name
-        return cls.getName().substring(cls.getName().lastIndexOf(".") + 1);
+        // use simplified class name if it's not an interface or abstract
+        if(!cls.isInterface() && !Modifier.isAbstract(cls.getModifiers())) {
+            return cls.getName().substring(cls.getName().lastIndexOf(".") + 1);
+        }
+        return null;
     }
 
     private static JsonSubTypes.Type getJsonSubTypeForClass(JsonSubTypes types, Class<?> cls) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Circle.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Circle.java
@@ -1,0 +1,14 @@
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCircle.class)
+@JsonDeserialize(as = ImmutableCircle.class)
+public interface Circle extends Shape {
+    double radius();
+
+    final class Builder extends ImmutableCircle.Builder {}
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
@@ -1,0 +1,41 @@
+
+package cz.habarta.typescript.generator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImmutablesTest {
+
+    @Test
+    public void testImmutables() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Shape.class));
+        final String expected = (
+                "\n" +
+                "interface Shape {\n" +
+                "    kind: 'square' | 'rectangle' | 'circle';\n" +
+                "}\n" +
+                "\n" +
+                "interface Square extends Shape {\n" +
+                "    kind: 'square';\n" +
+                "    size: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Rectangle extends Shape {\n" +
+                "    kind: 'rectangle';\n" +
+                "    width: number;\n" +
+                "    height: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Circle extends Shape {\n" +
+                "    kind: 'circle';\n" +
+                "    radius: number;\n" +
+                "}\n" +
+                "\n" +
+                "type ShapeUnion = Square | Rectangle | Circle;\n" +
+                ""
+                ).replace('\'', '"');
+        Assert.assertEquals(expected, output);
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Rectangle.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Rectangle.java
@@ -1,0 +1,19 @@
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableRectangle.class)
+@JsonDeserialize(as = ImmutableRectangle.class)
+public abstract class Rectangle implements Shape {
+    public abstract double width();
+    public abstract double height();
+
+    public static Rectangle.Builder builder() {
+        return new Rectangle.Builder();
+    }
+
+    public static final class Builder extends ImmutableRectangle.Builder {}
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Shape.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Shape.java
@@ -1,0 +1,13 @@
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = Square.class, name = "square"),
+        @JsonSubTypes.Type(value = Rectangle.class, name = "rectangle"),
+        @JsonSubTypes.Type(value = Circle.class, name = "circle"),
+})
+public interface Shape {
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Square.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Square.java
@@ -1,0 +1,5 @@
+package cz.habarta.typescript.generator;
+
+public class Square implements Shape {
+    public double size;
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -132,6 +132,7 @@ public class TaggedUnionsTest {
                 "}\n" +
                 "\n" +
                 "interface IQuadrilateral2 extends IShape2 {\n" +
+                "    kind: 'square' | 'rectangle';\n" +
                 "}\n" +
                 "\n" +
                 "type IShape2Union = CSquare2 | CRectangle2 | CCircle2;\n" +


### PR DESCRIPTION
By moving the check for interfaces and abstract classes into the getTypeName method as a fallback, the generator will now properly work for JsonSubTypes that are immutables. Previously, if your JsonSubTypes were immutables, those types would get improperly dropped from the taggedUnionClasses.

Also fixes a test case where Quadrilaterals should be type-restricted to only "square" and "rectangle"