### PR TITLE
allow extensions to add extra code in generated classes

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -179,6 +179,13 @@ public class Emitter implements EmitterExtension.Writer {
         for (TsMethodModel method : bean.getMethods()) {
             emitCallable(method);
         }
+        if (bean.isClass()) {
+            for (EmitterExtension emitterExtension : settings.extensions) {
+                if (emitterExtension.getFeatures().addsCodeToGeneratedClasses) {
+                    emitterExtension.beanGenerationAddCode(this, settings, bean);
+                }
+            }
+        }
         indent--;
         writeIndentedLine("}");
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtension.java
@@ -11,6 +11,9 @@ public abstract class EmitterExtension {
     public void emitElements(Writer writer, Settings settings, boolean exportKeyword, TsModel model) {
     }
 
+    public void beanGenerationAddCode(Writer writer, Settings settings, TsBeanModel bean) {
+    }
+
     public static interface Writer {
         public void writeIndentedLine(String line);
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/EmitterExtensionFeatures.java
@@ -11,6 +11,7 @@ public class EmitterExtensionFeatures {
     public boolean generatesModuleCode = false;
     public boolean worksWithPackagesMappedToNamespaces = false;
     public boolean overridesStringEnums = false;
+    public boolean addsCodeToGeneratedClasses = false;
 
     // overridden settings
     public boolean generatesJaxrsApplicationClient = false;


### PR DESCRIPTION
this is related to #168 -- add ability for extensions to add code in generated classes.

I have experimented with an extension to add hashcode/equals to classes with the right annotations, you can see a gist there:
https://gist.github.com/emmanueltouzery/200edb5d4611441584c501161fd2e622

It looks good in the TS we generate. However before I test the whole chain on our side, I probably need the feature we mentioned, to instantiate the classes in the JAX-RS client; but in theory, I think it should work!

PS: might be nice to add to the writer a function to add some source without trailing carriage return, it's a bit annoying sometimes to have to have the CR always.