### PR TITLE
Fix for #172 - Handling empty @JsonTypeName() correctly.

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -170,7 +170,7 @@ public class Jackson2Parser extends ModelParser {
     private String getTypeName(final Class<?> cls) {
         // find @JsonTypeName recursively
         final JsonTypeName jsonTypeName = getAnnotationRecursive(cls, JsonTypeName.class);
-        if (jsonTypeName != null) {
+        if (jsonTypeName != null && ! jsonTypeName.value().isEmpty()) {
             return jsonTypeName.value();
         }
         // find @JsonSubTypes.Type recursively

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -89,6 +89,7 @@ public class Jackson2ParserTest {
     @JsonTypeName("explicit-name1")
     private static class SubTypeDiscriminatedByName1 implements ParentWithNameDiscriminant {
     }
+    @JsonTypeName(/* Default should be the simplename of the class */)
     private static class SubTypeDiscriminatedByName2 implements ParentWithNameDiscriminant {
     }
     private static class SubTypeDiscriminatedByName3 implements ParentWithNameDiscriminant {


### PR DESCRIPTION
Adds logic to handle empty value of @JsonTypeName as it's javadoc specifies