### PR TITLE
Update & fixes for Checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,8 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <includeTestResources>true</includeTestResources>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <configLocation>../checkstyle.xml</configLocation>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <configuration>
+                    <includeTestResources>true</includeTestResources>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <configLocation>../checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
                 </configuration>
             </plugin>
             <plugin>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtension.java
@@ -22,7 +22,6 @@ import cz.habarta.typescript.generator.emitter.TsStatement;
 import cz.habarta.typescript.generator.emitter.TsStringLiteral;
 import cz.habarta.typescript.generator.emitter.TsSuperExpression;
 import cz.habarta.typescript.generator.emitter.TsThisExpression;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtension.java
@@ -25,7 +25,6 @@ import cz.habarta.typescript.generator.emitter.TsStatement;
 import cz.habarta.typescript.generator.emitter.TsStringLiteral;
 import cz.habarta.typescript.generator.emitter.TsSuperExpression;
 import cz.habarta.typescript.generator.emitter.TsThisExpression;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.util.Utils;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyClassEnum.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyClassEnum.java
@@ -2,7 +2,6 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Objects;
 
 public class DummyClassEnum {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
@@ -11,7 +11,6 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.TypeScriptOutputKind;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
-
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Previously Eclipse showed a bunch of CS violations. In order to tackle this following has been changed:

- Updated the Maven CS plugin to 3.1 (which is now based on CS 8.19 instead of CS 6.1)
- The build now fails on CS violations
- Fixed some files with CS violations
