### PR TITLE
WIP: Generate optional properties as null

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -34,6 +34,7 @@ public class Settings {
     private Predicate<String> excludeFilter = null;
     @Deprecated public boolean declarePropertiesAsOptional = false;
     public OptionalProperties optionalProperties; // default is OptionalProperties.useSpecifiedAnnotations
+    public boolean optionalAsNull = false;
     public boolean declarePropertiesAsReadOnly = false;
     public String removeTypeNamePrefix = null;
     public String removeTypeNameSuffix = null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
@@ -23,7 +23,7 @@ public class TsProperty {
     }
 
     public String format(Settings settings) {
-        final String questionMark = (tsType instanceof TsType.OptionalType) ? "?" : "";
+        final String questionMark = (tsType instanceof TsType.OptionalType && !settings.optionalAsNull) ? "?" : "";
         return Emitter.quoteIfNeeded(name, settings) + questionMark + ": " + tsType.format(settings) + ";";
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -200,7 +200,11 @@ public abstract class TsType implements Emittable {
 
         @Override
         public String format(Settings settings) {
-            return type.format(settings);
+            if (settings.optionalAsNull) {
+                return type.format(settings) + " | null";
+            } else {
+                return type.format(settings);
+            }
         }
 
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -200,7 +200,7 @@ public class Emitter implements EmitterExtension.Writer {
         final TsType tsType = property.getTsType();
         final String staticString = property.modifiers.isStatic ? "static " : "";
         final String readonlyString = property.modifiers.isReadonly ? "readonly " : "";
-        final String questionMark = tsType instanceof TsType.OptionalType ? "?" : "";
+        final String questionMark = tsType instanceof TsType.OptionalType && !settings.optionalAsNull ? "?" : "";
         writeIndentedLine(staticString + readonlyString + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + ";");
     }
 

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -30,6 +30,7 @@ public class GenerateTask extends DefaultTask {
     public JsonLibrary jsonLibrary;
     @Deprecated public boolean declarePropertiesAsOptional;
     public OptionalProperties optionalProperties;
+    public boolean optionalAsNull;
     public boolean declarePropertiesAsReadOnly;
     public String removeTypeNamePrefix;
     public String removeTypeNameSuffix;
@@ -115,6 +116,7 @@ public class GenerateTask extends DefaultTask {
         settings.jsonLibrary = jsonLibrary;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
         settings.optionalProperties = optionalProperties;
+        settings.optionalAsNull = optionalAsNull;
         settings.declarePropertiesAsReadOnly = declarePropertiesAsReadOnly;
         settings.removeTypeNamePrefix = removeTypeNamePrefix;
         settings.removeTypeNameSuffix = removeTypeNameSuffix;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -439,6 +439,12 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> optionalAnnotations;
 
     /**
+     * If <code>true</code> optional property types will be generated as foo: T | null instead of as foo?: T
+     */
+    @Parameter
+    private boolean optionalAsNull;
+
+    /**
      * If <code>true</code> NPM <code>package.json</code> will be generated.
      * Only applicable when {@link #outputKind} is set to <code>module</code>.
      * NPM package name and version can be specified using {@link #npmName} and {@link #npmVersion} parameters.
@@ -543,6 +549,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.jsonLibrary = jsonLibrary;
             settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
             settings.optionalProperties = optionalProperties;
+            settings.optionalAsNull = optionalAsNull;
             settings.declarePropertiesAsReadOnly = declarePropertiesAsReadOnly;
             settings.removeTypeNamePrefix = removeTypeNamePrefix;
             settings.removeTypeNameSuffix = removeTypeNameSuffix;


### PR DESCRIPTION
Currently, type interfaces which are generated from JAX-RS endpoints translate properties with a `@Nullable` annotation into an optional field as follows:

```
interface Foo {
  bar?: string
}
```

Whereas the actual object sent/expected by a JAX-RS endpoint would have the form:

```
interface: Foo {
  bar: string | null
}
```

This change allows the emitter to be switched from the first representation to the second by setting `optionalAsNull` to true.

Note:
- I'm hoping to start a discussion with this PR, it's not ready to be merged yet (hence WIP).
- I have't added tests for the new functionality because I'm not sure if this is the best way to implement it, or what the approach is with testing the impact of different settings. Also, I'm not too sure about other impacts on code/functionality that I'm not using.
- I'm not sure about the name of the parameter, maybe `optionalPropertiesAsNull` would be more explicit.
  