### PR TITLE
Order optional parameters to constructor as last

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -11,9 +11,10 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.TypeScriptOutputKind;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
+import javax.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,6 +61,16 @@ public class RequiredPropertyConstructorExtensionTest {
 
     static class SecondClass extends SimpleClass {
         public int field3;
+    }
+
+    static class SimpleOptionalClass {
+        public String field1;
+        @Nullable
+        public Integer field2;
+    }
+
+    static class SecondOptionalClass extends SimpleOptionalClass {
+        public String field3;
     }
 
     @Test
@@ -120,6 +131,19 @@ public class RequiredPropertyConstructorExtensionTest {
         String result = generateTypeScript(settings, SecondClass.class);
 
         String expected = readResource("inheritance.ts");
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testOptionalParameters() {
+        Settings settings = createBaseSettings();
+        settings.declarePropertiesAsReadOnly = true;
+        settings.optionalAnnotations = new ArrayList<>();
+        settings.optionalAnnotations.add(Nullable.class);
+
+        String result = generateTypeScript(settings, SecondOptionalClass.class);
+
+        String expected = readResource("optionalParameters.ts");
         Assert.assertEquals(expected, result);
     }
 

--- a/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-optionalParameters.ts
+++ b/typescript-generator-core/src/test/resources/ext/RequiredPropertyConstructorExtensionTest-optionalParameters.ts
@@ -1,0 +1,20 @@
+/* tslint:disable */
+
+export class SimpleOptionalClass {
+    readonly field1: string;
+    readonly field2?: number;
+
+    constructor(field1: string, field2?: number) {
+        this.field1 = field1;
+        this.field2 = field2;
+    }
+}
+
+export class SecondOptionalClass extends SimpleOptionalClass {
+    readonly field3: string;
+
+    constructor(field1: string, field3: string, field2?: number) {
+        super(field1, field2);
+        this.field3 = field3;
+    }
+}


### PR DESCRIPTION
Optional, but readonly fields in classes become optional parameters in constructor. These don't work well with inheritance without any modifications, because optional parameters can't be in constructor before non-optional ones.

This change fixes the problem by pushing optional parameters after required ones. Parameters will still retain their order in respect to position in hierarchy and declaration within class, i.e. required base class parameters will be positioned in constructor before required subclass parameters, and required parameters that are declared earlier will be before required parameters declared later. Same is true for pairs of optional parameters. But required parameters will be always before optional.

Fixes #395