### PR TITLE
Write messages through global `Logger` in `TypeScriptGenerator`

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
@@ -55,7 +55,7 @@ public class Input {
             }
             if (types.isEmpty()) {
                 final String errorMessage = "No input classes found.";
-                System.out.println(errorMessage);
+                TypeScriptGenerator.getLogger().error(errorMessage);
                 throw new RuntimeException(errorMessage);
             }
             return new Input(types);
@@ -77,7 +77,7 @@ public class Input {
 
         public ScanResult scanClasspath() {
             if (scanResult == null) {
-                System.out.println("Scanning classpath");
+                TypeScriptGenerator.getLogger().info("Scanning classpath");
                 final Date scanStart = new Date();
                 final ScanResult result = new FastClasspathScanner()
                         .overrideClasspath((Object[])classLoader.getURLs())
@@ -86,7 +86,7 @@ public class Input {
                 final int count = result.getNamesOfAllClasses().size();
                 final Date scanEnd = new Date();
                 final double timeInSeconds = (scanEnd.getTime() - scanStart.getTime()) / 1000.0;
-                System.out.println(String.format("Scanning finished in %.2f seconds. Total number of classes: %d.", timeInSeconds, count));
+                TypeScriptGenerator.getLogger().info(String.format("Scanning finished in %.2f seconds. Total number of classes: %d.", timeInSeconds, count));
                 scanResult = result;
             }
             return scanResult;
@@ -100,7 +100,7 @@ public class Input {
         allClassNames.addAll(scanResult.getNamesOfAllInterfaceClasses());
         Collections.sort(allClassNames);
         final List<String> classNames = filterClassNames(allClassNames, classNamePatterns);
-        System.out.println(String.format("Found %d classes matching pattern.", classNames.size()));
+        TypeScriptGenerator.getLogger().info(String.format("Found %d classes matching pattern.", classNames.size()));
         return fromClassNames(classNames);
     }
 
@@ -123,7 +123,7 @@ public class Input {
                 final Class<?> cls = Thread.currentThread().getContextClassLoader().loadClass(className);
                 classes.add(cls);
             } catch (ReflectiveOperationException e) {
-                System.out.println(String.format("Error: Cannot load class '%s'", className));
+                TypeScriptGenerator.getLogger().error(String.format("Cannot load class '%s'", className));
                 e.printStackTrace(System.out);
             }
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
@@ -16,7 +16,7 @@ public class JaxrsApplicationScanner {
         final ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(jaxrsApplicationClass.getClassLoader());
-            System.out.println("Scanning JAX-RS application: " + jaxrsApplicationClass.getName());
+            TypeScriptGenerator.getLogger().info("Scanning JAX-RS application: " + jaxrsApplicationClass.getName());
             final Constructor<?> constructor = jaxrsApplicationClass.getDeclaredConstructor();
             constructor.setAccessible(true);
             final Application application = (Application) constructor.newInstance();
@@ -37,14 +37,14 @@ public class JaxrsApplicationScanner {
     public static List<SourceType<Type>> scanAutomaticJaxrsApplication(ScanResult scanResult, Predicate<String> isClassNameExcluded) {
         final List<String> namesOfResourceClasses = scanResult.getNamesOfClassesWithAnnotation(Path.class);
         final List<Class<?>> resourceClasses = Input.loadClasses(namesOfResourceClasses);
-        System.out.println(String.format("Found %d root resources.", resourceClasses.size()));
+        TypeScriptGenerator.getLogger().info(String.format("Found %d root resources.", resourceClasses.size()));
         return new JaxrsApplicationScanner().scanJaxrsApplication(null, resourceClasses, isClassNameExcluded);
     }
 
     private static RuntimeException reportError(ReflectiveOperationException e) {
         final String url = "https://github.com/vojtechhabarta/typescript-generator/wiki/JAX-RS-Application";
         final String message = "Cannot load JAX-RS application. For more information see " + url + ".";
-        System.out.println(message);
+        TypeScriptGenerator.getLogger().error(message);
         return new RuntimeException(message, e);
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
@@ -1,0 +1,31 @@
+
+package cz.habarta.typescript.generator;
+
+
+public class Logger {
+
+    protected enum Level {
+        Verbose, Info, Warning, Error;
+    }
+
+    protected void write(Level level, String message) {
+        System.out.println(message);
+    }
+
+    public final void verbose(String message) {
+        write(Level.Verbose, message);
+    }
+
+    public final void info(String message) {
+        write(Level.Info, message);
+    }
+
+    public final void warning(String message) {
+        write(Level.Warning, "Warning: " + message);
+    }
+
+    public final void error(String message) {
+        write(Level.Error, "Error: " + message);
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
@@ -4,12 +4,24 @@ package cz.habarta.typescript.generator;
 
 public class Logger {
 
-    protected enum Level {
-        Verbose, Info, Warning, Error;
+    private final Level level;
+
+    public enum Level {
+        Debug, Verbose, Info, Warning, Error;
+    }
+
+    public Logger() {
+        this(null);
+    }
+
+    public Logger(Level level) {
+        this.level = level != null ? level : Level.Verbose;
     }
 
     protected void write(Level level, String message) {
-        System.out.println(message);
+        if (level.compareTo(this.level) >= 0) {
+            System.out.println(message);
+        }
     }
 
     public final void verbose(String message) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -200,7 +200,7 @@ public class Settings {
             final String extensionName = extension.getClass().getSimpleName();
             final DeprecationText deprecation = extension.getClass().getAnnotation(DeprecationText.class);
             if (deprecation != null) {
-                System.out.println(String.format("Warning: Extension '%s' is deprecated: %s", extensionName, deprecation.value()));
+                TypeScriptGenerator.getLogger().warning(String.format("Extension '%s' is deprecated: %s", extensionName, deprecation.value()));
             }
             final EmitterExtensionFeatures features = extension.getFeatures();
             if (features.generatesRuntimeCode && outputFileType != TypeScriptFileType.implementationFile) {
@@ -274,18 +274,18 @@ public class Settings {
         }
 
         if (declarePropertiesAsOptional) {
-            System.out.println("Warning: Parameter 'declarePropertiesAsOptional' is deprecated. Use 'optionalProperties' parameter.");
+            TypeScriptGenerator.getLogger().warning("Parameter 'declarePropertiesAsOptional' is deprecated. Use 'optionalProperties' parameter.");
             if (optionalProperties == null) {
                 optionalProperties = OptionalProperties.all;
             }
         }
         if (disableJackson2ModuleDiscovery) {
-            System.out.println("Warning: Parameter 'disableJackson2ModuleDiscovery' was removed. See 'jackson2ModuleDiscovery' and 'jackson2Modules' parameters.");
+            TypeScriptGenerator.getLogger().warning("Parameter 'disableJackson2ModuleDiscovery' was removed. See 'jackson2ModuleDiscovery' and 'jackson2Modules' parameters.");
         }
     }
 
     private static void reportConfigurationChange(String extensionName, String parameterName, String parameterValue) {
-        System.out.println(String.format("Configuration: '%s' extension set '%s' parameter to '%s'", extensionName, parameterName, parameterValue));
+        TypeScriptGenerator.getLogger().info(String.format("Configuration: '%s' extension set '%s' parameter to '%s'", extensionName, parameterName, parameterValue));
     }
 
     public String getExtension() {
@@ -384,7 +384,7 @@ public class Settings {
 
     private static <T> Class<? extends T> loadClass(ClassLoader classLoader, String className, Class<T> requiredClassType) {
         try {
-            System.out.println("Loading class " + className);
+            TypeScriptGenerator.getLogger().verbose("Loading class " + className);
             final Class<?> loadedClass = classLoader.loadClass(className);
             if (requiredClassType.isAssignableFrom(loadedClass)) {
                 @SuppressWarnings("unchecked")
@@ -411,7 +411,7 @@ public class Settings {
 
     private static <T> T loadInstance(ClassLoader classLoader, String className, Class<T> requiredType) {
         try {
-            System.out.println("Loading class " + className);
+            TypeScriptGenerator.getLogger().verbose("Loading class " + className);
             return requiredType.cast(classLoader.loadClass(className).newInstance());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -284,10 +284,10 @@ public class Settings {
             TypeScriptGenerator.getLogger().warning("Parameter 'disableJackson2ModuleDiscovery' was removed. See 'jackson2ModuleDiscovery' and 'jackson2Modules' parameters.");
         }
         if (displaySerializerWarning) {
-            TypeScriptGenerator.getLogger().warning("Parameter 'displaySerializerWarning' was removed. Please set 'loggingLevel' parameter to 'Info' value (or higher).");
+            TypeScriptGenerator.getLogger().warning("Parameter 'displaySerializerWarning' was removed. Please use 'loggingLevel' parameter, these messages have 'Verbose' level.");
         }
         if (debug) {
-            TypeScriptGenerator.getLogger().warning("Parameter 'debug' was removed. Please set 'loggingLevel' parameter to 'Debug' value.");
+            TypeScriptGenerator.getLogger().warning("Parameter 'debug' was removed. Please set 'loggingLevel' parameter to 'Debug'.");
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -75,7 +75,8 @@ public class Settings {
     public String npmVersion = null;
     public Map<String, String> npmPackageDependencies = new LinkedHashMap<>();
     public String typescriptVersion = "^2.4";
-    public boolean displaySerializerWarning = true;
+    @Deprecated public boolean displaySerializerWarning;
+    @Deprecated public boolean debug;
     @Deprecated public boolean disableJackson2ModuleDiscovery = false;
     public boolean jackson2ModuleDiscovery = false;
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
@@ -281,6 +282,12 @@ public class Settings {
         }
         if (disableJackson2ModuleDiscovery) {
             TypeScriptGenerator.getLogger().warning("Parameter 'disableJackson2ModuleDiscovery' was removed. See 'jackson2ModuleDiscovery' and 'jackson2Modules' parameters.");
+        }
+        if (displaySerializerWarning) {
+            TypeScriptGenerator.getLogger().warning("Parameter 'displaySerializerWarning' was removed. Please set 'loggingLevel' parameter to 'Info' value (or higher).");
+        }
+        if (debug) {
+            TypeScriptGenerator.getLogger().warning("Parameter 'debug' was removed. Please set 'loggingLevel' parameter to 'Debug' value.");
         }
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -13,12 +13,22 @@ public class TypeScriptGenerator {
 
     public static final String Version = getVersion();
 
+    private static Logger logger = new Logger();
+
     private final Settings settings;
     private TypeProcessor typeProcessor = null;
     private ModelParser modelParser = null;
     private ModelCompiler modelCompiler = null;
     private Emitter emitter = null;
     private NpmPackageJsonEmitter npmPackageJsonEmitter = null;
+
+    public static Logger getLogger() {
+        return logger;
+    }
+
+    public static void setLogger(Logger logger) {
+        TypeScriptGenerator.logger = logger;
+    }
 
     public TypeScriptGenerator() {
         this (new Settings());
@@ -30,7 +40,7 @@ public class TypeScriptGenerator {
     }
 
     public static void printVersion() {
-        System.out.println("Running TypeScriptGenerator version " + Version);
+        TypeScriptGenerator.getLogger().info("Running TypeScriptGenerator version " + Version);
     }
 
     public String generateTypeScript(Input input) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -314,9 +314,9 @@ public class ModelCompiler {
             return result.getTsType();
         } else {
             if (usedInClass != null && usedInProperty != null) {
-                System.out.println(String.format("Warning: Unsupported type '%s' used in '%s.%s'", javaType, usedInClass.getSimpleName(), usedInProperty));
+                TypeScriptGenerator.getLogger().warning(String.format("Unsupported type '%s' used in '%s.%s'", javaType, usedInClass.getSimpleName(), usedInProperty));
             } else {
-                System.out.println(String.format("Warning: Unsupported type '%s'", javaType));
+                TypeScriptGenerator.getLogger().warning(String.format("Unsupported type '%s'", javaType));
             }
             return TsType.Any;
         }
@@ -498,7 +498,7 @@ public class ModelCompiler {
                 if (Emitter.isValidIdentifierName(annotationValue)) {
                     return symbolTable.getSyntheticSymbol(annotationValue, nameSuffix);
                 } else {
-                    System.out.println(String.format("Warning: Ignoring annotation value '%s' since it is not a valid identifier, '%s' will be in default namespace", annotationValue, method.getOriginClass().getName() + "." + method.getName()));
+                    TypeScriptGenerator.getLogger().warning(String.format("Ignoring annotation value '%s' since it is not a valid identifier, '%s' will be in default namespace", annotationValue, method.getOriginClass().getName() + "." + method.getName()));
                 }
             }
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.compiler;
 
 import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
 import java.util.*;
@@ -100,7 +101,7 @@ public class SymbolTable {
             final String name = entry.getKey();
             final List<Class<?>> classes = entry.getValue();
             if (classes.size() > 1) {
-                System.out.println(String.format("Multiple classes are mapped to '%s' name. Conflicting classes: %s", name, classes));
+                TypeScriptGenerator.getLogger().warning(String.format("Multiple classes are mapped to '%s' name. Conflicting classes: %s", name, classes));
                 conflict = true;
             }
         }
@@ -191,9 +192,9 @@ public class SymbolTable {
             final ScriptEngine engine = new NashornScriptEngineFactory().getScriptEngine();
 
             if (engine == null) {
-                System.out.println(String.format("Error: Script engine for '%s' MIME type not found. Available engines: %s", engineMimeType, manager.getEngineFactories().size()));
+                TypeScriptGenerator.getLogger().error(String.format("Script engine for '%s' MIME type not found. Available engines: %s", engineMimeType, manager.getEngineFactories().size()));
                 for (ScriptEngineFactory factory : manager.getEngineFactories()) {
-                    System.out.println(String.format("  %s %s - MIME types: %s", factory.getEngineName(), factory.getEngineVersion(), factory.getMimeTypes()));
+                    TypeScriptGenerator.getLogger().info(String.format("  %s %s - MIME types: %s", factory.getEngineName(), factory.getEngineVersion(), factory.getMimeTypes()));
                 }
                 throw new RuntimeException("Cannot evaluate function specified using 'customTypeNamingFunction' parameter. See log for details.");
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -25,7 +25,7 @@ public class Emitter implements EmitterExtension.Writer {
         this.forceExportKeyword = forceExportKeyword;
         this.indent = initialIndentationLevel;
         if (outputName != null) {
-            System.out.println("Writing declarations to: " + outputName);
+            TypeScriptGenerator.getLogger().info("Writing declarations to: " + outputName);
         }
         emitFileComment();
         emitReferences();

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJsonEmitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/NpmPackageJsonEmitter.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.emitter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.StandardJsonPrettyPrinter;
 import java.io.*;
 
@@ -15,7 +16,7 @@ public class NpmPackageJsonEmitter {
     public void emit(NpmPackageJson npmPackageJson, Writer output, String outputName, boolean closeOutput) {
         this.writer = output;
         if (outputName != null) {
-            System.out.println("Writing NPM package to: " + outputName);
+            TypeScriptGenerator.getLogger().info("Writing NPM package to: " + outputName);
         }
         emitPackageJson(npmPackageJson);
         if (closeOutput) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -63,7 +63,7 @@ public class Jackson1Parser extends ModelParser {
                         }
                     }
                     if (!isInAnnotationFilter) {
-                        System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
+                        TypeScriptGenerator.getLogger().info("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
                         continue;
                     }
                 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -258,7 +258,7 @@ public class Jackson2Parser extends ModelParser {
             } else {
                 final String jsonSerializerName = jsonSerializer.getClass().getName();
                 if (settings.displaySerializerWarning) {
-                    TypeScriptGenerator.getLogger().warning(String.format("Unknown serializer '%s' for class '%s'", jsonSerializerName, beanClass));
+                    TypeScriptGenerator.getLogger().verbose(String.format("Unknown serializer '%s' for class '%s'", jsonSerializerName, beanClass));
                 }
                 return null;
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -85,7 +85,7 @@ public class Jackson2Parser extends ModelParser {
                         }
                     }
                     if (!isInAnnotationFilter) {
-                        System.out.println("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
+                        TypeScriptGenerator.getLogger().info("Skipping " + sourceClass.type + "." + beanPropertyWriter.getName() + " because it is missing an annotation from includePropertyAnnotations!");
                         continue;
                     }
                 }
@@ -258,7 +258,7 @@ public class Jackson2Parser extends ModelParser {
             } else {
                 final String jsonSerializerName = jsonSerializer.getClass().getName();
                 if (settings.displaySerializerWarning) {
-                    System.out.println(String.format("Warning: Unknown serializer '%s' for class '%s'", jsonSerializerName, beanClass));
+                    TypeScriptGenerator.getLogger().warning(String.format("Unknown serializer '%s' for class '%s'", jsonSerializerName, beanClass));
                 }
                 return null;
             }
@@ -330,11 +330,11 @@ public class Jackson2Parser extends ModelParser {
                     } else if (value instanceof Number) {
                         enumMembers.add(new EnumMemberModel(constant.getName(), (Number) value, null));
                     } else {
-                        System.out.println(String.format("'%s' enum as a @JsonValue that isn't a String or Number, ignoring", enumClass.getName()));
+                        TypeScriptGenerator.getLogger().warning(String.format("'%s' enum as a @JsonValue that isn't a String or Number, ignoring", enumClass.getName()));
                     }
                 }
             } catch (Exception e) {
-                System.out.println(String.format("Cannot get enum values for '%s' enum", enumClass.getName()));
+                TypeScriptGenerator.getLogger().error(String.format("Cannot get enum values for '%s' enum", enumClass.getName()));
                 e.printStackTrace(System.out);
             }
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -1,6 +1,7 @@
 
 package cz.habarta.typescript.generator.parser;
 
+import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.util.Utils;
 import cz.habarta.typescript.generator.xmldoclet.Class;
@@ -29,7 +30,7 @@ public class Javadoc {
         final List<Root> dRoots = new ArrayList<>();
         if (javadocXmlFiles != null) {
             for (File file : javadocXmlFiles) {
-                System.out.println("Loading Javadoc XML file: " + file);
+                TypeScriptGenerator.getLogger().info("Loading Javadoc XML file: " + file);
                 final Root dRoot = JAXB.unmarshal(file, Root.class);
                 dRoots.add(dRoot);
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.JaxrsApplicationScanner;
 import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Predicate;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.annotation.Annotation;
@@ -77,7 +78,7 @@ public class JaxrsApplicationParser {
         // resource
         final Path path = cls.getAnnotation(Path.class);
         if (path != null) {
-            System.out.println("Parsing JAX-RS resource: " + cls.getName());
+            TypeScriptGenerator.getLogger().verbose("Parsing JAX-RS resource: " + cls.getName());
             final Result result = new Result();
             parseResource(result, new ResourceContext(cls, path.value()), cls);
             return result;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -62,7 +62,7 @@ public abstract class ModelParser {
             if (result != null) {
                 if (sourceType.type instanceof Class<?> && result.getTsType() instanceof TsType.ReferenceType) {
                     final Class<?> cls = (Class<?>) sourceType.type;
-                    System.out.println("Parsing '" + cls.getName() + "'" +
+                    TypeScriptGenerator.getLogger().verbose("Parsing '" + cls.getName() + "'" +
                             (sourceType.usedInClass != null ? " used in '" + sourceType.usedInClass.getSimpleName() + "." + sourceType.usedInMember + "'" : ""));
                     final DeclarationModel model = parseClass(sourceType.asSourceClass());
                     if (model instanceof EnumModel) {

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -68,11 +68,12 @@ public class GenerateTask extends DefaultTask {
     public String npmVersion;
     public StringQuotes stringQuotes;
     public String indentString;
-    public boolean displaySerializerWarning = true;
+    @Deprecated public boolean displaySerializerWarning;
     @Deprecated public boolean disableJackson2ModuleDiscovery;
     public boolean jackson2ModuleDiscovery;
     public List<String> jackson2Modules;
-    public boolean debug;
+    @Deprecated public boolean debug;
+    public Logger.Level loggingLevel;
 
     @TaskAction
     public void generate() throws Exception {
@@ -83,6 +84,7 @@ public class GenerateTask extends DefaultTask {
             throw new RuntimeException("Please specify 'jsonLibrary' property.");
         }
 
+        TypeScriptGenerator.setLogger(new Logger(loggingLevel));
         TypeScriptGenerator.printVersion();
 
         // class loader
@@ -154,6 +156,7 @@ public class GenerateTask extends DefaultTask {
         settings.setStringQuotes(stringQuotes);
         settings.setIndentString(indentString);
         settings.displaySerializerWarning = displaySerializerWarning;
+        settings.debug = debug;
         settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
         settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
         settings.loadJackson2Modules(classLoader, jackson2Modules);
@@ -165,7 +168,8 @@ public class GenerateTask extends DefaultTask {
 
         // TypeScriptGenerator
         new TypeScriptGenerator(settings).generateTypeScript(
-                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader, debug),
+                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
+                        settings.getExcludeFilter(), classLoader, loggingLevel == Logger.Level.Debug),
                 Output.to(output)
         );
     }

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -496,9 +496,10 @@ public class GenerateMojo extends AbstractMojo {
     private String indentString;
 
     /**
-     * Display warnings when bean serializer is not found.
+     * <b>Deprecated</b>, use {@link #loggingLevel} parameter.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter
+    @Deprecated
     private boolean displaySerializerWarning;
 
     /**
@@ -521,10 +522,26 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> jackson2Modules;
 
     /**
-     * Turns on verbose output for debugging purposes.
+     * <b>Deprecated</b>, use {@link #loggingLevel} parameter.
      */
     @Parameter
+    @Deprecated
     private boolean debug;
+
+    /**
+     * Specifies level of logging output.
+     * Supported values are:
+     * <ul>
+     * <li><code>Debug</code></li>
+     * <li><code>Verbose</code></li>
+     * <li><code>Info</code></li>
+     * <li><code>Warning</code></li>
+     * <li><code>Error</code></li>
+     * </ul>
+     * Default value is <code>Verbose</code>.
+     */
+    @Parameter
+    private Logger.Level loggingLevel;
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
@@ -535,6 +552,7 @@ public class GenerateMojo extends AbstractMojo {
     @Override
     public void execute() {
         try {
+            TypeScriptGenerator.setLogger(new Logger(loggingLevel));
             TypeScriptGenerator.printVersion();
 
             // class loader
@@ -596,6 +614,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.setStringQuotes(stringQuotes);
             settings.setIndentString(indentString);
             settings.displaySerializerWarning = displaySerializerWarning;
+            settings.debug = debug;
             settings.disableJackson2ModuleDiscovery = disableJackson2ModuleDiscovery;
             settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
             settings.loadJackson2Modules(classLoader, jackson2Modules);
@@ -607,7 +626,8 @@ public class GenerateMojo extends AbstractMojo {
 
             // TypeScriptGenerator
             new TypeScriptGenerator(settings).generateTypeScript(
-                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication, settings.getExcludeFilter(), classLoader, debug),
+                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
+                            settings.getExcludeFilter(), classLoader, loggingLevel == Logger.Level.Debug),
                     Output.to(output)
             );
 


### PR DESCRIPTION
Adding global `Logger` (custom simple class) to `TypeScriptGenerator` where it is accessible to all classes and can also be changed:
- `TypeScriptGenerator.getLogger()`
- `TypeScriptGenerator.setLogger(Logger logger)`

This PR also makes possible to set logging level from Maven and Gradle plugins using `loggingLevel` parameter with possible values `Debug`, `Verbose`, `Info`, `Warning`, `Error`. Default value is `Verbose` which behaves as previous versions.

Parameters `displaySerializerWarning` and `debug` are affectively removed. They stay in code but are not used except for displaying message that they are replaced by `loggingLevel` parameter.