### PR TITLE
Preserve indentation, allowing code examples to be formatted correctly

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -214,7 +214,7 @@ public class Utils {
     }
 
     public static List<String> readLines(InputStream stream) {
-        return splitMultiline(readString(stream), false);        
+        return splitMultiline(readString(stream), false);
     }
 
     public static String readString(InputStream stream) {
@@ -234,9 +234,16 @@ public class Utils {
         final List<String> result = new ArrayList<>();
         final String[] lines = text.split("\\r\\n|\\n|\\r");
         for (String line : lines) {
-            result.add(trimLines ? line.trim() : line);
+            result.add(trimLines ? trimOneLeadingSpaceOnly(line) : line);
         }
         return result;
+    }
+
+    private static String trimOneLeadingSpaceOnly(String line) {
+        if (line.startsWith(" ")) {
+            return line.substring(1);
+        }
+        return line;
     }
 
     public static File replaceExtension(File file, String newExtension) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -40,7 +40,9 @@ public class JavadocTest {
             Assert.assertNull(property.getComments());
         }
         {
-            final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithJavadoc.class, InterfaceWithJavadoc.class));
+            final String generated = new TypeScriptGenerator(settings).generateTypeScript(
+                    Input.from(ClassWithJavadoc.class, InterfaceWithJavadoc.class, ClassWithEmbeddedExample.class));
+
             Assert.assertTrue(generated.contains("Documentation for ClassWithJavadoc. First line."));
             Assert.assertTrue(generated.contains("Second line."));
             Assert.assertTrue(generated.contains("Documentation for documentedField."));
@@ -52,6 +54,9 @@ public class JavadocTest {
             Assert.assertTrue(generated.contains("Documentation for interface getter property."));
             Assert.assertTrue(generated.contains("@return value of getterPropery"));
             Assert.assertTrue(generated.contains("@deprecated replaced by something else"));
+
+            Assert.assertTrue(generated.contains(" *     // indentation and line breaks are kept\n * \n *     {@literal @}"));
+            Assert.assertTrue(generated.contains(" *     public List<String> generics() {\n"));
         }
     }
 
@@ -104,6 +109,26 @@ public class JavadocTest {
     public static class ClassWithoutJavadoc {
 
         public String undocumentedField;
+
+    }
+
+    /**
+     * This class comes with an embedded example!
+     *
+     * <pre>{@code
+     * public class Example {
+     *     // indentation and line breaks are kept
+     *
+     *     {@literal @}SuppressWarnings
+     *     public List<String> generics() {
+     *         return null;
+     *     }
+     * }
+     * }</pre>
+     */
+    public static class ClassWithEmbeddedExample {
+
+        public String field;
 
     }
 


### PR DESCRIPTION
I noticed that traditional JavaDoc (`{@code}`) or Markdown-styled (```) examples embedded inside of comments would lose their formatting and indentation. 

This patch modifies the trimming to be just enough.