### PR TITLE
Transform Java Maps to ES6 Maps

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -160,6 +160,19 @@ public abstract class TsType implements Emittable {
         }
 
     }
+    
+    public static class MapType extends IndexedArrayType {
+
+        public MapType(TsType indexType, TsType elementType) {
+            super(indexType, elementType);
+        }
+
+        @Override
+        public String format(Settings settings) {
+            return "Map<" + indexType.format(settings) + ", " + elementType.format(settings) + ">";
+        }
+
+    }
 
     public static class UnionType extends TsType {
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -285,9 +285,11 @@ public abstract class TsType implements Emittable {
         }
         if (type instanceof TsType.IndexedArrayType) {
             final TsType.IndexedArrayType indexedArrayType = (TsType.IndexedArrayType) type;
-            return new TsType.IndexedArrayType(
-                    transformTsType(context, indexedArrayType.indexType, transformer),
-                    transformTsType(context, indexedArrayType.elementType, transformer));
+            TsType indexType = transformTsType(context, indexedArrayType.indexType, transformer);
+            TsType elementType = transformTsType(context, indexedArrayType.elementType, transformer);
+            return type instanceof MapType
+                ? new TsType.MapType(indexType, elementType)
+                : new TsType.IndexedArrayType(indexType, elementType);
         }
         if (type instanceof TsType.ObjectType) {
             final TsType.ObjectType objectType = (TsType.ObjectType) type;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
@@ -22,11 +22,13 @@ public class CustomTypeMappingTest {
         assertTrue(output.contains("import * as myModule from '../src/test/ts/my-module.d.ts';"));
         assertTrue(output.contains("date1: MyDate;"));
         assertTrue(output.contains("calendar1: myModule.MyCalendar;"));
+        assertTrue(output.contains("map1: Map<MyDate, myModule.MyCalendar>;"));
     }
 
     private static class CustomTypesUsage {
         public Date date1;
         public Calendar calendar1;
+        public Map<Date, Calendar> map1;
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
@@ -18,7 +18,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Dates.class));
         Assert.assertTrue(dts.contains("date: Date;"));
         Assert.assertTrue(dts.contains("dateList: Date[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, Date[]>;"));
         Assert.assertTrue(dts.contains("dates: Date[];"));
     }
 
@@ -29,7 +29,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
         Assert.assertTrue(dts.contains("date: Date;"));
         Assert.assertTrue(dts.contains("dateList: Date[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, Date[]>;"));
         Assert.assertTrue(dts.contains("dates: Date[];"));
     }
 
@@ -40,7 +40,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Dates.class));
         Assert.assertTrue(dts.contains("date: DateAsNumber;"));
         Assert.assertTrue(dts.contains("dateList: DateAsNumber[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsNumber[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, DateAsNumber[]>;"));
         Assert.assertTrue(dts.contains("dates: DateAsNumber[];"));
         Assert.assertTrue(dts.contains("type DateAsNumber = number;"));
     }
@@ -52,7 +52,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
         Assert.assertTrue(dts.contains("date: number;"));
         Assert.assertTrue(dts.contains("dateList: number[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: number[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, number[]>;"));
         Assert.assertTrue(dts.contains("dates: number[];"));
         Assert.assertTrue(!dts.contains("type DateAsNumber = number;"));
     }
@@ -64,7 +64,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Dates.class));
         Assert.assertTrue(dts.contains("date: DateAsString;"));
         Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, DateAsString[]>;"));
         Assert.assertTrue(dts.contains("dates: DateAsString[];"));
         Assert.assertTrue(dts.contains("type DateAsString = string;"));
     }
@@ -76,7 +76,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
         Assert.assertTrue(dts.contains("date: string;"));
         Assert.assertTrue(dts.contains("dateList: string[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: string[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, string[]>;"));
         Assert.assertTrue(dts.contains("dates: string[];"));
         Assert.assertTrue(!dts.contains("type DateAsString = string;"));
     }
@@ -88,7 +88,7 @@ public class DateTest {
         final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Java8Dates.class));
         Assert.assertTrue(dts.contains("date: DateAsString;"));
         Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
