### PR TITLE
Class enum compatibility with regular enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ nbactions.xml
 
 # JetBrains IntelliJ
 .idea/
-**.iml
+*.iml
 
 # VS Code
 .vscode

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/ClassEnumExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/ClassEnumExtension.java
@@ -39,7 +39,6 @@ public class ClassEnumExtension extends Extension {
             @Override
             public TsModel transformModel(SymbolTable symbolTable, TsModel model) {
                 List<TsBeanModel> beans = model.getBeans();
-
                 List<TsBeanModel> classEnums = new ArrayList<>();
                 for (TsBeanModel bean : beans) {
                     if (bean.getName().getSimpleName().contains(classEnumPattern))
@@ -65,6 +64,7 @@ public class ClassEnumExtension extends Extension {
                     stringEnums.add(temp);
                 }
 
+                stringEnums.addAll(model.getEnums());
                 return model.withEnums(stringEnums).withoutBeans(classEnums);
             }
         }));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -5,9 +5,15 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import cz.habarta.typescript.generator.ext.ClassEnumExtension;
-import java.util.*;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class EnumTest {
@@ -95,21 +101,26 @@ public class EnumTest {
     }
 
     @Test
-    public void testClassAsEnum() {
+    public void testEnumsWithClassEnumPattern() {
         final Settings settings = TestUtils.settings();
         settings.mapEnum = EnumMapping.asEnum;
-        settings.jsonLibrary = JsonLibrary.jaxb;
+        settings.jsonLibrary = JsonLibrary.jackson2;
         final ClassEnumExtension classEnumExtension = new ClassEnumExtension();
-        classEnumExtension.setConfiguration(Collections.singletonMap("classEnumPattern", "ClassEnum"));
+        classEnumExtension.setConfiguration(Collections.singletonMap("classEnumPattern", "Enum"));
         settings.extensions.add(classEnumExtension);
-        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyClassEnum.class));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class));
         final String expected = (
-            "\ndeclare const enum DummyClassEnum {\n" +
-            "    ATYPE = 'ATYPE',\n" +
-            "    BTYPE = 'BTYPE',\n" +
-            "    CTYPE = 'CTYPE',\n" +
-            "}\n"
-        ).replace("'", "\"");
+                "\ndeclare const enum DummyClassEnum {\n" +
+                        "    ATYPE = 'ATYPE',\n" +
+                        "    BTYPE = 'BTYPE',\n" +
+                        "    CTYPE = 'CTYPE',\n" +
+                        "}\n" +
+                "\ndeclare const enum DummyEnum {\n" +
+                        "    Red = 'Red',\n" +
+                        "    Green = 'Green',\n" +
+                        "    Blue = 'Blue',\n" +
+                        "}\n"
+                ).replace("'", "\"");
         assertEquals(expected.trim(), output.trim());
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -5,10 +5,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import cz.habarta.typescript.generator.ext.ClassEnumExtension;
-import org.junit.Test;
-
 import java.util.*;
 import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class EnumTest {
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -7,14 +7,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import cz.habarta.typescript.generator.ext.ClassEnumExtension;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import java.util.*;
+import static org.junit.Assert.*;
 
 public class EnumTest {
 


### PR DESCRIPTION
I haven't seen this codebase since it's been merged with the [class enum PR](https://github.com/vojtechhabarta/typescript-generator/pull/194) as an extension. Very nice! 

I have recently started using the `ClassEnumExtension` in another project and I found an edge case where there are both enums and class based enums that contain the `classEnumPattern`. In this case, the regular enums do not get processed at all. Now it also returns enum models in the `TransformerDefinition`.

Also, I fixed the .gitignore for `.iml` files since it was getting picked up on my local.