### PR TITLE
expose noTsLintDisable setting to plugins

### DIFF
--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -61,6 +61,7 @@ public class GenerateTask extends DefaultTask {
     public boolean sortDeclarations;
     public boolean sortTypeDeclarations;
     public boolean noFileComment;
+    public boolean noTslintDisable;
     public List<File> javadocXmlFiles;
     public List<String> extensionClasses;
     public List<String> extensions;
@@ -151,6 +152,7 @@ public class GenerateTask extends DefaultTask {
         settings.sortDeclarations = sortDeclarations;
         settings.sortTypeDeclarations = sortTypeDeclarations;
         settings.noFileComment = noFileComment;
+        settings.noTslintDisable = noTslintDisable;
         settings.javadocXmlFiles = javadocXmlFiles;
         settings.loadExtensions(classLoader, Utils.concat(extensionClasses, extensions), extensionsWithConfiguration);
         settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -433,6 +433,14 @@ public class GenerateMojo extends AbstractMojo {
     private boolean noFileComment;
 
     /**
+     * If <code>true</code> generated file will be linted by TsLint.
+     * By default there is a {@code tslint:disable } comment that will force TsLint to ignore the generated file.
+     * This can be enabled to supress this comment so that the file can be linted by TsLint.
+     */
+    @Parameter
+    private boolean noTslintDisable;
+
+    /**
      * List of Javadoc XML files to search for documentation comments.
      * These files should be created using <code>com.github.markusbernhardt.xmldoclet.XmlDoclet</code> from <code>com.github.markusbernhardt:xml-doclet</code> artifact.
      * Javadoc comments are added to output declarations as JSDoc comments.
@@ -630,6 +638,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.sortDeclarations = sortDeclarations;
             settings.sortTypeDeclarations = sortTypeDeclarations;
             settings.noFileComment = noFileComment;
+            settings.noTslintDisable = noTslintDisable;
             settings.javadocXmlFiles = javadocXmlFiles;
             settings.loadExtensions(classLoader, extensions, extensionsWithConfiguration);
             settings.loadIncludePropertyAnnotations(classLoader, includePropertyAnnotations);


### PR DESCRIPTION
Prior to release `v2.1.410`, the generated file would be linted which in some cases is preferred. This setting was not being exposed through the plugins and I can no longer lint my generated file if I choose.