+        Assert.assertTrue(dts.contains("datesMap: Map<string, DateAsString[]>;"));
         Assert.assertTrue(dts.contains("dates: DateAsString[];"));
         Assert.assertTrue(dts.contains("type DateAsString = string;"));
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
@@ -23,7 +23,7 @@ public class GenericsTest {
                 "export interface IA<U, V> {" + nl +
                 "    x: IA<string, string>;" + nl +
                 "    y: IA<IA<string, IB>, string[]>;" + nl +
-                "    z: IA<{ [index: string]: V }, number[]>;" + nl +
+                "    z: IA<Map<string, V>, number[]>;" + nl +
                 "}" + nl +
                 "" + nl +
                 "export interface IB {" + nl +
@@ -31,7 +31,7 @@ public class GenericsTest {
         assertEquals(expected, actual);
         assertEquals("IA<string, string>", TestUtils.compileType(settings, A.class.getField("x").getGenericType()).toString());
         assertEquals("IA<IA<string, IB>, string[]>", TestUtils.compileType(settings, A.class.getField("y").getGenericType()).toString());
-        assertEquals("IA<{ [index: string]: V }, number[]>", TestUtils.compileType(settings, A.class.getField("z").getGenericType()).toString());
+        assertEquals("IA<Map<string, V>, number[]>", TestUtils.compileType(settings, A.class.getField("z").getGenericType()).toString());
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
@@ -18,7 +18,7 @@ public class ModelCompilerTest {
     public void testEnum() throws Exception {
         final Settings settings = getTestSettings();
         final Type javaType = A.class.getField("directions").getGenericType();
-        Assert.assertEquals("{ [index: string]: Direction }[]", TestUtils.compileType(settings, javaType).toString());
+        Assert.assertEquals("Map<string, Direction>[]", TestUtils.compileType(settings, javaType).toString());
     }
 
     @Test
@@ -32,7 +32,7 @@ public class ModelCompilerTest {
     public void testExclusion() throws Exception {
         final Settings settings = getTestSettings(Direction.class.getName());
         final Type javaType = A.class.getField("directions").getGenericType();
-        Assert.assertEquals("{ [index: string]: any }[]", TestUtils.compileType(settings, javaType).toString());
+        Assert.assertEquals("Map<string, any>[]", TestUtils.compileType(settings, javaType).toString());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class ModelCompilerTest {
         final Settings settings = TestUtils.settings();
         settings.setExcludeFilter(null, Arrays.asList("**Direction"));
         final Type javaType = A.class.getField("directions").getGenericType();
-        Assert.assertEquals("{ [index: string]: any }[]", TestUtils.compileType(settings, javaType).toString());
+        Assert.assertEquals("Map<string, any>[]", TestUtils.compileType(settings, javaType).toString());
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
@@ -30,7 +30,7 @@ public class SwaggerTest {
         Assert.assertTrue(output.contains("testOperation1(): RestResponse<TestResponse>;"));
         Assert.assertTrue(output.contains("testOperation2(): RestResponse<TestResponse[]>;"));
         Assert.assertTrue(output.contains("testOperation3(): RestResponse<TestResponse[]>;"));
-        Assert.assertTrue(output.contains("testOperation4(): RestResponse<{ [index: string]: TestResponse }>;"));
+        Assert.assertTrue(output.contains("testOperation4(): RestResponse<Map<string, TestResponse>>;"));
         Assert.assertTrue(!output.contains("testHiddenOperation"));
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
@@ -32,6 +32,7 @@ public class TsTypeTest {
         assertEquals("(string | number)[]", new BasicArrayType(new UnionType(Arrays.asList(String, Number))).format(settings));
         assertEquals("(string | number)[][]", new BasicArrayType(new BasicArrayType(new UnionType(Arrays.asList(String, Number)))).format(settings));
         assertEquals("{ [index: string]: string | number }", new IndexedArrayType(String, new UnionType(Arrays.asList(String, Number))).format(settings));
+        assertEquals("Map<string, any>", new MapType(String, Any).format(settings));
     }
 
     @Test

--- a/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTest-expected.ts
+++ b/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTest-expected.ts
@@ -6,11 +6,11 @@ export class User {
     age: number;
     address: Address;
     addresses: Address[];
-    taggedAddresses: { [index: string]: Address };
-    groupedAddresses: { [index: string]: Address[] };
-    listOfTaggedAddresses: { [index: string]: Address }[];
+    taggedAddresses: Map<string, Address>;
+    groupedAddresses: Map<string, Address[]>;
+    listOfTaggedAddresses: Map<string, Address>[];
     tags: string[];
-    mapping: { [index: string]: string };
+    mapping: Map<string, string>;
     listOfListOfString: string[][];
     orders: PagedList<Order, Authentication>;
     allOrders: PagedList<Order, Authentication>[];


### PR DESCRIPTION
References #236

The Java Map objects are now transformed into Map and not into indexed array. 