### PR TITLE
ability to enforce that a class is generated as a class not as interface

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -71,6 +71,11 @@ public class Settings {
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery = false;
     public ClassLoader classLoader = null;
+    /**
+     * Java classes with these annotations will be generated as typescript classes,
+     * even if the general configuration is to generate typescript interfaces
+     */
+    public List<String> classAnnotations = new ArrayList<>();
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -86,6 +86,13 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> classPatterns;
 
     /**
+     * Java classes with these annotations will be generated as typescript classes,
+     * even if the general configuration is to generate typescript interfaces
+     */
+    @Parameter
+    private List<String> classAnnotations;
+
+    /**
      * Scans specified JAX-RS {@link javax.ws.rs.core.Application} for JSON classes to process.
      * Parameter contains fully-qualified class name.
      * It is possible to exclude particular REST resource classes using {@link #excludeClasses} parameter.
@@ -484,6 +491,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
             settings.classLoader = classLoader;
+            settings.classAnnotations = classAnnotations;
             final File output = outputFile != null
                     ? outputFile
                     : new File(new File(projectBuildDirectory, "typescript-generator"), project.getArtifactId() + settings.getExtension());


### PR DESCRIPTION
ability to enforce that a class is generated as a class not as interface, even if we generate interfaces according to the global settings, see #168.

this is the first step for #168, the second being the ability to add extra contents in generated classes through extensions.