### PR TITLE
Ignore BeanParam parameters when looking for EntityParameter

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-
+import javax.ws.rs.BeanParam;
 
 public class JaxrsApplicationParser {
 
@@ -260,7 +260,8 @@ public class JaxrsApplicationParser {
                     HeaderParam.class,
                     Suspended.class,
                     Context.class,
-                    FormParam.class
+                    FormParam.class,
+                    BeanParam.class
                     ))) {
                 return new MethodParameterModel(parameter.getName(), parameter.getParameterizedType());
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -14,6 +14,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
@@ -29,7 +30,6 @@ import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.BeanParam;
 
 public class JaxrsApplicationParser {
 


### PR DESCRIPTION
When trying to determine the entity parameter for JAX-RS methods the BeanParam annotation should also be ignored. I have not compiled this PR but it is a simple change from quickly looking at the source code.