### PR TITLE
NPM module export "types" as declaration file (.d.ts)

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -66,10 +66,11 @@ public class TypeScriptGenerator {
             npmPackageJson.version = settings.npmVersion;
             npmPackageJson.types = outputFile.getName();
             if (settings.outputFileType == TypeScriptFileType.implementationFile) {
+                npmPackageJson.types = Utils.replaceExtension(outputFile, ".d.ts").getName();
                 npmPackageJson.main = Utils.replaceExtension(outputFile, ".js").getName();
                 npmPackageJson.dependencies = !settings.npmPackageDependencies.isEmpty() ? settings.npmPackageDependencies : null;
                 npmPackageJson.devDependencies = Collections.singletonMap("typescript", settings.typescriptVersion);
-                npmPackageJson.scripts = Collections.singletonMap("build", "tsc --module umd --moduleResolution node --target es5 --lib es6 --sourceMap " + outputFile.getName());
+                npmPackageJson.scripts = Collections.singletonMap("build", "tsc --module umd --moduleResolution node --target es5 --lib es6 --declaration --sourceMap " + outputFile.getName());
             }
             getNpmPackageJsonEmitter().emit(npmPackageJson, npmOutput.getWriter(), npmOutput.getName(), npmOutput.shouldCloseWriter());
         }


### PR DESCRIPTION
In addition to TypeScript declaration or implementation file typescript-generator can also generate NPM `package.json` file.

When generating **implementation files** (`.ts`) generated `package.json` looks like this:
``` json
{
  "name": "service",
  "version": "1.0.0",
  "types": "service.d.ts",
  "main": "service.js",
  "devDependencies": {
    "typescript": "^2.4"
  },
  "scripts": {
    "build": "tsc --module umd --moduleResolution node --target es5 --lib es6 --declaration --sourceMap service.ts"
  }
}
```
Previously `types` referenced directly generated `.ts` file. Now `build` script passes `--declaration` switch to TypeScript compiler to generate declaration file (`.d.ts`) and `types` references this file.

This behavior is more "correct" or "common" because in general modules should export JavaScript file (`.js`) and declaration file (`.d.ts`) instead of implementation file (`.ts`). In fact exporting implementation file causes problems in some cases.

That said I am not sure if this change could break something so please comment if previous behavior is needed.