### PR TITLE
Glen/fix interface inheritance types

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -237,6 +237,26 @@ public abstract class TsType {
 
     }
 
+    public static class CollisionType extends TsType {
+        public final List<TsType> types;
+
+        public CollisionType(TsType... types) {
+            this(Utils.removeNulls(Arrays.asList(types)));
+        }
+        public CollisionType(List<TsType> types) {
+            this.types = types;
+        }
+
+        @Override
+        public String format(Settings settings) {
+            final List<String> props = new ArrayList<>();
+            for (TsType type : types) {
+                props.add(type.format(settings));
+            }
+            return Utils.join(props, ", ");
+        }
+    }
+
     public static TsType transformTsType(TsType tsType, Transformer transformer) {
         final TsType type = transformer.transform(tsType);
         if (type instanceof TsType.GenericReferenceType) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -276,16 +276,32 @@ public class ModelCompiler {
         return tsModel.setBeans(beans);
     }
 
-    private static Map<String, TsType> getInheritedProperties(SymbolTable symbolTable, TsModel tsModel, List<TsType> parents) {
+    // Get inherited properties for a list of types and combine them
+    private static Map<String, TsType> getInheritedProperties(SymbolTable symbolTable, TsModel tsModel, List<TsType> types) {
         final Map<String, TsType> properties = new LinkedHashMap<>();
-        for (TsType parentType : parents) {
-            final TsBeanModel parent = tsModel.getBean(getOriginClass(symbolTable, parentType));
-            if (parent != null) {
-                properties.putAll(getInheritedProperties(symbolTable, tsModel, parent.getParentAndInterfaces()));
-                for (TsPropertyModel property : parent.getProperties()) {
-                    properties.put(property.getName(), property.getTsType());
+        for (TsType type : types) {
+            final Map<String, TsType> inheritedProperties = getInheritedProperties(symbolTable, tsModel, type);
+            for (String inheritedPropertyName : inheritedProperties.keySet()) {
+                final TsType existingProperty = properties.get(inheritedPropertyName);
+                final TsType newProperty = inheritedProperties.get(inheritedPropertyName);
+                // If two of the inherited types collide, store a CollisionType
+                if (existingProperty != null && !existingProperty.equals(newProperty)) {
+                    properties.put(inheritedPropertyName, new TsType.CollisionType(existingProperty, newProperty));
+                } else {
+                    properties.put(inheritedPropertyName, newProperty);
                 }
             }
+        }
+        return properties;
+    }
+
+    // Get inherited properties for a type, while overriding parent types if they differ
+    private static Map<String, TsType> getInheritedProperties(SymbolTable symbolTable, TsModel tsModel, TsType type) {
+        final Map<String, TsType> properties = new LinkedHashMap<>();
+        final TsBeanModel bean = tsModel.getBean(getOriginClass(symbolTable, type));
+        properties.putAll(getInheritedProperties(symbolTable, tsModel, bean.getParentAndInterfaces()));
+        for (TsPropertyModel property : bean.getProperties()) {
+            properties.put(property.getName(), property.getTsType());
         }
         return properties;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -190,6 +190,9 @@ public class Emitter implements EmitterExtension.Writer {
     private void emitProperty(TsPropertyModel property) {
         emitComments(property.getComments());
         final TsType tsType = property.getTsType();
+        if (tsType instanceof TsType.CollisionType) {
+            throw new RuntimeException("Error! Unresolvable collision type: " + tsType.format(settings));
+        }
         final String readonly = property.readonly ? "readonly " : "";
         final String questionMark = settings.declarePropertiesAsOptional || (tsType instanceof TsType.OptionalType) ? "?" : "";
         writeIndentedLine(readonly + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + ";");

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -71,6 +71,32 @@ public class TaggedUnionsTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
     @JsonSubTypes({
+        @JsonSubTypes.Type(IRectangle3.class),
+        @JsonSubTypes.Type(ICircle3.class),
+    })
+    interface IShape3 {
+    }
+    
+    interface IQuadrilateral3 extends IShape3 {
+    }
+    
+    interface INamedShape3 extends IShape3 {
+        String getName();
+    }
+    
+    interface INamedQuadrilateral3 extends INamedShape3, IQuadrilateral3 {
+    }
+    
+    @JsonTypeName("rectangle")
+    interface IRectangle3 extends INamedQuadrilateral3 {
+    }
+    
+    @JsonTypeName("circle")
+    interface ICircle3 extends INamedShape3 {
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
         @JsonSubTypes.Type(DiamondB1.class),
         @JsonSubTypes.Type(DiamondB2.class),
         @JsonSubTypes.Type(DiamondC.class),
@@ -162,6 +188,41 @@ public class TaggedUnionsTest {
                 "\n" +
                 "type IShape2Union = CSquare2 | CRectangle2 | CCircle2;\n" +
                 ""
+                ).replace('\'', '"');
+        Assert.assertEquals(expected, output);
+    }
+
+    @Test
+    public void testTaggedUnionsWithOverlappingInterfaces() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(IShape3.class));
+        System.out.println(output);
+        final String expected = (
+                "\n" +
+                "interface IShape3 {\n" +
+                "    kind: 'circle' | 'rectangle';\n" +
+                "}\n" +
+                "\n" +
+                "interface IRectangle3 extends INamedQuadrilateral3 {\n" +
+                "}\n" +
+                "\n" +
+                "interface ICircle3 extends INamedShape3 {\n" +
+                "    kind: 'circle';\n" +
+                "}\n" +
+                "\n" +
+                "interface INamedQuadrilateral3 extends INamedShape3, IQuadrilateral3 {\n" +
+                "    kind: 'rectangle';\n" +
+                "}\n" +
+                "\n" +
+                "interface INamedShape3 extends IShape3 {\n" +
+                "    name: string;\n" +
+                "}\n" +
+                "\n" +
+                "interface IQuadrilateral3 extends IShape3 {\n" +
+                "    kind: 'rectangle';\n" +
+                "}\n" +
+                "\n" +
+                "type IShape3Union = IRectangle3 | ICircle3;\n"
                 ).replace('\'', '"');
         Assert.assertEquals(expected, output);
     }


### PR DESCRIPTION
@sayresRT this should fix your bug and add in your test

The bug was previously that getInheritedProperties would not handle duplicates, and if two parents differed it was just the last one that won out. If the last one happened to equal your current property (as it happened to do in your use case), it would think they're compatible and remove just that one property.

Essentially what I did was rewrite the "getInheritedProperties" method to create a new "collision type" if two parents have differing types for a property. this means that the equality check when removing inherited props will fail and the class will include the property itself.

If you're two degrees away (i.e. your parent inherits incompatible properties), splitting the function into two recursive functions causes single classes to override their parents if they collide, which gives us the functionality that we want.