### PR TITLE
Fix for #174 - Flag to use Jackson2's required for optional

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -70,6 +70,7 @@ public class Settings {
     public String typescriptVersion = "^2.4";
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery = false;
+    public boolean useJackson2RequiredForOptional = false;
     public ClassLoader classLoader = null;
 
     private boolean defaultStringEnumsOverriddenByExtension = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -80,7 +80,13 @@ public class Jackson2Parser extends ModelParser {
                         continue;
                     }
                 }
+
                 boolean optional = false;
+
+                if (settings.useJackson2RequiredForOptional) {
+                    optional = ! beanPropertyWriter.isRequired();
+                }
+
                 for (Class<? extends Annotation> optionalAnnotation : settings.optionalAnnotations) {
                     if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
                         optional = true;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -1,10 +1,17 @@
 
 package cz.habarta.typescript.generator;
 
-import cz.habarta.typescript.generator.parser.*;
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import cz.habarta.typescript.generator.parser.BeanModel;
+import cz.habarta.typescript.generator.parser.Jackson2Parser;
+import cz.habarta.typescript.generator.parser.Model;
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.xml.bind.annotation.XmlElement;
 
 
 public class Jackson2ParserTest {
@@ -60,6 +67,24 @@ public class Jackson2ParserTest {
         Assert.assertEquals("Jackson2ParserTest$SubTypeDiscriminatedByName3", bean3.getDiscriminantLiteral());
     }
 
+    @Test
+    public void testNonJacksonRequiredOptional() {
+        final Settings settings = new Settings();
+        settings.useJackson2RequiredForOptional = true;
+
+        final Jackson2Parser jacksonParser = new Jackson2Parser(settings, new DefaultTypeProcessor());
+
+        final Model model = jacksonParser.parseModel(NonJacksonRequiredOptionalBean.class);
+
+        final BeanModel bean = model.getBean(NonJacksonRequiredOptionalBean.class);
+
+        Assert.assertEquals("required", bean.getProperties().get(0).getName());
+        Assert.assertFalse(bean.getProperties().get(0).isOptional());
+
+        Assert.assertEquals("optional", bean.getProperties().get(1).getName());
+        Assert.assertTrue(bean.getProperties().get(1).isOptional());
+    }
+
     static Jackson2Parser getJackson2Parser() {
         final Settings settings = new Settings();
         return new Jackson2Parser(settings, new DefaultTypeProcessor());
@@ -94,4 +119,15 @@ public class Jackson2ParserTest {
     private static class SubTypeDiscriminatedByName3 implements ParentWithNameDiscriminant {
     }
 
+    private static class NonJacksonRequiredOptionalBean {
+        // Note: We use @XmlElement instead of @JsonProperty because the Jaxb annotations processing logic takes
+        // precedence even when there are no jaxb annotations on the members, due to what seems like a bug in
+        // com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector.hasRequiredMarker()
+
+        @XmlElement(required = true)
+        public String required;
+
+        @XmlElement(required = false)
+        public String optional;
+    }
 }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -1,13 +1,27 @@
 
 package cz.habarta.typescript.generator.gradle;
 
-import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.ClassMapping;
+import cz.habarta.typescript.generator.DateMapping;
+import cz.habarta.typescript.generator.EnumMapping;
 import cz.habarta.typescript.generator.Input;
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import org.gradle.api.*;
-import org.gradle.api.tasks.*;
+import cz.habarta.typescript.generator.JaxrsNamespacing;
+import cz.habarta.typescript.generator.JsonLibrary;
+import cz.habarta.typescript.generator.Output;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.StringQuotes;
+import cz.habarta.typescript.generator.TypeScriptFileType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class GenerateTask extends DefaultTask {
@@ -63,6 +77,7 @@ public class GenerateTask extends DefaultTask {
     public StringQuotes stringQuotes;
     public boolean displaySerializerWarning = true;
     public boolean disableJackson2ModuleDiscovery;
+    public boolean useJackson2RequiredForOptional;
     public boolean debug;
 
     @TaskAction
@@ -137,6 +152,7 @@ public class GenerateTask extends DefaultTask {
         settings.setStringQuotes(stringQuotes);
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+        settings.useJackson2RequiredForOptional = useJackson2RequiredForOptional;
         settings.classLoader = classLoader;
         final File output = outputFile != null
                 ? getProject().file(outputFile)

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -410,6 +410,13 @@ public class GenerateMojo extends AbstractMojo {
     private boolean disableJackson2ModuleDiscovery;
 
     /**
+     * Use Jackson's concept of required parameters to specify optionality in the generated definition. If a property
+     * is not marked as required, the TypeScript property will be emitted as optional.
+     */
+    @Parameter
+    private boolean useJackson2RequiredForOptional;
+
+    /**
      * Turns on verbose output for debugging purposes.
      */
     @Parameter
@@ -483,6 +490,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.setStringQuotes(stringQuotes);
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+            settings.useJackson2RequiredForOptional = useJackson2RequiredForOptional;
             settings.classLoader = classLoader;
             final File output = outputFile != null
                     ? outputFile


### PR DESCRIPTION
Adds a flag which enables use of the Jackson2 optional concept to control the default optionality status for properties. Allows use of custom Jackson2 module logic to control optionality instead of relying on optional annotations alone. 

My use case is to allow correct handling of Kotlin's optional properties, for which there are no runtime-readable annotations generated.