### PR TITLE
Optional properties using Jackson2

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalProperties.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalProperties.java
@@ -1,0 +1,7 @@
+
+package cz.habarta.typescript.generator;
+
+
+public enum OptionalProperties {
+    useSpecifiedAnnotations, useLibraryDefinition, all
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator;
 
+import com.fasterxml.jackson.databind.Module;
 import cz.habarta.typescript.generator.emitter.Emitter;
 import cz.habarta.typescript.generator.emitter.EmitterExtension;
 import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
@@ -30,7 +31,8 @@ public class Settings {
     public String umdNamespace = null;
     public JsonLibrary jsonLibrary = null;
     private Predicate<String> excludeFilter = null;
-    public boolean declarePropertiesAsOptional = false;
+    @Deprecated public boolean declarePropertiesAsOptional = false;
+    public OptionalProperties optionalProperties; // default is OptionalProperties.useSpecifiedAnnotations
     public boolean declarePropertiesAsReadOnly = false;
     public String removeTypeNamePrefix = null;
     public String removeTypeNameSuffix = null;
@@ -69,7 +71,9 @@ public class Settings {
     public Map<String, String> npmPackageDependencies = new LinkedHashMap<>();
     public String typescriptVersion = "^2.4";
     public boolean displaySerializerWarning = true;
-    public boolean disableJackson2ModuleDiscovery = false;
+    @Deprecated public boolean disableJackson2ModuleDiscovery = false;
+    public boolean jackson2ModuleDiscovery = false;
+    public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
@@ -120,6 +124,12 @@ public class Settings {
     public void loadOptionalAnnotations(ClassLoader classLoader, List<String> optionalAnnotations) {
         if (optionalAnnotations != null) {
             this.optionalAnnotations = loadClasses(classLoader, optionalAnnotations, Annotation.class);
+        }
+    }
+
+    public void loadJackson2Modules(ClassLoader classLoader, List<String> jackson2Modules) {
+        if (jackson2Modules != null) {
+            this.jackson2Modules = loadClasses(classLoader, jackson2Modules, Module.class);
         }
     }
 
@@ -234,6 +244,16 @@ public class Settings {
             if (npmName != null || npmVersion != null) {
                 throw new RuntimeException("'npmName' and 'npmVersion' is only applicable when generating NPM 'package.json'.");
             }
+        }
+
+        if (declarePropertiesAsOptional) {
+            System.out.println("Warning: Parameter 'declarePropertiesAsOptional' is deprecated. Use 'optionalProperties' parameter.");
+            if (optionalProperties == null) {
+                optionalProperties = OptionalProperties.all;
+            }
+        }
+        if (disableJackson2ModuleDiscovery) {
+            System.out.println("Warning: Parameter 'disableJackson2ModuleDiscovery' was removed. See 'jackson2ModuleDiscovery' and 'jackson2Modules' parameters.");
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -187,7 +187,7 @@ public class Emitter implements EmitterExtension.Writer {
         emitComments(property.getComments());
         final TsType tsType = property.getTsType();
         final String readonly = property.readonly ? "readonly " : "";
-        final String questionMark = settings.declarePropertiesAsOptional || (tsType instanceof TsType.OptionalType) ? "?" : "";
+        final String questionMark = tsType instanceof TsType.OptionalType ? "?" : "";
         writeIndentedLine(readonly + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + ";");
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.*;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
 import java.lang.reflect.Type;
 import java.util.*;
@@ -48,6 +49,8 @@ public class Jackson1Parser extends ModelParser {
         final BeanHelper beanHelper = getBeanHelper(sourceClass.type);
         if (beanHelper != null) {
             for (BeanPropertyWriter beanPropertyWriter : beanHelper.getProperties()) {
+                final Member propertyMember = beanPropertyWriter.getMember().getMember();
+                checkMember(propertyMember, beanPropertyWriter.getName(), sourceClass.type);
                 Type propertyType = beanPropertyWriter.getGenericPropertyType();
                 if (propertyType == JsonNode.class) {
                     propertyType = Object.class;
@@ -65,13 +68,7 @@ public class Jackson1Parser extends ModelParser {
                         continue;
                     }
                 }
-                boolean optional = false;
-                for (Class<? extends Annotation> optionalAnnotation : settings.optionalAnnotations) {
-                    if (beanPropertyWriter.getAnnotation(optionalAnnotation) != null) {
-                        optional = true;
-                        break;
-                    }
-                }
+                final boolean optional = isAnnotatedPropertyOptional((AnnotatedElement) propertyMember);
                 final Member originalMember = beanPropertyWriter.getMember().getMember();
                 properties.add(processTypeAndCreateProperty(beanPropertyWriter.getName(), propertyType, optional, sourceClass.type, originalMember, null));
             }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -5,6 +5,7 @@ import cz.habarta.typescript.generator.parser.*;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.xml.bind.annotation.XmlElement;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -107,6 +108,70 @@ public class Jackson2ParserTest {
         System.out.println(new ObjectMapper().writeValueAsString(new SubTypeDiscriminatedByName2()));
         System.out.println(new ObjectMapper().writeValueAsString(new SubTypeDiscriminatedByName3()));
         System.out.println(new ObjectMapper().writeValueAsString(new SubTypeDiscriminatedByName4()));
+    }
+
+    @Test
+    public void testOptionalJsonProperty() {
+        final Settings settings = TestUtils.settings();
+        settings.optionalProperties = OptionalProperties.useLibraryDefinition;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithOptionals.class));
+        Assert.assertTrue(output.contains("oname1?: string"));
+//        Assert.assertTrue(output.contains("oname2?: string"));  // uncomment on Java 8
+        Assert.assertTrue(output.contains("jname1?: string"));
+        Assert.assertTrue(output.contains("jname2?: string"));
+        Assert.assertTrue(output.contains("jname3: string"));
+        Assert.assertTrue(output.contains("jname4: string"));
+        Assert.assertTrue(output.contains("xname1?: string"));
+        Assert.assertTrue(output.contains("xname2?: string"));
+        Assert.assertTrue(output.contains("xname3?: string"));
+        Assert.assertTrue(output.contains("xname4?: string"));
+    }
+
+    @Test
+    public void testOptionalXmlElement() {
+        final Settings settings = TestUtils.settings();
+        settings.jsonLibrary = JsonLibrary.jaxb;
+        settings.optionalProperties = OptionalProperties.useLibraryDefinition;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithOptionals.class));
+        Assert.assertTrue(output.contains("oname1?: string"));
+//        Assert.assertTrue(output.contains("oname2?: string"));  // uncomment on Java 8
+        Assert.assertTrue(output.contains("jname1?: string"));
+        Assert.assertTrue(output.contains("jname2?: string"));
+        Assert.assertTrue(output.contains("jname3?: string"));
+        Assert.assertTrue(output.contains("jname4?: string"));
+        Assert.assertTrue(output.contains("xname1?: string"));
+        Assert.assertTrue(output.contains("xname2?: string"));
+        Assert.assertTrue(output.contains("xname3: string"));
+        Assert.assertTrue(output.contains("xname4: string"));
+    }
+
+    public static class ClassWithOptionals {
+        public String oname1;
+//        public Optional<String> oname2;  // uncomment on Java 8
+
+        @JsonProperty
+        public String jname1;
+        @JsonProperty(required = false)
+        public String jname2;
+        @JsonProperty(required = true)
+        public String jname3;
+        private String jname4;
+        @JsonProperty(required = true)
+        public String getJname4() {
+            return jname4;
+        }
+
+        @XmlElement
+        public String xname1;
+        @XmlElement(required = false)
+        public String xname2;
+        @XmlElement(required = true)
+        public String xname3;
+        private String xname4;
+        @XmlElement(required = true)
+        public String getXname4() {
+            return xname4;
+        }
     }
 
 }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -27,7 +27,8 @@ public class GenerateTask extends DefaultTask {
     public List<String> excludeClassPatterns;
     public List<String> includePropertyAnnotations;
     public JsonLibrary jsonLibrary;
-    public boolean declarePropertiesAsOptional;
+    @Deprecated public boolean declarePropertiesAsOptional;
+    public OptionalProperties optionalProperties;
     public boolean declarePropertiesAsReadOnly;
     public String removeTypeNamePrefix;
     public String removeTypeNameSuffix;
@@ -62,7 +63,9 @@ public class GenerateTask extends DefaultTask {
     public String npmVersion;
     public StringQuotes stringQuotes;
     public boolean displaySerializerWarning = true;
-    public boolean disableJackson2ModuleDiscovery;
+    @Deprecated public boolean disableJackson2ModuleDiscovery;
+    public boolean jackson2ModuleDiscovery;
+    public List<String> jackson2Modules;
     public boolean debug;
 
     @TaskAction
@@ -101,6 +104,7 @@ public class GenerateTask extends DefaultTask {
         settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
         settings.jsonLibrary = jsonLibrary;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
+        settings.optionalProperties = optionalProperties;
         settings.declarePropertiesAsReadOnly = declarePropertiesAsReadOnly;
         settings.removeTypeNamePrefix = removeTypeNamePrefix;
         settings.removeTypeNameSuffix = removeTypeNameSuffix;
@@ -137,6 +141,8 @@ public class GenerateTask extends DefaultTask {
         settings.setStringQuotes(stringQuotes);
         settings.displaySerializerWarning = displaySerializerWarning;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+        settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
+        settings.loadJackson2Modules(classLoader, jackson2Modules);
         settings.classLoader = classLoader;
         final File output = outputFile != null
                 ? getProject().file(outputFile)

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -131,10 +131,25 @@ public class GenerateMojo extends AbstractMojo {
     private JsonLibrary jsonLibrary;
 
     /**
-     * If true declared properties will be optional.
+     * Deprecated, use <code>optionalProperties</code> parameter.
      */
+    @Deprecated
     @Parameter
     private boolean declarePropertiesAsOptional;
+
+    /**
+     * Specifies how properties are defined to be optional.
+     * Supported values are:
+     * <ul>
+     * <li><code>useSpecifiedAnnotations</code> - annotations specified using <code>optionalAnnotations</code> parameter</li>
+     * <li><code>useLibraryDefinition</code> - examples: <code>@JsonProperty(required = false)</code> when using <code>jackson2</code> library
+     *   or <code>@XmlElement(required = false)</code> when using <code>jaxb</code> library</li>
+     * <li><code>all</code> - all properties are optional</li>
+     * </ul>
+     * Default value is <code>useSpecifiedAnnotations</code>.
+     */
+    @Parameter
+    private OptionalProperties optionalProperties;
 
     /**
      * If true declared properties will be <code>readonly</code>.
@@ -404,10 +419,23 @@ public class GenerateMojo extends AbstractMojo {
     private boolean displaySerializerWarning;
 
     /**
-     * Turns off Jackson2 automatic module discovery.
+     * Deprecated, see <code>jackson2ModuleDiscovery</code> and <code>jackson2Modules</code> parameters.
      */
+    @Deprecated
     @Parameter
     private boolean disableJackson2ModuleDiscovery;
+
+    /**
+     * Turns on Jackson2 automatic module discovery.
+     */
+    @Parameter
+    private boolean jackson2ModuleDiscovery;
+
+    /**
+     * Specifies Jackson2 modules to use.
+     */
+    @Parameter
+    private List<String> jackson2Modules;
 
     /**
      * Turns on verbose output for debugging purposes.
@@ -447,6 +475,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.setExcludeFilter(excludeClasses, excludeClassPatterns);
             settings.jsonLibrary = jsonLibrary;
             settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
+            settings.optionalProperties = optionalProperties;
             settings.declarePropertiesAsReadOnly = declarePropertiesAsReadOnly;
             settings.removeTypeNamePrefix = removeTypeNamePrefix;
             settings.removeTypeNameSuffix = removeTypeNameSuffix;
@@ -483,6 +512,8 @@ public class GenerateMojo extends AbstractMojo {
             settings.setStringQuotes(stringQuotes);
             settings.displaySerializerWarning = displaySerializerWarning;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
+            settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
+            settings.loadJackson2Modules(classLoader, jackson2Modules);
             settings.classLoader = classLoader;
             final File output = outputFile != null
                     ? outputFile


### PR DESCRIPTION
This PR is continuation of #179, thanks @Yona-Appletree for feature request and first implementation.

This PR adds `optionalProperties` parameter with allowed values `useSpecifiedAnnotations`, `useLibraryDefinition` and `all`.

It also changes how Jackson2 modules are treated, this is incompatible change, please see details below.

## Optional Properties

### 1. `optionalProperties` = `useSpecifiedAnnotations`
Let's say we want to generate following TypeScript interface:
``` typescript
interface Person {
    name: string;  // required
    age?: number;  // optional
}
```
We can do this with this configuration:
``` xml
<configuration>
    <optionalProperties>useSpecifiedAnnotations</optionalProperties>
    <optionalAnnotations>
        <annotation>javax.annotation.Nullable</annotation>
    </optionalAnnotations>
</configuration>
```
and Java class:
``` java
public class Person {
    public String name;
    @Nullable
    public int age;
}
```

This was already possible and it is still **default** behavior.

### 2. `optionalProperties` = `useLibraryDefinition`
With this new feature we can leverage Jackson2 to determine which properties are optional and which required. Then it is possible to use Jackson2 annotations, JAXB annotations or even Kotlin nullable types to specify property optionality.

#### Jackson2 library
Following configuration:
``` xml
<configuration>
    <jsonLibrary>jackson2</jsonLibrary>
    <optionalProperties>useLibraryDefinition</optionalProperties>
</configuration>
```
allows us to use `@JsonProperty` to specify optionality:
``` java
public class Person {
    @JsonProperty(required = true)
    public String name;
    @JsonProperty(required = false)
    public int age;
}
```

#### JAXB library
Similarly for JAXB. Configuration:
``` xml
<configuration>
    <jsonLibrary>jaxb</jsonLibrary>
    <optionalProperties>useLibraryDefinition</optionalProperties>
</configuration>
```
class:
``` java
public class Person {
    @XmlElement(required = true)
    public String name;
    @XmlElement(required = false)
    public int age;
}
```

#### Kotlin nullable types
Jackson2 provides `KotlinModule` which makes nullable types accessible to typescript-generator.
This module can be configured using this snippet:
``` xml
<configuration>
    <jsonLibrary>jackson2</jsonLibrary>
    <optionalProperties>useLibraryDefinition</optionalProperties>
    <jackson2Modules>
        <module>com.fasterxml.jackson.module.kotlin.KotlinModule</module>
    </jackson2Modules>
</configuration>
```
Then we can write Kotlin data class like this:
``` kotlin
data class Person(
        val name: String,
        val age: Int? = null
)
```
and typescript-generator will know from Jackson2 which properties are required/optional.

### 3. `optionalProperties` = `all`
This makes all properties optional. This setting have same effect as `declarePropertiesAsOptional` parameter (which is now deprecated).

## Jackson2 modules
Before this PR typescript-generator by default loaded all Jackson2 modules automatically. This automatic module discovery relies on module presence on classpath which is relatively fragile mechanism and for example `JaxbAnnotationModule` currently breaks `@JsonProperty.required` functionality.

So now typescript-generator by default loads no modules. Previous behavior can be turned on using `jackson2ModuleDiscovery` parameter. Individual modules can be specified using `jackson2Modules` parameter (recommended way). Old `disableJackson2ModuleDiscovery` parameter is effectively removed.
