### PR TITLE
Add whitelist for classes which should have constructor generated

### DIFF
--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithConfiguration.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-basicWithConfiguration.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+
+export class OtherClass {
+    readonly field2: string;
+
+    constructor(field2: string) {
+        this.field2 = field2;
+    }
+}
+
+export class PolymorphicClass implements SuperInterface {
+    readonly discriminator: "class-b";
+    readonly field1: number;
+}
+
+export class SimpleClass {
+    readonly field1: string;
+    readonly field2: PolymorphicClass;
+
+    constructor(field1: string, field2: PolymorphicClass) {
+        this.field1 = field1;
+        this.field2 = field2;
+    }
+}
+
+export interface SuperInterface {
+    readonly discriminator: "class-b";
+}


### PR DESCRIPTION
This change adds possibility to specify which classes should have constructor generated. Configuration is provided as list of FQCNs, separated by whitespace, like that:
```xml
<extensionsWithConfiguration>
    <className>cz.habarta.typescript.generator.ext.RequiredPropertyConstructorExtension</className>
    <configuration>
        <classes>
            org.example.project.FirstClass
            org.example.project.SecondClass
        </classes>
    </configuration>
</extensionsWithConfiguration>
```

If no configuration parameter is provided, or extension is inserted not as `extensionWithConfiguration`, then all classes have constructor generated. This is the same behavior as current.