### PR TITLE
Sort the discriminants by the tagged unions of the first matching parent

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -139,10 +139,19 @@ public class ModelCompiler {
             }
         }
         final List<TsPropertyModel> properties = processProperties(symbolTable, model, bean, "", "");
+        final List<Class<?>> parentTaggedUnionClasses = getParentTaggedUnionClasses(bean, model);
 
         if (bean.getDiscriminantProperty() != null && !containsProperty(properties, bean.getDiscriminantProperty())) {
             final List<BeanModel> selfAndDescendants = getSelfAndDescendants(bean, children);
             final List<TsType.StringLiteralType> literals = new ArrayList<>();
+            if (parentTaggedUnionClasses != null) {
+                Collections.sort(selfAndDescendants, new Comparator<BeanModel>() {
+                    @Override
+                    public int compare(BeanModel o1, BeanModel o2) {
+                        return parentTaggedUnionClasses.indexOf(o1.getOrigin()) - parentTaggedUnionClasses.indexOf(o2.getOrigin());
+                    }
+                });
+            }
             for (BeanModel descendant : selfAndDescendants) {
                 if (descendant.getDiscriminantLiteral() != null) {
                     literals.add(new TsType.StringLiteralType(descendant.getDiscriminantLiteral()));
@@ -176,6 +185,25 @@ public class ModelCompiler {
             }
         }
         return properties;
+    }
+
+    private static List<Class<?>> getParentTaggedUnionClasses(BeanModel bean, Model model) {
+        if (bean == null) {
+            return null;
+        }
+        final List<Class<?>> taggedUnionClasses = bean.getTaggedUnionClasses();
+        if (taggedUnionClasses == null) {
+            final List<Type> parentTypes = bean.getParentAndInterfaces();
+            for (Type parentType : parentTypes) {
+                final BeanModel parent = model.getBean(parentType.getClass());
+                final List<Class<?>> results = getParentTaggedUnionClasses(parent, model);
+                if (results != null) {
+                    return results;
+                }
+            }
+            return null;
+        }
+        return taggedUnionClasses;
     }
 
     private static List<BeanModel> getSelfAndDescendants(BeanModel bean, Map<Type, List<BeanModel>> children) {


### PR DESCRIPTION
@vojtechhabarta So, this is an alternative to the other PR that just merged. I meant to say [DONT MERGE] because I wanted to open it up for discussion, but forgot to add that.

This one seems a little heavy handed, but I wanted to throw it out there. Basically, this finds the first matching parent and uses the tagged unions on those to sort the discriminants. This means that all the orderings will be the same across the types.

The one worry that I had was about my use of getParentAndInterfaces(), because I wasn't sure if it was possible for a class to implement multiple classes which have taggedUnions. E.g. for two interfaces with @JsonTypeInfo, I don't think it's possible for a class to implement both, is it? If that were the case, you wouldn't be able to guarantee non-clashing type names.