### PR TITLE
Generate files into different output units

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -176,7 +176,7 @@ public class Settings {
         if (outputKind == null) {
             throw new RuntimeException("Required 'outputKind' parameter is not configured. " + seeLink());
         }
-        if (outputKind == TypeScriptOutputKind.ambientModule && outputFileType == TypeScriptFileType.implementationFile) {
+        if (outputKind == TypeScriptOutputKind.ambientModule && outputFileType.isImplementation()) {
             throw new RuntimeException("Ambient modules are not supported in implementation files. " + seeLink());
         }
         if (outputKind == TypeScriptOutputKind.ambientModule && module == null) {
@@ -188,7 +188,7 @@ public class Settings {
         if (outputKind != TypeScriptOutputKind.module && umdNamespace != null) {
             throw new RuntimeException("'umdNamespace' parameter is only applicable to modules. " + seeLink());
         }
-        if (outputFileType == TypeScriptFileType.implementationFile && umdNamespace != null) {
+        if (outputFileType.isImplementation() && umdNamespace != null) {
             throw new RuntimeException("'umdNamespace' parameter is not applicable to implementation files. " + seeLink());
         }
         if (umdNamespace != null && !Emitter.isValidIdentifierName(umdNamespace)) {
@@ -204,7 +204,7 @@ public class Settings {
                 TypeScriptGenerator.getLogger().warning(String.format("Extension '%s' is deprecated: %s", extensionName, deprecation.value()));
             }
             final EmitterExtensionFeatures features = extension.getFeatures();
-            if (features.generatesRuntimeCode && outputFileType != TypeScriptFileType.implementationFile) {
+            if (features.generatesRuntimeCode && outputFileType.isDeclaration()) {
                 throw new RuntimeException(String.format("Extension '%s' generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.", extensionName));
             }
             if (features.generatesModuleCode && outputKind != TypeScriptOutputKind.module) {
@@ -232,16 +232,16 @@ public class Settings {
                 defaultStringEnumsOverriddenByExtension = true;
             }
         }
-        if (nonConstEnums && outputFileType != TypeScriptFileType.implementationFile) {
+        if (nonConstEnums && !outputFileType.isImplementation()) {
             throw new RuntimeException("Non-const enums can only be used in implementation files but 'outputFileType' parameter is not set to 'implementationFile'.");
         }
-        if (mapClasses == ClassMapping.asClasses && outputFileType != TypeScriptFileType.implementationFile) {
+        if (mapClasses == ClassMapping.asClasses && !outputFileType.isImplementation()) {
             throw new RuntimeException("'mapClasses' parameter is set to 'asClasses' which generates runtime code but 'outputFileType' parameter is not set to 'implementationFile'.");
         }
         if (mapClassesAsClassesPatterns != null && mapClasses != ClassMapping.asClasses) {
             throw new RuntimeException("'mapClassesAsClassesPatterns' parameter can only be used when 'mapClasses' parameter is set to 'asClasses'.");
         }
-        if (generateJaxrsApplicationClient && outputFileType != TypeScriptFileType.implementationFile) {
+        if (generateJaxrsApplicationClient && !outputFileType.isImplementation()) {
             throw new RuntimeException("'generateJaxrsApplicationClient' can only be used when generating implementation file ('outputFileType' parameter is 'implementationFile').");
         }
         final boolean generateJaxrs = generateJaxrsApplicationClient || generateJaxrsApplicationInterface;
@@ -296,14 +296,14 @@ public class Settings {
     }
 
     public String getExtension() {
-        return outputFileType == TypeScriptFileType.implementationFile ? ".ts" : ".d.ts";
+        return outputFileType.isImplementation() ? ".ts" : ".d.ts";
     }
 
     public void validateFileName(File outputFile) {
-        if (outputFileType == TypeScriptFileType.declarationFile && !outputFile.getName().endsWith(".d.ts")) {
+        if (outputFileType.isDeclaration() && !outputFile.getName().endsWith(".d.ts")) {
             throw new RuntimeException("Declaration file must have 'd.ts' extension: " + outputFile);
         }
-        if (outputFileType == TypeScriptFileType.implementationFile && (!outputFile.getName().endsWith(".ts") || outputFile.getName().endsWith(".d.ts"))) {
+        if (outputFileType.isImplementation() && (!outputFile.getName().endsWith(".ts") || outputFile.getName().endsWith(".d.ts"))) {
             throw new RuntimeException("Implementation file must have 'ts' extension: " + outputFile);
         }
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -87,7 +87,7 @@ public abstract class TsType implements Emittable {
 
         @Override
         public String format(Settings settings) {
-            return symbol.getFullName();
+            return settings.outputFileType.isDirectory() ? symbol.getSimpleName() : symbol.getFullName();
         }
 
     }
@@ -107,10 +107,10 @@ public abstract class TsType implements Emittable {
 
         @Override
         public String format(Settings settings) {
-            return symbol.getFullName() + "<" + Emitter.formatList(settings, typeArguments) + ">";
+            return super.format(settings) + "<" + Emitter.formatList(settings, typeArguments) + ">";
         }
     }
-    
+
     public static class GenericVariableType extends TsType.BasicType {
 
         public GenericVariableType(String name) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptFileType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptFileType.java
@@ -4,6 +4,17 @@ package cz.habarta.typescript.generator;
 
 public enum TypeScriptFileType {
 
-    declarationFile, implementationFile
+    declarationFile, implementationFile, declarationDirectory, implementationDirectory;
 
+    public boolean isDeclaration() {
+    	return this == declarationFile || this == TypeScriptFileType.declarationDirectory;
+    }
+
+    public boolean isImplementation() {
+    	return !isDeclaration();
+    }
+
+    public boolean isDirectory() {
+    	return this == declarationDirectory || this == TypeScriptFileType.implementationDirectory;
+    }
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/Symbol.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/Symbol.java
@@ -34,4 +34,9 @@ public class Symbol {
         }
     }
 
+    @Override
+    public String toString() {
+        return getFullName();
+    }
+
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/DirectoryEmitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/DirectoryEmitter.java
@@ -1,0 +1,190 @@
+package cz.habarta.typescript.generator.emitter;
+
+import java.io.File;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import cz.habarta.typescript.generator.Output;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TsProperty;
+import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.TsType.BasicArrayType;
+import cz.habarta.typescript.generator.TsType.IndexedArrayType;
+import cz.habarta.typescript.generator.TsType.ObjectType;
+import cz.habarta.typescript.generator.TsType.OptionalType;
+import cz.habarta.typescript.generator.TsType.ReferenceType;
+import cz.habarta.typescript.generator.TsType.UnionType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
+import cz.habarta.typescript.generator.compiler.Symbol;
+
+public class DirectoryEmitter extends Emitter {
+
+    private TsModel currentModel;
+
+    public DirectoryEmitter(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public void emit(TsModel model, Writer output, String outputName, boolean closeOutput, boolean forceExportKeyword, int initialIndentationLevel) {
+        initSettings(output, forceExportKeyword, initialIndentationLevel);
+        this.currentModel = model;
+
+        final boolean exportElements = settings.outputKind == TypeScriptOutputKind.module;
+
+        emitElements(model, exportElements, false);
+
+        emitUmdNamespace();
+
+        if (closeOutput) {
+            close();
+        }
+    }
+
+    @Override
+    protected void emitFullyQualifiedDeclaration(TsDeclarationModel declaration, boolean exportKeyword, boolean declareKeyword) {
+        Output fileOutput = null;
+        final File outputFile = new File(this.output.getName());
+
+        String simpleName = convertTypeScriptFileName(declaration.getName().getSimpleName());
+        String fullName = declaration.getName().getNamespace() != null ? declaration.getName().getNamespace() + "." + simpleName : simpleName;
+        String fileName = fullName.replace('.', '/') + settings.getExtension();
+        fileOutput = Output.to(new File(outputFile.getParent(), fileName));
+        Writer oldWriter = this.writer;
+        this.writer = fileOutput.getWriter();
+        TypeScriptGenerator.getLogger().info("Writing declarations to: " + fileName);
+
+        emitFileComment();
+        emitReferences();
+        emitImports();
+        emitFileImports(declaration);
+
+        super.emitDeclaration(declaration, exportKeyword, declareKeyword);
+
+        emitDirectoryExtensions(currentModel, declaration, exportKeyword);
+
+        close();
+
+        this.writer = oldWriter;
+    }
+
+    private void emitFileImports(TsDeclarationModel declaration) {
+        Set<TsType> list = new HashSet<>();
+
+        if (declaration instanceof TsBeanModel) {
+            TsBeanModel bean = (TsBeanModel) declaration;
+            collectTypes(list, bean.getAllParents());
+            collectTypes(list, bean.getProperties().stream().map(TsPropertyModel::getTsType).collect(Collectors.toList()));
+        } else if (declaration instanceof TsAliasModel) {
+            TsAliasModel alias = (TsAliasModel) declaration;
+            collectType(list, alias.getDefinition());
+        } else if (declaration instanceof TsEnumModel) {
+            // do nothing
+        } else {
+            throw new RuntimeException("Unknown declaration type: " + declaration.getClass().getName());
+        }
+
+        for (TsType tsType : list) {
+            TsType type = tsType;
+            if (type instanceof ReferenceType) {
+                ReferenceType refType = (ReferenceType) type;
+                if (refType.symbol.getNamespace() != null) {
+                    String importPath = calculateImportPath(declaration.name, refType);
+                    if (importPath != null) {
+                        writeIndentedLine("import { " + refType.symbol.getSimpleName() + " } from " + quote("./" + importPath, settings) + ";");
+                    }
+                }
+            }
+        }
+    }
+
+    private String convertTypeScriptFileName(String simpleName) {
+        return simpleName.replaceAll("(.)(\\p{Upper})", "$1-$2").toLowerCase();
+    }
+
+    private String calculateImportPath(Symbol basePath, ReferenceType refType) {
+        String baseNamespace = basePath.getNamespace();
+        String refNamespace = refType.symbol.getNamespace();
+
+        if (baseNamespace == null || basePath.equals(refType.symbol))
+            return null;
+
+        List<String> base = new ArrayList<>(Arrays.asList(baseNamespace.split("\\.")));
+        List<String> ref = new ArrayList<>(Arrays.asList(refNamespace.split("\\.")));
+
+        while (!base.isEmpty() && !ref.isEmpty() && base.get(0).equals(ref.get(0))) {
+            base.remove(0);
+            ref.remove(0);
+        }
+
+        for (int i = 0; i < base.size(); i++) {
+            ref.add(0, "..");
+        }
+
+        ref.add(convertTypeScriptFileName(refType.symbol.getSimpleName()));
+
+        return String.join("/", ref);
+    }
+
+    private void emitDirectoryExtensions(TsModel model, TsDeclarationModel declaration, boolean exportKeyword) {
+        for (EmitterExtension emitterExtension : settings.extensions) {
+            if (emitterExtension instanceof DirectoryEmitterExtension) {
+                DirectoryEmitterExtension directoryEmitter = (DirectoryEmitterExtension) emitterExtension;
+
+                final List<String> extensionLines = new ArrayList<>();
+                final EmitterExtension.Writer extensionWriter = new EmitterExtension.Writer() {
+                    @Override
+                    public void writeIndentedLine(String line) {
+                        extensionLines.add(line);
+                    }
+                };
+                directoryEmitter.emitElement(extensionWriter, settings, exportKeyword, model, declaration);
+                if (!extensionLines.isEmpty()) {
+                    writeNewLine();
+                    writeNewLine();
+                    writeIndentedLine(String.format("// Added by '%s' extension", emitterExtension.getClass().getSimpleName()));
+                    for (String line : extensionLines) {
+                        this.writeIndentedLine(line);
+                    }
+                }
+            }
+        }
+    }
+
+    private void collectTypes(Set<TsType> list, Collection<TsType> types) {
+        for (TsType type : types) {
+            collectType(list, type);
+        }
+    }
+
+    private void collectType(Set<TsType> list, TsType type) {
+        if (type instanceof BasicArrayType) {
+            collectType(list, ((BasicArrayType) type).elementType);
+        } else if (type instanceof IndexedArrayType) {
+            collectType(list, ((IndexedArrayType) type).elementType);
+            collectType(list, ((IndexedArrayType) type).indexType);
+        } else if (type instanceof ObjectType) {
+            List<TsProperty> properties = ((ObjectType) type).properties;
+            for (TsProperty tsProperty : properties) {
+                collectType(list, tsProperty.tsType);
+            }
+        } else if (type instanceof OptionalType) {
+            collectType(list, ((OptionalType) type).type);
+        } else if (type instanceof UnionType) {
+            List<TsType> types2 = ((UnionType) type).types;
+            for (TsType tsType2 : types2) {
+                collectType(list, tsType2);
+            }
+        }
+        else
+            list.add(type);
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/DirectoryEmitterExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/DirectoryEmitterExtension.java
@@ -1,0 +1,10 @@
+package cz.habarta.typescript.generator.emitter;
+
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.emitter.EmitterExtension.Writer;
+
+public interface DirectoryEmitterExtension {
+
+    void emitElement(Writer writer, Settings settings, boolean exportKeyword, TsModel model, TsDeclarationModel declaration);
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ser.*;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import cz.habarta.typescript.generator.*;
@@ -132,7 +133,7 @@ public class Jackson2Parser extends ModelParser {
             discriminantProperty = null;
             discriminantLiteral = null;
         }
-        
+
         final List<Class<?>> taggedUnionClasses;
         final JsonSubTypes jsonSubTypes = sourceClass.type.getAnnotation(JsonSubTypes.class);
         if (jsonSubTypes != null) {


### PR DESCRIPTION
The idea was to split the output into separate files, instead of putting everything into one output. First, in bigger projects a lot of files might get generated. Second, the `mapPackagesToNamespaces` wasn't really handy when it comes to using it actually in typescript.

Comments to the implementation:
- the goal was to remain API compatible with previous version. Therefore, currently the `outputFileType` has been extended. A slightly cleaner (but breaking) solution would have been, to change the _mapPackagesToNamespaces_ to `mapPackages = {toNamespaces, toFiles}` for example
- I also allowed extensions to append to those files, by adding a dedicated interface for EmitterExtensions
