### PR TITLE
Add extension point before TsModel generation

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -42,6 +42,7 @@ public class ModelCompiler {
     }
 
     public enum TransformationPhase {
+        BeforeTsModel,
         BeforeEnums,
         BeforeSymbolResolution,
     }
@@ -49,6 +50,7 @@ public class ModelCompiler {
     public TsModel javaToTypeScript(Model model) {
         final SymbolTable symbolTable = new SymbolTable(settings);
         final List<Extension.TransformerDefinition> extensionTransformers = getExtensionTransformers();
+        model = applyExtensionModelTransformers(symbolTable, model, extensionTransformers);
         TsModel tsModel = processModel(symbolTable, model);
         tsModel = removeInheritedProperties(symbolTable, tsModel);
         tsModel = addImplementedProperties(symbolTable, tsModel);
@@ -110,6 +112,15 @@ public class ModelCompiler {
             }
         }
         return transformers;
+    }
+
+    private static Model applyExtensionModelTransformers(SymbolTable symbolTable, Model model, List<Extension.TransformerDefinition> transformerDefinitions) {
+        for (Extension.TransformerDefinition definition : transformerDefinitions) {
+            if (definition.phase == TransformationPhase.BeforeTsModel) {
+                model = definition.transformer.transformModel(symbolTable, model);
+            }
+        }
+        return model;
     }
 
     private static TsModel applyExtensionTransformers(SymbolTable symbolTable, TsModel model, TransformationPhase phase, List<Extension.TransformerDefinition> transformerDefinitions) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelTransformer.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelTransformer.java
@@ -2,10 +2,15 @@
 package cz.habarta.typescript.generator.compiler;
 
 import cz.habarta.typescript.generator.emitter.TsModel;
+import cz.habarta.typescript.generator.parser.Model;
 
 
 public interface ModelTransformer {
 
     public TsModel transformModel(SymbolTable symbolTable, TsModel model);
+
+    default Model transformModel(SymbolTable symbolTable, Model model) {
+        return model;
+    }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ExtensionTest.java
@@ -1,0 +1,71 @@
+package cz.habarta.typescript.generator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import cz.habarta.typescript.generator.compiler.ModelCompiler;
+import cz.habarta.typescript.generator.compiler.ModelCompiler.TransformationPhase;
+import cz.habarta.typescript.generator.compiler.ModelTransformer;
+import cz.habarta.typescript.generator.compiler.SymbolTable;
+import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
+import cz.habarta.typescript.generator.emitter.TsModel;
+import cz.habarta.typescript.generator.parser.BeanModel;
+import cz.habarta.typescript.generator.parser.Jackson2Parser;
+import cz.habarta.typescript.generator.parser.Model;
+
+public class ExtensionTest {
+
+    @Test
+    public void testBeforeTsExtension() throws Exception {
+        final Settings settings = TestUtils.settings();
+
+        settings.extensions.add(new Extension() {
+
+            @Override
+            public EmitterExtensionFeatures getFeatures() {
+                return new EmitterExtensionFeatures();
+            }
+
+            @Override
+            public List<TransformerDefinition> getTransformers() {
+                return Collections.singletonList(new TransformerDefinition(TransformationPhase.BeforeTsModel, new ModelTransformer() {
+
+                    @Override
+                    public TsModel transformModel(SymbolTable symbolTable, TsModel model) {
+                        return model;
+                    }
+
+                    @Override
+                    public Model transformModel(SymbolTable symbolTable, Model model) {
+                        List<BeanModel> beans = new ArrayList<>(model.getBeans());
+
+                        BeanModel implementationBean = model.getBean(Implementation.class);
+                        BeanModel beanWithComments = implementationBean.withComments(Collections.singletonList("My new comment"));
+
+                        beans.remove(implementationBean);
+                        beans.add(beanWithComments);
+
+                        return new Model(beans, model.getEnums(), model.getJaxrsApplication());
+                    }
+                }));
+            }
+        });
+
+        final Jackson2Parser jacksonParser = new Jackson2Parser(settings, new DefaultTypeProcessor());
+        final Model model = jacksonParser.parseModel(Implementation.class);
+        final ModelCompiler modelCompiler = new TypeScriptGenerator(settings).getModelCompiler();
+
+        final TsModel result = modelCompiler.javaToTypeScript(model);
+
+        Assert.assertEquals(1, result.getBean(Implementation.class).getComments().size());
+        Assert.assertThat(result.getBean(Implementation.class).getComments().get(0), CoreMatchers.containsString("My new comment"));
+    }
+
+    private static class Implementation { }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ExtensionTest.java
@@ -1,13 +1,5 @@
 package cz.habarta.typescript.generator;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
-
 import cz.habarta.typescript.generator.compiler.ModelCompiler;
 import cz.habarta.typescript.generator.compiler.ModelCompiler.TransformationPhase;
 import cz.habarta.typescript.generator.compiler.ModelTransformer;
@@ -17,6 +9,12 @@ import cz.habarta.typescript.generator.emitter.TsModel;
 import cz.habarta.typescript.generator.parser.BeanModel;
 import cz.habarta.typescript.generator.parser.Jackson2Parser;
 import cz.habarta.typescript.generator.parser.Model;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class ExtensionTest {
 


### PR DESCRIPTION
As a finding of #250 I extended the ExtensionTransformer to be able to transform not only a `TsModel` but also a `Model`. This for example now allows to easily add class or method comments to the model, or perform some changes to the original model before it is actually converted to TS. 