### PR TITLE
feat(expanded-enum-values): Expand @JsonValue scenarios for enums

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -175,4 +175,44 @@ public class Jackson2ParserTest {
         }
     }
 
+    @Test
+    public void testStandardEnumValue() {
+        testEnumByType(TestEnums.StandardEnum.class, "A", "B", "C");
+    }
+
+    @Test
+    public void testStringPropertyEnumValue() {
+        testEnumByType(TestEnums.StringPropertyValuedEnum.class, "_A", "_B", "_C");
+    }
+
+    @Test
+    public void testNumberPropertyEnumValue() {
+        testEnumByType(TestEnums.NumberPropertyValuedEnum.class, 0, 1, 2);
+    }
+
+    @Test
+    public void testMethodEnumValue() {
+        testEnumByType(TestEnums.GeneralMethodValuedEnum.class, "_A", "_B", "_C");
+    }
+
+    @Test
+    public void testToStringEnumValue() {
+        testEnumByType(TestEnums.ToStringValuedEnum.class, "_A", "_B", "_C");
+    }
+
+    @Test
+    public void testJsonPropertyEnumValue() {
+        testEnumByType(TestEnums.JsonPropertyValuedEnum.class, "_A", "_B", "_C");
+    }
+
+    private void testEnumByType(Class<? extends Enum<?>> type, Object... expectedValues) {
+        final Jackson2Parser jacksonParser = getJackson2Parser();
+        final Model model = jacksonParser.parseModel(type);
+        Assert.assertEquals(1, model.getEnums().size());
+        final EnumModel enumModel = model.getEnums().get(0);
+        Assert.assertEquals(expectedValues.length, enumModel.getMembers().size());
+        for (int i = 0; i < expectedValues.length; i++) {
+            Assert.assertEquals(expectedValues[i], enumModel.getMembers().get(i).getEnumValue());
+        }
+    }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
@@ -1,0 +1,49 @@
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class TestEnums {
+    public enum StandardEnum {
+        A, B, C
+    }
+
+    public enum GeneralMethodValuedEnum {
+        A, B, C;
+
+        @JsonValue
+        public String getValue() {
+            return "_" + name();
+        }
+    }
+
+    public enum ToStringValuedEnum {
+        A, B, C;
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return "_" + name();
+        }
+    }
+
+    public enum StringPropertyValuedEnum {
+        A, B, C;
+
+        @JsonValue
+        private final String value = "_" + name();
+    }
+
+    public enum NumberPropertyValuedEnum {
+        A, B, C;
+
+        @JsonValue
+        private final Integer value = ordinal();
+    }
+
+    public enum JsonPropertyValuedEnum {
+        @JsonProperty("_A") A,
+        @JsonProperty("_B") B,
+        @JsonProperty("_C") C
+    }
+}


### PR DESCRIPTION
Currently enums support generating by `name`, `@JsonProperty` annotation on constant, or `@JsonValue` annotation on read method. I've encountered scenarios where code utilizes `@JsonValue` on enum instance fields or non-accessor methods (like `toString`) and propose expanding custom enum value support to these scenarios.

This PR expands support to enums like the following:

```java
public enum ToStringValuedEnum {
    A, B, C;

    @JsonValue
    @Override
    public String toString() {
        return "_" + name();
    }
}  // -> "_A", "_B", "_C"

public enum StringPropertyValuedEnum {
    A, B, C;

    @JsonValue
    private final String value = "_" + name();
}  // -> "_A", "_B", "_C"

public enum NumberPropertyValuedEnum {
    A, B, C;

    @JsonValue
    private final Integer value = ordinal();
}  // -> 0, 1, 2
```

## Performance Impact
Logic changes will increase the number of methods being checked per-enum and also will evaluate more fields than before thus it will technically be slower. This impact should be negligible considering the number of instance fields and methods on enums are typically minimal, and I believe the increased capability more than offsets any slowdown.

## Compatibility
This will modify generated schemas for any baselines making use of the scenarios above. I believe any situations where a change occurs would be desired since the schema would be updating to more accurately reflect what is serialized via JSON. I'm also not aware of any new edge cases that might cause issues since `@JsonValue` was already supported in more limited conditions.