### PR TITLE
Respect outputs for compileGroovy tasks

### DIFF
--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -85,9 +85,11 @@ public class GenerateTask extends DefaultTask {
 
         // class loader
         final List<URL> urls = new ArrayList<>();
-        for (Task task : getProject().getTasksByName("compileJava", false)) {
-            for (File file : task.getOutputs().getFiles()) {
-                urls.add(file.toURI().toURL());
+        for (String taskName: Arrays.asList("compileJava", "compileGroovy")) {
+            for (Task task : getProject().getTasksByName(taskName, false)) {
+                for (File file : task.getOutputs().getFiles()) {
+                    urls.add(file.toURI().toURL());
+                }
             }
         }
         for (File file : getProject().getConfigurations().getAt("compile").getFiles()) {


### PR DESCRIPTION
So that you can write classes in groovy for translation to .d.ts.

Prior to gradle 4.0, this worked fine, as compileGroovy and compileJava
shared the same output path. After gradle 4.0, each language has a
different output directory.