### PR TITLE
Added additional options for optional property declarations

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalPropertiesDeclaration.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalPropertiesDeclaration.java
@@ -3,7 +3,9 @@ package cz.habarta.typescript.generator;
 
 
 public enum OptionalPropertiesDeclaration {
-    questionMark,
     nullableType,
+    nullableTypeAndUndefined,
+    questionMark,
     questionMarkAndNullableType,
+    undefined,
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalPropertiesDeclaration.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/OptionalPropertiesDeclaration.java
@@ -3,9 +3,9 @@ package cz.habarta.typescript.generator;
 
 
 public enum OptionalPropertiesDeclaration {
-    nullableType,
-    nullableTypeAndUndefined,
     questionMark,
     questionMarkAndNullableType,
-    undefined,
+    nullableType,
+    nullableAndUndefinableType,
+    undefinableType,
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -764,6 +764,14 @@ public class ModelCompiler {
                                                 new TsType.OptionalType(
                                                         new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Null))));
                                     }
+                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.nullableTypeAndUndefined) {
+                                        return property.setTsType(
+                                                new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Null, TsType.Undefined)));
+                                    }
+                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.undefined) {
+                                        return property.setTsType(
+                                                new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Undefined)));
+                                    }
                                 }
                                 return property;
                             })

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -764,11 +764,11 @@ public class ModelCompiler {
                                                 new TsType.OptionalType(
                                                         new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Null))));
                                     }
-                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.nullableTypeAndUndefined) {
+                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.nullableAndUndefinableType) {
                                         return property.setTsType(
                                                 new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Null, TsType.Undefined)));
                                     }
-                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.undefined) {
+                                    if (settings.optionalPropertiesDeclaration == OptionalPropertiesDeclaration.undefinableType) {
                                         return property.setTsType(
                                                 new TsType.UnionType(Arrays.asList(optionalType.type, TsType.Undefined)));
                                     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
@@ -82,8 +82,8 @@ public class OptionalTest {
     }
 
     @Test
-    public void testDeclarationNullableTypeAndUndefined() {
-        testDeclaration(OptionalPropertiesDeclaration.nullableTypeAndUndefined,
+    public void testDeclarationNullableAndUndefinableType() {
+        testDeclaration(OptionalPropertiesDeclaration.nullableAndUndefinableType,
                 "interface Person {\n" +
                         "    name: string;\n" +
                         "    email: string | null | undefined;\n" +
@@ -93,8 +93,8 @@ public class OptionalTest {
     }
 
     @Test
-    public void testDeclarationUndefined() {
-        testDeclaration(OptionalPropertiesDeclaration.undefined,
+    public void testDeclarationUndefinableType() {
+        testDeclaration(OptionalPropertiesDeclaration.undefinableType,
                 "interface Person {\n" +
                         "    name: string;\n" +
                         "    email: string | undefined;\n" +

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
@@ -81,6 +81,28 @@ public class OptionalTest {
         );
     }
 
+    @Test
+    public void testDeclarationNullableTypeAndUndefined() {
+        testDeclaration(OptionalPropertiesDeclaration.nullableTypeAndUndefined,
+                "interface Person {\n" +
+                        "    name: string;\n" +
+                        "    email: string | null | undefined;\n" +
+                        "    age: number | null | undefined;\n" +
+                        "}"
+        );
+    }
+
+    @Test
+    public void testDeclarationUndefined() {
+        testDeclaration(OptionalPropertiesDeclaration.undefined,
+                "interface Person {\n" +
+                        "    name: string;\n" +
+                        "    email: string | undefined;\n" +
+                        "    age: number | undefined;\n" +
+                        "}"
+        );
+    }
+
     private static void testDeclaration(OptionalPropertiesDeclaration declaration, String expected) {
         final Settings settings = TestUtils.settings();
         settings.optionalPropertiesDeclaration = declaration;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -212,10 +212,10 @@ public class GenerateMojo extends AbstractMojo {
      * Supported values are:
      * <ul>
      * <li><code>questionMark</code> - property will be marked using <code>?</code> character as optional</li>
-     * <li><code>nullableType</code> - property will not be optional but its type will be union with <code>null</code> value</li>
-     * <li><code>nullableTypeAndUndefined</code> - property will not be optional but its type will be union with <code>null</code> and <code>undefined</code> values</li>
      * <li><code>questionMarkAndNullableType</code> - property will be optional and it will also have union with <code>null</code> value</li>
-     * <li><code>undefined</code> - property will not be optional but its type will be union with <code>undefined</code> value</li>
+     * <li><code>nullableType</code> - property will not be optional but its type will be union with <code>null</code> value</li>
+     * <li><code>nullableAndUndefinableType</code> - property will not be optional but its type will be union with <code>null</code> and <code>undefined</code> values</li>
+     * <li><code>undefinableType</code> - property will not be optional but its type will be union with <code>undefined</code> value</li>
      * </ul>
      * Default value is <code>questionMark</code>.
      */

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -213,7 +213,9 @@ public class GenerateMojo extends AbstractMojo {
      * <ul>
      * <li><code>questionMark</code> - property will be marked using <code>?</code> character as optional</li>
      * <li><code>nullableType</code> - property will not be optional but its type will be union with <code>null</code> value</li>
+     * <li><code>nullableTypeAndUndefined</code> - property will not be optional but its type will be union with <code>null</code> and <code>undefined</code> values</li>
      * <li><code>questionMarkAndNullableType</code> - property will be optional and it will also have union with <code>null</code> value</li>
+     * <li><code>undefined</code> - property will not be optional but its type will be union with <code>undefined</code> value</li>
      * </ul>
      * Default value is <code>questionMark</code>.
      */


### PR DESCRIPTION
**Undefined use case:**
Properties in interfaces that can be undefined but are not optional to implement for classes implementing the interface. 

**Null or undefined use case:**
Same as the use case for undefined, but additionally we see a usage when doing partial resource updates undefined means "do not update property" whereas null means "set property to null in Java", i.e. deserialized to something like:
Optional<String> property = null;
Optional<String> property = Optional.ofNullable(null);
