### PR TITLE
New extension: OnePossiblePropertyValueAssigningExtension

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 /**
  * The extension marks all properties which type allows only one possible value (for instance, enum with only one value
  * or {@link cz.habarta.typescript.generator.TsType.UnionType} with only one option) as read only and sets their
- * value in the constructor.<br/>
+ * value in the constructor.
  * It may be useful while generating code for class hierarchy where each subclass has a discriminator property that can
  * only have one value. Hence, using the TypeScript code it will not be necessary to set this value manually.
  *

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
@@ -1,0 +1,159 @@
+package cz.habarta.typescript.generator.ext;
+
+import cz.habarta.typescript.generator.Extension;
+import cz.habarta.typescript.generator.TsType;
+import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.compiler.ModelCompiler;
+import cz.habarta.typescript.generator.compiler.Symbol;
+import cz.habarta.typescript.generator.compiler.SymbolTable;
+import cz.habarta.typescript.generator.emitter.EmitterExtensionFeatures;
+import cz.habarta.typescript.generator.emitter.TsAssignmentExpression;
+import cz.habarta.typescript.generator.emitter.TsBeanModel;
+import cz.habarta.typescript.generator.emitter.TsCallExpression;
+import cz.habarta.typescript.generator.emitter.TsConstructorModel;
+import cz.habarta.typescript.generator.emitter.TsEnumModel;
+import cz.habarta.typescript.generator.emitter.TsExpression;
+import cz.habarta.typescript.generator.emitter.TsExpressionStatement;
+import cz.habarta.typescript.generator.emitter.TsMemberExpression;
+import cz.habarta.typescript.generator.emitter.TsModel;
+import cz.habarta.typescript.generator.emitter.TsModifierFlags;
+import cz.habarta.typescript.generator.emitter.TsPropertyModel;
+import cz.habarta.typescript.generator.emitter.TsStatement;
+import cz.habarta.typescript.generator.emitter.TsStringLiteral;
+import cz.habarta.typescript.generator.emitter.TsSuperExpression;
+import cz.habarta.typescript.generator.emitter.TsThisExpression;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The extension marks all properties which type allows only one possible value (for instance, enum with only one value
+ * or {@link cz.habarta.typescript.generator.TsType.UnionType} with only one option) as read only and sets their
+ * value in the constructor.<br/>
+ * It may be useful while generating code for class hierarchy where each subclass has a discriminator property that can
+ * only have one value. Hence, using the TypeScript code it will not be necessary to set this value manually.
+ *
+ * @author krzs
+ */
+public class OnePossiblePropertyValueAssigningExtension extends Extension {
+
+    @Override
+    public EmitterExtensionFeatures getFeatures() {
+        EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+        features.generatesRuntimeCode = true;
+        return features;
+    }
+
+    @Override
+    public List<TransformerDefinition> getTransformers() {
+        return Collections.singletonList(
+                new TransformerDefinition(ModelCompiler.TransformationPhase.AfterDeclarationSorting,
+                        OnePossiblePropertyValueAssigningExtension::transformModel)
+        );
+    }
+
+    private static TsModel transformModel(SymbolTable symbolTable, TsModel model) {
+        List<TsBeanModel> beans = model.getBeans().stream()
+                .map(bean -> transformBean(bean, model))
+                .collect(Collectors.toList());
+        return model.withBeans(beans);
+    }
+
+    private static TsBeanModel transformBean(TsBeanModel bean, TsModel model) {
+        if (!bean.isClass() || bean.getConstructor() != null) {
+            return bean;
+        }
+
+        List<TsPropertyModel> newProperties = new ArrayList<>();
+        Collection<TsExpressionStatement> valueAssignmentStatements = new ArrayList<>();
+
+        for (TsPropertyModel property : bean.getProperties()) {
+            TsPropertyModel newProperty = property;
+
+            Optional<TsExpression> onlyValue = findOnlyValueForProperty(property, model);
+            if (onlyValue.isPresent()) {
+                newProperty = new TsPropertyModel(property.name, property.tsType,
+                        TsModifierFlags.None.setReadonly(), property.ownProperty, property.comments);
+
+                TsExpressionStatement assignmentStatement = createValueAssignmentStatement(newProperty, onlyValue.get());
+                valueAssignmentStatements.add(assignmentStatement);
+            }
+
+            newProperties.add(newProperty);
+        }
+
+        TsBeanModel newBean = bean.withProperties(newProperties);
+        if (!valueAssignmentStatements.isEmpty()) {
+            TsConstructorModel constructor = createConstructor(bean, valueAssignmentStatements);
+            newBean = newBean.withConstructor(constructor);
+        }
+        return newBean;
+    }
+
+    private static TsConstructorModel createConstructor(TsBeanModel bean,
+                                                        Collection<TsExpressionStatement> valueAssignmentStatements) {
+        List<TsStatement> body = new ArrayList<>();
+        if (bean.getParent() != null) {
+            body.add(new TsExpressionStatement(new TsCallExpression(new TsSuperExpression())));
+        }
+
+        body.addAll(valueAssignmentStatements);
+
+        return new TsConstructorModel(TsModifierFlags.None, Collections.emptyList(), body, null);
+    }
+
+    private static TsExpressionStatement createValueAssignmentStatement(TsPropertyModel property, TsExpression value) {
+        TsMemberExpression leftHandSideExpression = new TsMemberExpression(new TsThisExpression(), property.name);
+        TsExpression assignment = new TsAssignmentExpression(leftHandSideExpression, value);
+        return new TsExpressionStatement(assignment);
+    }
+
+    private static Optional<TsExpression> findOnlyValueForProperty(TsPropertyModel property, TsModel model) {
+        TsType propertyType = property.tsType;
+        if (propertyType instanceof TsType.UnionType) {
+            return findOnlyValueForUnionType((TsType.UnionType) propertyType);
+        }
+        if (propertyType instanceof TsType.EnumReferenceType) {
+            return findOnlyValueForEnumReferenceType(model, (TsType.EnumReferenceType) propertyType);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<TsExpression> findOnlyValueForUnionType(TsType.UnionType unionType) {
+        List<TsType> unionTypeElements = unionType.types;
+        if (unionTypeElements.size() != 1) {
+            return Optional.empty();
+        }
+        TsType onlyElement = unionTypeElements.iterator().next();
+        if (!(onlyElement instanceof TsType.StringLiteralType)) {
+            return Optional.empty();
+        }
+        TsType.StringLiteralType onlyValue = (TsType.StringLiteralType) onlyElement;
+        TsStringLiteral expression = new TsStringLiteral(onlyValue.literal);
+        return Optional.of(expression);
+    }
+
+    private static Optional<TsExpression> findOnlyValueForEnumReferenceType(TsModel model,
+                                                                            TsType.EnumReferenceType propertyType) {
+        Symbol symbol = propertyType.symbol;
+        Optional<TsEnumModel> enumModelOption = model.getOriginalStringEnums().stream()
+                .filter(candidate -> candidate.getName().getFullName().equals(symbol.getFullName()))
+                .findAny();
+        if (!enumModelOption.isPresent()) {
+            return Optional.empty();
+        }
+        TsEnumModel enumModel = enumModelOption.get();
+        if (enumModel.getMembers().size() != 1) {
+            return Optional.empty();
+        }
+        EnumMemberModel singleElement = enumModel.getMembers().iterator().next();
+        Object enumValue = singleElement.getEnumValue();
+        TsStringLiteral expression = new TsStringLiteral((String) enumValue);
+        return Optional.of(expression);
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
@@ -1,0 +1,91 @@
+package cz.habarta.typescript.generator.ext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import cz.habarta.typescript.generator.ClassMapping;
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.JsonLibrary;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TypeScriptFileType;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.TypeScriptOutputKind;
+import cz.habarta.typescript.generator.util.Utils;
+import java.lang.reflect.Type;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OnePossiblePropertyValueAssigningExtensionTest {
+    private static final String BASE_PATH = "/ext/OnePossiblePropertyValueAssigningExtensionTest-";
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "discriminator")
+    static class BaseClass {
+
+        @JsonProperty
+        private Long field1;
+
+        @JsonProperty
+        private OneValueEnum field2;
+    }
+
+    static class SubClass extends BaseClass {
+
+        @JsonProperty
+        private String testField1;
+    }
+
+    static class OtherSubClass extends BaseClass {
+
+        @JsonProperty
+        private String testField2;
+
+        @JsonProperty
+        private OneValueEnum enumField1;
+
+        @JsonProperty
+        private TwoValueEnum enumField2;
+    }
+
+    enum OneValueEnum {
+        MY_VALUE
+    }
+
+    enum TwoValueEnum {
+        ONE,
+        TWO
+    }
+
+    @Test
+    public void testGeneration() {
+        Settings settings = createBaseSettings(new OnePossiblePropertyValueAssigningExtension());
+        String result = generateTypeScript(settings, SubClass.class, OtherSubClass.class);
+
+        String expected = readResource("all.ts");
+
+        Assert.assertEquals(expected, result);
+    }
+
+    private static Settings createBaseSettings(OnePossiblePropertyValueAssigningExtension extension) {
+        Settings settings = new Settings();
+        settings.sortDeclarations = true;
+        settings.extensions.add(extension);
+        settings.jsonLibrary = JsonLibrary.jackson2;
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.outputKind = TypeScriptOutputKind.module;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.noFileComment = true;
+        settings.noEslintDisable = true;
+        return settings;
+    }
+
+    private static String generateTypeScript(Settings settings, Type... types) {
+        TypeScriptGenerator typeScriptGenerator = new TypeScriptGenerator(settings);
+        String result = typeScriptGenerator.generateTypeScript(Input.from(types));
+        return Utils.normalizeLineEndings(result, "\n");
+    }
+
+    private String readResource(String suffix) {
+        return Utils.readString(getClass().getResourceAsStream(BASE_PATH + suffix), "\n");
+    }
+
+}

--- a/typescript-generator-core/src/test/resources/ext/OnePossiblePropertyValueAssigningExtensionTest-all.ts
+++ b/typescript-generator-core/src/test/resources/ext/OnePossiblePropertyValueAssigningExtensionTest-all.ts
@@ -1,0 +1,38 @@
+/* tslint:disable */
+
+export class BaseClass {
+    discriminator: "OnePossiblePropertyValueAssigningExtensionTest$SubClass" | "OnePossiblePropertyValueAssigningExtensionTest$OtherSubClass";
+    field1: number;
+    readonly field2: OneValueEnum;
+
+    constructor() {
+        this.field2 = "MY_VALUE";
+    }
+}
+
+export class OtherSubClass extends BaseClass {
+    readonly discriminator: "OnePossiblePropertyValueAssigningExtensionTest$OtherSubClass";
+    readonly enumField1: OneValueEnum;
+    enumField2: TwoValueEnum;
+    testField2: string;
+
+    constructor() {
+        super();
+        this.discriminator = "OnePossiblePropertyValueAssigningExtensionTest$OtherSubClass";
+        this.enumField1 = "MY_VALUE";
+    }
+}
+
+export class SubClass extends BaseClass {
+    readonly discriminator: "OnePossiblePropertyValueAssigningExtensionTest$SubClass";
+    testField1: string;
+
+    constructor() {
+        super();
+        this.discriminator = "OnePossiblePropertyValueAssigningExtensionTest$SubClass";
+    }
+}
+
+export type OneValueEnum = "MY_VALUE";
+
+export type TwoValueEnum = "ONE" | "TWO";


### PR DESCRIPTION
If you have a class hierarchy usually you add some discriminator property to distinguish between the subclasses (in JSON mapping). However, in these subclasses that properties can have only one value (usually the name of the class). This extension marks such properties (with only one possible value) as read only and sets their value in the constructor, so it will not be necessary to set it manually.