### PR TITLE
Add option to sort discriminant types

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -56,6 +56,7 @@ public class Settings {
     public boolean restOptionsTypeIsGeneric;
     public TypeProcessor customTypeProcessor = null;
     public boolean sortDeclarations = false;
+    public boolean sortDiscriminantTypes = false;
     public boolean sortTypeDeclarations = false;
     public boolean noFileComment = false;
     public List<File> javadocXmlFiles = null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -166,16 +166,26 @@ public abstract class TsType {
     public static class UnionType extends TsType {
 
         public final List<TsType> types;
+        public final boolean sort;
 
         public UnionType(List<? extends TsType> types) {
+            this(types, false);
+        }
+
+        public UnionType(List<? extends TsType> types, boolean sort) {
             this.types = new ArrayList<TsType>(new LinkedHashSet<TsType>(types));
+            this.sort = sort;
         }
 
         @Override
         public String format(Settings settings) {
-            return types.isEmpty()
+            List<String> formattedTypes = format(this.types, settings);
+            if (this.sort) {
+                Collections.sort(formattedTypes);
+            }
+            return formattedTypes.isEmpty()
                     ? "never"
-                    : Utils.join(format(types, settings), " | ");
+                    : Utils.join(formattedTypes, " | ");
         }
 
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -150,7 +150,7 @@ public class ModelCompiler {
             }
             final TsType discriminantType = literals.isEmpty()
                     ? TsType.String
-                    : new TsType.UnionType(literals);
+                    : new TsType.UnionType(literals, settings.sortDiscriminantTypes);
             properties.add(0, new TsPropertyModel(bean.getDiscriminantProperty(), discriminantType, settings.declarePropertiesAsReadOnly, null));
         }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedDiscriminantTypesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedDiscriminantTypesTest.java
@@ -1,0 +1,81 @@
+
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+
+public class SortedDiscriminantTypesTest {
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(Square.class),
+        @JsonSubTypes.Type(Rectangle.class),
+        @JsonSubTypes.Type(Circle.class),
+    })
+    private interface Shape {
+    }
+
+    private interface Quadrilateral extends Shape {
+    }
+
+    @JsonTypeName("square")
+    private static class Square implements Quadrilateral {
+        public double size;
+    }
+
+    @JsonTypeName("rectangle")
+    private static class Rectangle implements Quadrilateral {
+        public double width;
+        public double height;
+    }
+
+    @JsonTypeName("circle")
+    private static class Circle implements Shape {
+        public double radius;
+    }
+
+    @Test
+    public void testSortedDiscriminantTypes() {
+        final Settings settings = TestUtils.settings();
+        settings.sortDiscriminantTypes = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Shape.class));
+        System.out.println(output);
+        final String expected = (
+                "\n" +
+                "interface Shape {\n" +
+                "    kind: 'circle' | 'rectangle' | 'square';\n" +
+                "}\n" +
+                "\n" +
+                "interface Square extends Quadrilateral {\n" +
+                "    kind: 'square';\n" +
+                "    size: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Rectangle extends Quadrilateral {\n" +
+                "    kind: 'rectangle';\n" +
+                "    width: number;\n" +
+                "    height: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Circle extends Shape {\n" +
+                "    kind: 'circle';\n" +
+                "    radius: number;\n" +
+                "}\n" +
+                "\n" +
+                "interface Quadrilateral extends Shape {\n" +
+                "    kind: 'rectangle' | 'square';\n" +
+                "}\n" +
+                "\n" +
+                "type ShapeUnion = Square | Rectangle | Circle;\n" +
+                ""
+                ).replace('\'', '"');
+        Assert.assertEquals(expected, output);
+    }
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -51,6 +51,7 @@ public class GenerateTask extends DefaultTask {
     public String restOptionsType;
     public String customTypeProcessor;
     public boolean sortDeclarations;
+    public boolean sortDiscriminantTypes;
     public boolean sortTypeDeclarations;
     public boolean noFileComment;
     public List<File> javadocXmlFiles;
@@ -123,6 +124,7 @@ public class GenerateTask extends DefaultTask {
         settings.setRestOptionsType(restOptionsType);
         settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
         settings.sortDeclarations = sortDeclarations;
+        settings.sortDiscriminantTypes = sortDiscriminantTypes;
         settings.sortTypeDeclarations = sortTypeDeclarations;
         settings.noFileComment = noFileComment;
         settings.javadocXmlFiles = javadocXmlFiles;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -318,6 +318,12 @@ public class GenerateMojo extends AbstractMojo {
     private boolean sortDeclarations;
 
     /**
+     * If true discriminant types will be sorted alphabetically.
+     */
+    @Parameter
+    private boolean sortDiscriminantTypes;
+
+    /**
      * If true TypeScript type declarations (interfaces) will be sorted alphabetically.
      */
     @Parameter
@@ -462,6 +468,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.setRestOptionsType(restOptionsType);
             settings.loadCustomTypeProcessor(classLoader, customTypeProcessor);
             settings.sortDeclarations = sortDeclarations;
+            settings.sortDiscriminantTypes = sortDiscriminantTypes;
             settings.sortTypeDeclarations = sortTypeDeclarations;
             settings.noFileComment = noFileComment;
             settings.javadocXmlFiles = javadocXmlFiles;


### PR DESCRIPTION
I've found that in practice, because of the way that discriminant types are traversed, the ordering can be pretty random. Because of this, minor changes into inheritance of types can drastically change ordering leading to ugly diffs.

This adds new functionality to sort the discriminant types.

As far as I can tell, taggedUnions and enums dont' suffer from this problem, because their ordering is relatively tied directly to how the code is laid out in java.