### PR TITLE
Extension for generating constructors with required properties 

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
@@ -1,0 +1,110 @@
+package cz.habarta.typescript.generator.ext;
+
+import cz.habarta.typescript.generator.Extension;
+import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.compiler.ModelCompiler;
+import cz.habarta.typescript.generator.compiler.ModelTransformer;
+import cz.habarta.typescript.generator.compiler.SymbolTable;
+import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
+import cz.habarta.typescript.generator.emitter.TsAssignmentExpression;
+import cz.habarta.typescript.generator.emitter.TsBeanModel;
+import cz.habarta.typescript.generator.emitter.TsConstructorModel;
+import cz.habarta.typescript.generator.emitter.TsExpression;
+import cz.habarta.typescript.generator.emitter.TsExpressionStatement;
+import cz.habarta.typescript.generator.emitter.TsIdentifierReference;
+import cz.habarta.typescript.generator.emitter.TsMemberExpression;
+import cz.habarta.typescript.generator.emitter.TsModel;
+import cz.habarta.typescript.generator.emitter.TsModifierFlags;
+import cz.habarta.typescript.generator.emitter.TsParameterModel;
+import cz.habarta.typescript.generator.emitter.TsPropertyModel;
+import cz.habarta.typescript.generator.emitter.TsStatement;
+import cz.habarta.typescript.generator.emitter.TsStringLiteral;
+import cz.habarta.typescript.generator.emitter.TsThisExpression;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adds constructor with each required property to every generated class.
+ */
+public class RequiredPropertyConstructorExtension extends Extension {
+    @Override
+    public EmitterExtensionFeatures getFeatures() {
+        EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+        features.generatesRuntimeCode = true;
+        return features;
+    }
+
+    @Override
+    public List<TransformerDefinition> getTransformers() {
+        return Arrays.asList(new TransformerDefinition(ModelCompiler.TransformationPhase.BeforeEnums, new ModelTransformer() {
+            @Override
+            public TsModel transformModel(SymbolTable symbolTable, TsModel model) {
+                List<TsBeanModel> beans = new ArrayList<>();
+                for (TsBeanModel bean : model.getBeans()) {
+                    TsBeanModel newBean = transformBean(bean);
+                    beans.add(newBean);
+                }
+                return model.withBeans(beans);
+            }
+        }));
+    }
+
+    private static TsBeanModel transformBean(TsBeanModel bean) {
+        if (!bean.isClass() || bean.getConstructor() != null) {
+            return bean;
+        }
+        Optional<TsConstructorModel> constructorOption = createConstructor(bean);
+        if (!constructorOption.isPresent()) {
+            return bean;
+        }
+        return bean.withConstructor(constructorOption.get());
+    }
+
+    private static Optional<TsConstructorModel> createConstructor(TsBeanModel bean) {
+        List<TsParameterModel> parameters = new ArrayList<>();
+        List<TsStatement> body = new ArrayList<>();
+        for (TsPropertyModel property : bean.getProperties()) {
+            if (!property.modifiers.isReadonly) {
+                continue;
+            }
+            TsExpression assignmentExpression;
+            Optional<TsExpression> predefinedValue = getPredefinedValueForProperty(property);
+            if (predefinedValue.isPresent()) {
+                assignmentExpression = predefinedValue.get();
+            } else {
+                parameters.add(new TsParameterModel(property.name, property.tsType));
+                assignmentExpression = new TsIdentifierReference(property.name);
+            }
+            TsMemberExpression leftHandSideExpression = new TsMemberExpression(new TsThisExpression(), property.name);
+            TsExpression assignment = new TsAssignmentExpression(leftHandSideExpression, assignmentExpression);
+            TsExpressionStatement assignmentStatement = new TsExpressionStatement(assignment);
+            body.add(assignmentStatement);
+        }
+        if(parameters.isEmpty() && body.isEmpty()) {
+            return Optional.empty();
+        }
+        TsConstructorModel constructor = new TsConstructorModel(TsModifierFlags.None, parameters, body, null);
+        return Optional.of(constructor);
+    }
+
+    private static Optional<TsExpression> getPredefinedValueForProperty(TsPropertyModel property) {
+        if (!(property.tsType instanceof TsType.UnionType)) {
+            return Optional.empty();
+        }
+        List<TsType> unionTypeElements = ((TsType.UnionType) property.tsType).types;
+        if (unionTypeElements.size() != 1) {
+            return Optional.empty();
+        }
+        TsType onlyElement = unionTypeElements.iterator().next();
+        if (!(onlyElement instanceof TsType.StringLiteralType)) {
+            return Optional.empty();
+        }
+        TsType.StringLiteralType onlyValue = (TsType.StringLiteralType) onlyElement;
+        TsStringLiteral expression = new TsStringLiteral(onlyValue.literal);
+        return Optional.of(expression);
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
@@ -2,13 +2,16 @@ package cz.habarta.typescript.generator.ext;
 
 import cz.habarta.typescript.generator.Extension;
 import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.compiler.ModelCompiler;
 import cz.habarta.typescript.generator.compiler.ModelTransformer;
+import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.compiler.SymbolTable;
 import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
 import cz.habarta.typescript.generator.emitter.TsAssignmentExpression;
 import cz.habarta.typescript.generator.emitter.TsBeanModel;
 import cz.habarta.typescript.generator.emitter.TsConstructorModel;
+import cz.habarta.typescript.generator.emitter.TsEnumModel;
 import cz.habarta.typescript.generator.emitter.TsExpression;
 import cz.habarta.typescript.generator.emitter.TsExpressionStatement;
 import cz.habarta.typescript.generator.emitter.TsIdentifierReference;
@@ -39,12 +42,12 @@ public class RequiredPropertyConstructorExtension extends Extension {
 
     @Override
     public List<TransformerDefinition> getTransformers() {
-        return Arrays.asList(new TransformerDefinition(ModelCompiler.TransformationPhase.BeforeEnums, new ModelTransformer() {
+        return Arrays.asList(new TransformerDefinition(ModelCompiler.TransformationPhase.BeforeSymbolResolution, new ModelTransformer() {
             @Override
             public TsModel transformModel(SymbolTable symbolTable, TsModel model) {
                 List<TsBeanModel> beans = new ArrayList<>();
                 for (TsBeanModel bean : model.getBeans()) {
-                    TsBeanModel newBean = transformBean(bean);
+                    TsBeanModel newBean = transformBean(bean, model);
                     beans.add(newBean);
                 }
                 return model.withBeans(beans);
@@ -52,26 +55,29 @@ public class RequiredPropertyConstructorExtension extends Extension {
         }));
     }
 
-    private static TsBeanModel transformBean(TsBeanModel bean) {
+    private static TsBeanModel transformBean(TsBeanModel bean, TsModel model) {
         if (!bean.isClass() || bean.getConstructor() != null) {
             return bean;
         }
-        Optional<TsConstructorModel> constructorOption = createConstructor(bean);
+        Optional<TsConstructorModel> constructorOption = createConstructor(bean, model);
         if (!constructorOption.isPresent()) {
             return bean;
         }
         return bean.withConstructor(constructorOption.get());
     }
 
-    private static Optional<TsConstructorModel> createConstructor(TsBeanModel bean) {
+    private static Optional<TsConstructorModel> createConstructor(TsBeanModel bean, TsModel model) {
         List<TsParameterModel> parameters = new ArrayList<>();
         List<TsStatement> body = new ArrayList<>();
+        if (bean.getParent() != null) {
+            throw new IllegalStateException("Creating constructors for inherited beans is not currently supported");
+        }
         for (TsPropertyModel property : bean.getProperties()) {
             if (!property.modifiers.isReadonly) {
                 continue;
             }
             TsExpression assignmentExpression;
-            Optional<TsExpression> predefinedValue = getPredefinedValueForProperty(property);
+            Optional<TsExpression> predefinedValue = getPredefinedValueForProperty(property, model);
             if (predefinedValue.isPresent()) {
                 assignmentExpression = predefinedValue.get();
             } else {
@@ -90,21 +96,38 @@ public class RequiredPropertyConstructorExtension extends Extension {
         return Optional.of(constructor);
     }
 
-    private static Optional<TsExpression> getPredefinedValueForProperty(TsPropertyModel property) {
-        if (!(property.tsType instanceof TsType.UnionType)) {
-            return Optional.empty();
+    private static Optional<TsExpression> getPredefinedValueForProperty(TsPropertyModel property, TsModel model) {
+        if (property.tsType instanceof TsType.UnionType) {
+            List<TsType> unionTypeElements = ((TsType.UnionType) property.tsType).types;
+            if (unionTypeElements.size() != 1) {
+                return Optional.empty();
+            }
+            TsType onlyElement = unionTypeElements.iterator().next();
+            if (!(onlyElement instanceof TsType.StringLiteralType)) {
+                return Optional.empty();
+            }
+            TsType.StringLiteralType onlyValue = (TsType.StringLiteralType) onlyElement;
+            TsStringLiteral expression = new TsStringLiteral(onlyValue.literal);
+            return Optional.of(expression);
         }
-        List<TsType> unionTypeElements = ((TsType.UnionType) property.tsType).types;
-        if (unionTypeElements.size() != 1) {
-            return Optional.empty();
+        if (property.tsType instanceof TsType.EnumReferenceType) {
+            Symbol symbol = ((TsType.EnumReferenceType) property.tsType).symbol;
+            Optional<TsEnumModel> enumModelOption = model.getOriginalStringEnums().stream()
+                    .filter(candidate -> candidate.getName().getFullName().equals(symbol.getFullName()))
+                    .findAny();
+            if (!enumModelOption.isPresent()) {
+                return Optional.empty();
+            }
+            TsEnumModel enumModel = enumModelOption.get();
+            if(enumModel.getMembers().size() != 1) {
+                return Optional.empty();
+            }
+            EnumMemberModel singleElement = enumModel.getMembers().iterator().next();
+            Object enumValue = singleElement.getEnumValue();
+            TsStringLiteral expression = new TsStringLiteral((String) enumValue);
+            return Optional.of(expression);
         }
-        TsType onlyElement = unionTypeElements.iterator().next();
-        if (!(onlyElement instanceof TsType.StringLiteralType)) {
-            return Optional.empty();
-        }
-        TsType.StringLiteralType onlyValue = (TsType.StringLiteralType) onlyElement;
-        TsStringLiteral expression = new TsStringLiteral(onlyValue.literal);
-        return Optional.of(expression);
+        return Optional.empty();
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -282,7 +282,7 @@ public class Utils {
         return normalizeLineEndings(readString(stream), lineEndings);
     }
 
-    private static String normalizeLineEndings(String text, String lineEndings) {
+    public static String normalizeLineEndings(String text, String lineEndings) {
         return text.replaceAll("\\r\\n|\\n|\\r", lineEndings);
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -2,22 +2,46 @@ package cz.habarta.typescript.generator.ext;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.ClassMapping;
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.JsonLibrary;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeScriptFileType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
 import cz.habarta.typescript.generator.util.Utils;
+import java.lang.reflect.Type;
+import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Type;
-
-import static org.junit.Assert.assertEquals;
-
 public class RequiredPropertyConstructorExtensionTest {
+
+    private static final String BASE_PATH = "/ext/RequiredPropertyConstructorExtensionTest-";
 
     static class SimpleClass {
         public String field1;
         public PolymorphicClass field2;
     }
 
-    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "class")
+    static class MultipleEnumContainerClass {
+        public MultipleEntryEnum multiple;
+    }
+
+    enum MultipleEntryEnum {
+        ENTRY_1,
+        ENTRY_2,
+        ENTRY_3
+    }
+
+    static class SingleEnumContainerClass {
+        public SingleEntryEnum single;
+    }
+
+    enum SingleEntryEnum {
+        ENTRY_1
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "discriminator")
     interface SuperInterface {
 
     }
@@ -27,14 +51,20 @@ public class RequiredPropertyConstructorExtensionTest {
         public int field1;
     }
 
+    @JsonTypeName("class-c")
+    static class SecondClass extends PolymorphicClass {
+        public int field2;
+    }
+
     @Test
     public void testBasicWithReadOnly() {
         Settings settings = createBaseSettings();
         settings.declarePropertiesAsReadOnly = true;
         String result = generateTypeScript(settings, SimpleClass.class);
 
-        String expected = readResource("/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts");
-        assertEquals(expected, result);
+        String expected = readResource("basicWithReadOnly.ts");
+
+        Assert.assertEquals(expected, result);
     }
 
     @Test
@@ -43,8 +73,34 @@ public class RequiredPropertyConstructorExtensionTest {
         settings.declarePropertiesAsReadOnly = false;
         String result = generateTypeScript(settings, SimpleClass.class);
 
-        String expected = readResource("/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts");
-        assertEquals(expected, result);
+        String expected = readResource("basicWithoutReadOnly.ts");
+
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testEnums() {
+        Settings settings = createBaseSettings();
+        settings.declarePropertiesAsReadOnly = true;
+
+        String result = generateTypeScript(settings, MultipleEnumContainerClass.class, SingleEnumContainerClass.class);
+
+        String expected = readResource("enums.ts");
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testInheritance() {
+        Settings settings = createBaseSettings();
+        settings.declarePropertiesAsReadOnly = true;
+
+        try {
+            generateTypeScript(settings, SecondClass.class);
+            Assert.fail("Expected exception");
+        }
+        catch (IllegalStateException expected) {
+            Assert.assertEquals("Creating constructors for inherited beans is not currently supported", expected.getMessage());
+        }
     }
 
     private static String generateTypeScript(Settings settings, Type... types) {
@@ -64,7 +120,7 @@ public class RequiredPropertyConstructorExtensionTest {
         return settings;
     }
 
-    private String readResource(String name) {
-        return Utils.readString(getClass().getResourceAsStream(name), "\n");
+    private String readResource(String suffix) {
+        return Utils.readString(getClass().getResourceAsStream(BASE_PATH + suffix), "\n");
     }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -105,7 +105,8 @@ public class RequiredPropertyConstructorExtensionTest {
 
     private static String generateTypeScript(Settings settings, Type... types) {
         TypeScriptGenerator typeScriptGenerator = new TypeScriptGenerator(settings);
-        return typeScriptGenerator.generateTypeScript(Input.from(types));
+        String result = typeScriptGenerator.generateTypeScript(Input.from(types));
+        return Utils.normalizeLineEndings(result, "\n");
     }
 
     private static Settings createBaseSettings() {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -1,0 +1,70 @@
+package cz.habarta.typescript.generator.ext;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import cz.habarta.typescript.generator.*;
+import cz.habarta.typescript.generator.util.Utils;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.assertEquals;
+
+public class RequiredPropertyConstructorExtensionTest {
+
+    static class SimpleClass {
+        public String field1;
+        public PolymorphicClass field2;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "class")
+    interface SuperInterface {
+
+    }
+
+    @JsonTypeName("class-b")
+    static class PolymorphicClass implements SuperInterface {
+        public int field1;
+    }
+
+    @Test
+    public void testBasicWithReadOnly() {
+        Settings settings = createBaseSettings();
+        settings.declarePropertiesAsReadOnly = true;
+        String result = generateTypeScript(settings, SimpleClass.class);
+
+        String expected = readResource("/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts");
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testBasicWithoutReadOnly() {
+        Settings settings = createBaseSettings();
+        settings.declarePropertiesAsReadOnly = false;
+        String result = generateTypeScript(settings, SimpleClass.class);
+
+        String expected = readResource("/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts");
+        assertEquals(expected, result);
+    }
+
+    private static String generateTypeScript(Settings settings, Type... types) {
+        TypeScriptGenerator typeScriptGenerator = new TypeScriptGenerator(settings);
+        return typeScriptGenerator.generateTypeScript(Input.from(types));
+    }
+
+    private static Settings createBaseSettings() {
+        Settings settings = new Settings();
+        settings.sortDeclarations = true;
+        settings.extensions.add(new RequiredPropertyConstructorExtension());
+        settings.jsonLibrary = JsonLibrary.jackson2;
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.outputKind = TypeScriptOutputKind.module;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.noFileComment = true;
+        return settings;
+    }
+
+    private String readResource(String name) {
+        return Utils.readString(getClass().getResourceAsStream(name), "\n");
+    }
+}

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts
@@ -1,11 +1,11 @@
 /* tslint:disable */
 
 export class PolymorphicClass implements SuperInterface {
-    readonly class: "class-b";
+    readonly discriminator: "class-b";
     readonly field1: number;
 
     constructor(field1: number) {
-        this.class = "class-b";
+        this.discriminator = "class-b";
         this.field1 = field1;
     }
 }
@@ -21,5 +21,5 @@ export class SimpleClass {
 }
 
 export interface SuperInterface {
-    readonly class: "class-b";
+    readonly discriminator: "class-b";
 }

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithReadOnly.ts
@@ -1,0 +1,25 @@
+/* tslint:disable */
+
+export class PolymorphicClass implements SuperInterface {
+    readonly class: "class-b";
+    readonly field1: number;
+
+    constructor(field1: number) {
+        this.class = "class-b";
+        this.field1 = field1;
+    }
+}
+
+export class SimpleClass {
+    readonly field1: string;
+    readonly field2: PolymorphicClass;
+
+    constructor(field1: string, field2: PolymorphicClass) {
+        this.field1 = field1;
+        this.field2 = field2;
+    }
+}
+
+export interface SuperInterface {
+    readonly class: "class-b";
+}

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 
 export class PolymorphicClass implements SuperInterface {
-    class: "class-b";
+    discriminator: "class-b";
     field1: number;
 }
 
@@ -11,5 +11,5 @@ export class SimpleClass {
 }
 
 export interface SuperInterface {
-    class: "class-b";
+    discriminator: "class-b";
 }

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithoutReadOnly.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+
+export class PolymorphicClass implements SuperInterface {
+    class: "class-b";
+    field1: number;
+}
+
+export class SimpleClass {
+    field1: string;
+    field2: PolymorphicClass;
+}
+
+export interface SuperInterface {
+    class: "class-b";
+}

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-enums.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-enums.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+
+export class MultipleEnumContainerClass {
+    readonly multiple: MultipleEntryEnum;
+
+    constructor(multiple: MultipleEntryEnum) {
+        this.multiple = multiple;
+    }
+}
+
+export class SingleEnumContainerClass {
+    readonly single: SingleEntryEnum;
+
+    constructor() {
+        this.single = "ENTRY_1";
+    }
+}
+
+export type MultipleEntryEnum = "ENTRY_1" | "ENTRY_2" | "ENTRY_3";
+
+export type SingleEntryEnum = "ENTRY_1";


### PR DESCRIPTION
Here is an extension which generates constructors for generated classes. This constructor has a required parameter for each property that is `readonly` and has multiple possible values. This parameter is assigned to associated property. For each property which has a single possible value (as in union types with single string literal type), this value is assigned to the field.

This could be implemented as constructors which declare parameters as field (using any modifier), but as this is an extension, this would change already-generated bean classes by removing properties, which would be hard to do right.

This implementation currently doesn't support extension classes (class inheritance), because accessing superclass constructor declaration is not easy from the bean model, and it would require ordered bean processing, in order of inheritance (parent classes first). For now, this extensions throws exception when encounters class inheritance in any generated class.

Constructors are only generated for classes that have not defined constructor earlier (other extensions might do it).

