### PR TITLE
Allow setting constructor on bean model

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -133,6 +133,10 @@ public class TsBeanModel extends TsDeclarationModel {
         return constructor;
     }
 
+    public TsBeanModel withConstructor(TsConstructorModel constructor) {
+        return new TsBeanModel(origin, category, isClass, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+    }
+
     public List<TsMethodModel> getMethods() {
         return methods;
     }


### PR DESCRIPTION
Constructor field in `TsBeanModel` looks like it could be changed (with clone-and-set), but there's method missing. This pull request adds the method.
This method is required for extension which adds constructor with required fields to the generated code.