### PR TITLE
Fix for generic parameter in method declaration

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -103,6 +103,10 @@ public class DefaultTypeProcessor implements TypeProcessor {
         }
         if (javaType instanceof TypeVariable) {
             final TypeVariable<?> typeVariable = (TypeVariable<?>) javaType;
+            if (typeVariable.getGenericDeclaration() instanceof Method) {
+                // example method: public <T extends Number> T getData();
+                return context.processType(typeVariable.getBounds()[0]);
+            }
             return new Result(new TsType.GenericVariableType(typeVariable.getName()));
         }
         if (javaType instanceof WildcardType) {
@@ -138,6 +142,7 @@ public class DefaultTypeProcessor implements TypeProcessor {
         knownTypes.put(String.class, TsType.String);
         knownTypes.put(void.class, TsType.Void);
         knownTypes.put(Void.class, TsType.Void);
+        knownTypes.put(Number.class, TsType.Number);
         // other java packages
         knownTypes.put(BigDecimal.class, TsType.Number);
         knownTypes.put(BigInteger.class, TsType.Number);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
@@ -125,6 +125,17 @@ public class GenericsTest {
         assertEquals(expected, output.trim());
     }
 
+    @Test
+    public void testArbitraryGenericParameter() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ExecutionResult.class));
+        final String expected =
+                "interface ExecutionResult {\n" +
+                "    data: number;\n" +
+                "}";
+        assertEquals(expected, output.trim());
+    }
+
     class A<U,V> {
         public A<String, String> x;
         public A<A<String, B>, List<String>> y;
@@ -171,6 +182,10 @@ public class GenericsTest {
 
     class TableGA<T> {
         public T[] rows;
+    }
+
+    interface ExecutionResult {
+        public <T extends Number> T getData();
     }
 
 }


### PR DESCRIPTION
Example Java interface:
``` java
interface ExecutionResult { 
    public <T> T getData(); 
}
```
Previously typescript-generator generated `data` property of type `T` which resulted in compile error.

Now typescript-generator generates `data` property of type `any` in this example (or other type if generic variable has upper bound).