### PR TITLE
Enum values using `toString()` method, internal change

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2Configuration.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2Configuration.java
@@ -45,4 +45,15 @@ public class Jackson2Configuration {
      */
     public List<String> shapeConfigOverrides;
 
+    /**
+     * Feature that determines standard Enum values representation:
+     * if enabled, return value of <code>Enum.toString()</code> is used;
+     * if disabled, return value of <code>Enum.name()</code> is used.<br>
+     * (In <code>ObjectMapper</code> this feature is controlled using
+     * <code>SerializationFeature.WRITE_ENUMS_USING_TO_STRING</code> and
+     * <code>DeserializationFeature.READ_ENUMS_USING_TO_STRING</code> constants.)<br>
+     * Default value is <code>false</code>.
+     */
+    public boolean enumsUsingToString;
+
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolved.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolved.java
@@ -16,6 +16,7 @@ public class Jackson2ConfigurationResolved {
     public JsonAutoDetect.Visibility setterVisibility;
     public JsonAutoDetect.Visibility creatorVisibility;
     public Map<Class<?>, JsonFormat.Shape> shapeConfigOverrides;
+    public boolean enumsUsingToString;
 
     public static Jackson2ConfigurationResolved from(Jackson2Configuration configuration, ClassLoader classLoader) {
         final Jackson2ConfigurationResolved resolved = new Jackson2ConfigurationResolved();
@@ -26,6 +27,7 @@ public class Jackson2ConfigurationResolved {
         resolved.creatorVisibility = configuration.creatorVisibility;
         resolved.fieldVisibility = configuration.fieldVisibility;
         resolved.shapeConfigOverrides = resolveShapeConfigOverrides(configuration.shapeConfigOverrides, classLoader);
+        resolved.enumsUsingToString = configuration.enumsUsingToString;
         return resolved;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -129,12 +129,36 @@ public class EnumTest {
     }
 
     @Test
-    public void testEnumWithJsonValueAnnotation() {
+    public void testEnumWithJsonValueMethodAnnotation() {
         final Settings settings = TestUtils.settings();
-        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueAnnotations.class));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueMethodAnnotation.class));
         final String expected = (
                 "\n" +
-                "type SideWithJsonValueAnnotations = 'left-side' | 'right-side';\n"
+                "type SideWithJsonValueMethodAnnotation = 'left-side' | 'right-side';\n"
+                ).replace("'", "\"");
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testEnumWithJsonValueFieldAnnotation() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueFieldAnnotation.class));
+        final String expected = (
+                "\n" +
+                "type SideWithJsonValueFieldAnnotation = 'left-side' | 'right-side';\n"
+                ).replace("'", "\"");
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testEnumUsingToString() {
+        final Settings settings = TestUtils.settings();
+        settings.jackson2Configuration = new Jackson2ConfigurationResolved();
+        settings.jackson2Configuration.enumsUsingToString = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideUsingToString.class));
+        final String expected = (
+                "\n" +
+                "type SideUsingToString = 'toString:left-side' | 'toString:right-side';\n"
                 ).replace("'", "\"");
         assertEquals(expected, output);
     }
@@ -188,7 +212,7 @@ public class EnumTest {
         Right
     }
 
-    enum SideWithJsonValueAnnotations {
+    enum SideWithJsonValueMethodAnnotation {
         @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
         Left("left-side"),
         @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
@@ -196,13 +220,50 @@ public class EnumTest {
 
         private final String jsonValue;
 
-        private SideWithJsonValueAnnotations(String jsonValue) {
+        private SideWithJsonValueMethodAnnotation(String jsonValue) {
             this.jsonValue = jsonValue;
         }
 
         @JsonValue
         public Object getJsonValue() {
             return jsonValue;
+        }
+    }
+
+    enum SideWithJsonValueFieldAnnotation {
+        @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
+        Left("left-side"),
+        @JsonProperty("@JsonProperty ignored since @JsonValue has higher precedence")
+        Right("right-side");
+
+        @JsonValue
+        private final String jsonValue;
+
+        private SideWithJsonValueFieldAnnotation(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        @Override
+        public String toString() {
+            return "AAA " + name();
+        }
+    }
+
+    enum SideUsingToString {
+        @JsonProperty("@JsonProperty ignored since toString() has higher precedence")
+        Left("left-side"),
+        @JsonProperty("@JsonProperty ignored since toString() has higher precedence")
+        Right("right-side");
+
+        private final String jsonValue;
+
+        private SideUsingToString(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        @Override
+        public String toString() {
+            return "toString:" + jsonValue;
         }
     }
 


### PR DESCRIPTION
Firstly, I want to summarize how Jackson determines enum value when serializing enum constant to JSON. Jackson ObjectMapper offers several ways how user can define the value, here is a list of these possibilities ordered from highest precedence:

1. `@JsonValue` annotation on _method_ or _field_
2. Value from `Enum.toString()` method (when `SerializationFeature.WRITE_ENUMS_USING_TO_STRING` is enabled)
3. `@JsonProperty("value")` annotation on enum constant
4. Value of `Enum.name()` method (constant name)

**From user's perspective** typescript-generator supported points 1, 3 and 4. With this PR it also supports point 2. By setting `jackson2Configuration.enumsUsingToString` configuration parameter to `true` it is now possible to use `toString()` method instead of `name()`.

**Internally** this PR changes how typescript-generator determines enum values. Previously it handled all these ways on its own, now it calls ObjectMapper to get the right value. Advantage of this is better consistency with Jackson behavior (not reimplementing the same behavior).