### PR TITLE
#348: Fixed NPE when superclasses are mapping to primitives

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -245,7 +245,7 @@ public class ModelCompiler {
     }
 
     private boolean mappedToClass(Class<?> cls) {
-        return !cls.isInterface() && settings.getMapClassesAsClassesFilter().test(cls.getName());
+        return cls != null && !cls.isInterface() && settings.getMapClassesAsClassesFilter().test(cls.getName());
     }
 
     private static List<TsType.GenericVariableType> getTypeParameters(Class<?> cls) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import static org.junit.Assert.*;
-import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
 
 public class CustomTypeMappingTest {
 
@@ -48,6 +49,19 @@ public class CustomTypeMappingTest {
         System.out.println(output);
         assertTrue(output.contains("someValue: { code: string, definition: string }"));
     }
+
+    /**
+     * Tests that custom mapping a superclass to a primitive doesn't cause errors.
+     */
+    @Test
+    public void testSuperTypeString() throws Exception {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeMappings = Collections.singletonMap("cz.habarta.typescript.generator.CustomTypeMappingTest$BaseCustomMapping", "string");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(InterfaceUsingSubCustomMapping.class));
+        System.out.println(output);
+        assertTrue(output.contains("sub: SubCustomMapping;"));
+    }
+
 
     @JsonSerialize(using = CodedValueSerializer.class)
     public interface CodedValue {
@@ -103,4 +117,10 @@ public class CustomTypeMappingTest {
         }
     }
 
+
+    class BaseCustomMapping {}
+    class SubCustomMapping extends BaseCustomMapping {}
+    interface InterfaceUsingSubCustomMapping {
+        SubCustomMapping getSub();
+    }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
@@ -5,14 +5,12 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class CustomTypeMappingTest {
 


### PR DESCRIPTION
Adds a test and a null-check for `mappedToClass` which I think should return false for a null `cls`.