### PR TITLE
Add ability to scan for classes with specific annotations

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
@@ -35,6 +35,11 @@ public class Input {
 
     public static Input fromClassNamesAndJaxrsApplication(List<String> classNames, List<String> classNamePatterns, String jaxrsApplicationClassName,
             boolean automaticJaxrsApplication, Predicate<String> isClassNameExcluded, URLClassLoader classLoader, boolean debug) {
+        return fromClassNamesAndJaxrsApplication(classNames, classNamePatterns, null, jaxrsApplicationClassName, automaticJaxrsApplication, isClassNameExcluded, classLoader, debug);
+    }
+
+    public static Input fromClassNamesAndJaxrsApplication(List<String> classNames, List<String> classNamePatterns, List<String> classesWithAnnotations, String jaxrsApplicationClassName,
+		    boolean automaticJaxrsApplication, Predicate<String> isClassNameExcluded, URLClassLoader classLoader, boolean debug) {
         Objects.requireNonNull(classLoader, "classLoader");
         final ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
@@ -46,6 +51,9 @@ public class Input {
             }
             if (classNamePatterns != null) {
                 types.addAll(fromClassNamePatterns(classpathScanner.scanClasspath(), classNamePatterns));
+            }
+            if(classesWithAnnotations != null) {
+                types.addAll(fromClassNames(classpathScanner.scanClasspath().getNamesOfClassesWithAnnotationsAnyOf(classesWithAnnotations.stream().toArray(String[]::new))));
             }
             if (jaxrsApplicationClassName != null) {
                 types.addAll(fromClassNames(Arrays.asList(jaxrsApplicationClassName)));

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -22,6 +22,7 @@ public class GenerateTask extends DefaultTask {
     public String umdNamespace;
     public List<String> classes;
     public List<String> classPatterns;
+    public List<String> classesWithAnnotations;
     public String classesFromJaxrsApplication;
     public boolean classesFromAutomaticJaxrsApplication;
     public List<String> excludeClasses;
@@ -168,7 +169,7 @@ public class GenerateTask extends DefaultTask {
 
         // TypeScriptGenerator
         new TypeScriptGenerator(settings).generateTypeScript(
-                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
+                Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesWithAnnotations, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
                         settings.getExcludeFilter(), classLoader, loggingLevel == Logger.Level.Debug),
                 Output.to(output)
         );

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -95,6 +95,13 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter
     private List<String> classPatterns;
 
+
+    /**
+     * Only retrieve classes from the classpath with the specified annotations
+     */
+    @Parameter
+    private List<String> classesWithAnnotations;
+
     /**
      * Scans specified JAX-RS {@link javax.ws.rs.core.Application} for JSON classes to process.
      * Parameter contains fully-qualified class name.
@@ -626,7 +633,7 @@ public class GenerateMojo extends AbstractMojo {
 
             // TypeScriptGenerator
             new TypeScriptGenerator(settings).generateTypeScript(
-                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
+                    Input.fromClassNamesAndJaxrsApplication(classes, classPatterns, classesWithAnnotations, classesFromJaxrsApplication, classesFromAutomaticJaxrsApplication,
                             settings.getExcludeFilter(), classLoader, loggingLevel == Logger.Level.Debug),
                     Output.to(output)
             );


### PR DESCRIPTION
Adds the parameter `classesWithAnnotations` which will run a scan on the classpath and retrieve only the classes with the given annotations.

Example usage:
````xml
    <configuration>
        <classesWithAnnotations>com.example.annotation.Expose</classesWithAnnotations>
        ...
    </configuration>
````

````java
@Expose
public class A {
    ...
}
````