### PR TITLE
 Enable @JsonIdentityReference and @JsonIdentityInfo for bounded type parameters

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -271,7 +271,11 @@ public class Jackson2Parser extends ModelParser {
 
     // @JsonIdentityInfo and @JsonIdentityReference
     private Type processIdentity(Type propertyType, BeanPropertyWriter propertyWriter) {
-        final Class<?> cls = Utils.getRawClassOrNull(propertyType);
+
+        final Class<?> clsT = Utils.getRawClassOrNull(propertyType);
+        final Class<?> clsW = propertyWriter.getType().getRawClass();
+        final Class<?> cls = clsT != null ? clsT : clsW;
+
         if (cls != null) {
             final JsonIdentityInfo identityInfoC = cls.getAnnotation(JsonIdentityInfo.class);
             final JsonIdentityInfo identityInfoP = propertyWriter.getAnnotation(JsonIdentityInfo.class);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
@@ -164,6 +164,15 @@ public class ObjectAsIdTest {
         Assert.assertTrue(!output.contains("interface TestObjectE"));
     }
 
+
+    @Test
+    public void testGenerics() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(TestObjectWithGeneric.class));
+        Assert.assertTrue(output.contains("objectReference: string"));
+    }
+
+
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "@@@id")
     @JsonIdentityReference(alwaysAsId = true)
     private static class TestObjectA {
@@ -204,6 +213,44 @@ public class ObjectAsIdTest {
 
         public String myProperty = "valueD";
     }
+
+
+    private static class ObjectWithID {
+        @JsonProperty("@@@id")
+        public String myIdentification;
+
+    }
+
+    private static class TestObjectWithID extends ObjectWithID {
+        public String myProperty = "valueE";
+
+        public TestObjectWithID(String myIdentification) {
+            this.myIdentification = myIdentification;
+        }
+    }
+
+
+    private static class GenericWrapper<M extends ObjectWithID> {
+        @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "@@@id") @JsonIdentityReference(alwaysAsId = true)
+        public M objectReference;
+
+
+        public GenericWrapper(M objectReference) {
+            this.objectReference = objectReference;
+        }
+    }
+
+
+    private static class TestObjectWithGeneric {
+        public GenericWrapper<ObjectWithID> genericTestObject;
+
+        public TestObjectWithGeneric(GenericWrapper<ObjectWithID> genericTestObject) {
+            this.genericTestObject = genericTestObject;
+        }
+    }
+
+
+
 
     private static class TestObjectE {
 


### PR DESCRIPTION
It would be helpful if I could use @JsonIdentityInfo and @JsonIdentityReference anotations on a generic property at least if it has bounds like in the following example:

```
public class ValueAssignment<M extends IdData, T> {

    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
    @JsonIdentityReference(alwaysAsId = true)
    private M idReference;

    private T assignedValue;
}
```