### PR TITLE
Allow generating constructors for child classes

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -48,6 +48,7 @@ public class ModelCompiler {
         BeforeTsModel,
         BeforeEnums,
         BeforeSymbolResolution,
+        AfterDeclarationSorting,
     }
 
     public TsModel javaToTypeScript(Model model) {
@@ -108,6 +109,7 @@ public class ModelCompiler {
         symbolTable.resolveSymbolNames();
         tsModel = removeDeclarationsImportedFromDependencies(symbolTable, tsModel);
         tsModel = sortDeclarations(symbolTable, tsModel);
+        tsModel = applyExtensionTransformers(symbolTable, tsModel, TransformationPhase.AfterDeclarationSorting, extensionTransformers);
         return tsModel;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -58,9 +58,8 @@ public class RequiredPropertyConstructorExtensionTest {
         public int field1;
     }
 
-    @JsonTypeName("class-c")
-    static class SecondClass extends PolymorphicClass {
-        public int field2;
+    static class SecondClass extends SimpleClass {
+        public int field3;
     }
 
     @Test
@@ -118,13 +117,10 @@ public class RequiredPropertyConstructorExtensionTest {
         Settings settings = createBaseSettings();
         settings.declarePropertiesAsReadOnly = true;
 
-        try {
-            generateTypeScript(settings, SecondClass.class);
-            Assert.fail("Expected exception");
-        }
-        catch (IllegalStateException expected) {
-            Assert.assertEquals("Creating constructors for inherited beans is not currently supported", expected.getMessage());
-        }
+        String result = generateTypeScript(settings, SecondClass.class);
+
+        String expected = readResource("inheritance.ts");
+        Assert.assertEquals(expected, result);
     }
 
     private static String generateTypeScript(Settings settings, Type... types) {

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-inheritance.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-inheritance.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+
+export class PolymorphicClass implements SuperInterface {
+    readonly discriminator: "class-b";
+    readonly field1: number;
+
+    constructor(field1: number) {
+        this.discriminator = "class-b";
+        this.field1 = field1;
+    }
+}
+
+export class SimpleClass {
+    readonly field1: string;
+    readonly field2: PolymorphicClass;
+
+    constructor(field1: string, field2: PolymorphicClass) {
+        this.field1 = field1;
+        this.field2 = field2;
+    }
+}
+
+export class SecondClass extends SimpleClass {
+    readonly field3: number;
+
+    constructor(field1: string, field2: PolymorphicClass, field3: number) {
+        super(field1, field2);
+        this.field3 = field3;
+    }
+}
+
+export interface SuperInterface {
+    readonly discriminator: "class-b";
+}


### PR DESCRIPTION
This removes the limitation of not being able to generate constructors if any bean has a parent class.

Solution doesn't remove limitations completely:
* Parent class constructor must still be generated with the same extension (cannot be preexisting). This limitation could be probably further removed to read any constructor, but this would require providing access to the parent `TsBeanModel`, which I assume is currently breaking model compilation layers.
* Bean must be inheriting from a reference type. Excluding some extreme cases, which I cannot even think of, this will be always true.

If bean does not inherit from any other class, constructor is generated as before. If bean inherits from parent, its constructor parameters are extracted and prepanded to current constructor parameters. Then, a superconstructor call is added as a first statement of a constructor, with arguments same as added parameters.

This has a problem of parent bean having the same parameter names as current bean properties. This is not currently handled in any way, but it will produce compilation error when compiling produced TypeScript code.