### PR TITLE
@JsonValue doesn't correctly work for number-typed methods

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -332,7 +332,7 @@ public class Jackson2Parser extends ModelParser {
                     } else if (isNumberBased) {
                         value = getNumberEnumValue(constant, valueMethod, index++);
                     } else {
-                        value = getStringEnumValue(constant, valueMethod);
+                        value = getMethodEnumValue(constant, valueMethod);
                     }
 
                     if (value instanceof String) {
@@ -362,11 +362,11 @@ public class Jackson2Parser extends ModelParser {
         return index;
     }
 
-    private String getStringEnumValue(Field field, Method valueMethod) throws Exception {
+    private Object getMethodEnumValue(Field field, Method valueMethod) throws Exception {
         if (valueMethod != null) {
             final Object valueObject = invokeJsonValueMethod(field, valueMethod);
-            if (valueObject instanceof String) {
-                return (String) valueObject;
+            if (valueObject instanceof String || valueObject instanceof Number) {
+                return valueObject;
             }
         }
         if (field.isAnnotationPresent(JsonProperty.class)) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -191,6 +191,16 @@ public class Jackson2ParserTest {
     }
 
     @Test
+    public void testJsonNumberFieldValuedEnum() {
+        testEnumByType(TestEnums.NumberFieldValuedEnum.class, 1, 2, 3);
+    }
+
+    @Test
+    public void testJsonNumberMethodValuedEnum() {
+        testEnumByType(TestEnums.NumberMethodValuedEnum.class, 1, 2, 3);
+    }
+
+    @Test
     public void testMethodEnumValue() {
         testEnumByType(TestEnums.GeneralMethodValuedEnum.class, "_A", "_B", "_C");
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
@@ -17,6 +17,32 @@ public class TestEnums {
         }
     }
 
+    public enum NumberFieldValuedEnum {
+        A(1), B(2), C(3);
+
+        @JsonValue
+        private int value;
+
+        NumberFieldValuedEnum(int value) {
+            this.value = value;
+        }
+    }
+    
+    public enum NumberMethodValuedEnum {
+        A(1), B(2), C(3);
+
+        private int value;
+
+        NumberMethodValuedEnum(int value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public int getValue() {
+            return value;
+        }
+    }
+
     public enum ToStringValuedEnum {
         A, B, C;
 


### PR DESCRIPTION
`@JsonValue` can be indicated to set a custom value for enums. It works fine for strings. But it appeared, that for number it only worked on a field, but not on a method.
This PR one adds a fix + some tests for that (the first test, already worked without the fix)