### PR TITLE
Fixed ignoring npm name and version properties

### DIFF
--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -144,8 +144,8 @@ public class GenerateTask extends DefaultTask {
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.generateNpmPackageJson = generateNpmPackageJson;
-        settings.npmName = npmName != null && generateNpmPackageJson ? getProject().getName() : npmName;
-        settings.npmVersion = npmVersion != null && generateNpmPackageJson ? settings.getDefaultNpmVersion() : npmVersion;
+        settings.npmName = npmName != null ? npmName : getProject().getName();
+        settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
         settings.setStringQuotes(stringQuotes);
         settings.setIndentString(indentString);
         settings.displaySerializerWarning = displaySerializerWarning;

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -144,8 +144,8 @@ public class GenerateTask extends DefaultTask {
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.generateNpmPackageJson = generateNpmPackageJson;
-        settings.npmName = npmName != null ? npmName : getProject().getName();
-        settings.npmVersion = npmVersion != null ? npmVersion : settings.getDefaultNpmVersion();
+        settings.npmName = npmName == null && generateNpmPackageJson ? getProject().getName() : npmName;
+        settings.npmVersion = npmVersion == null && generateNpmPackageJson ? settings.getDefaultNpmVersion() : npmVersion;
         settings.setStringQuotes(stringQuotes);
         settings.setIndentString(indentString);
         settings.displaySerializerWarning = displaySerializerWarning;


### PR DESCRIPTION
It looks like current version of GenerateTask.java has a wrong condition when setting npmName and npmVersion properties. I assume it should work like that (if generateNpmPackageJson is set to true):
1. npmName/npmVersion not set -> use default value
1. npmName/npmVersion set -> use given value

However, currently it works like that:
1. npmName/npmVersion not set -> error is being thrown with message that those properties are required
1. npmName/npmVersion set -> uses default values (ignores the given ones)

This PR fixes that issue.