### PR TITLE
gson: add support for @SerializedName

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>classgraph</artifactId>
             <version>4.8.24</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
         <!--test dependencies-->
         <dependency>
             <groupId>junit</groupId>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
@@ -1,5 +1,6 @@
 package cz.habarta.typescript.generator.parser;
 
+import com.google.gson.annotations.SerializedName;
 import cz.habarta.typescript.generator.ExcludingTypeProcessor;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TypeProcessor;
@@ -57,10 +58,12 @@ public class GsonParser extends ModelParser {
         Class<?> cls = sourceClass.type;
         while (cls != null) {
             for (Field field : cls.getDeclaredFields()) {
-
-                properties.add(
-                        new PropertyModel(field.getName(), field.getGenericType(), false, field, null, null, null));
-                addBeanToQueue(new SourceType<>(field.getGenericType(), sourceClass.type, field.getName()));
+                String name = field.getName();
+                SerializedName serializedName = field.getAnnotation(SerializedName.class);
+                if (serializedName != null)
+                    name = serializedName.value();
+                properties.add(new PropertyModel(name, field.getGenericType(), false, field, null, null, null));
+                addBeanToQueue(new SourceType<>(field.getGenericType(), sourceClass.type, name));
             }
             cls = cls.getSuperclass();
         }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
@@ -1,5 +1,6 @@
 package cz.habarta.typescript.generator.parser;
 
+import com.google.gson.annotations.SerializedName;
 import cz.habarta.typescript.generator.DefaultTypeProcessor;
 import cz.habarta.typescript.generator.DummyBean;
 import cz.habarta.typescript.generator.Input;
@@ -8,14 +9,22 @@ import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TestUtils;
 import cz.habarta.typescript.generator.TypeScriptGenerator;
 import org.junit.Assert;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
 import org.junit.Test;
 
 public class GsonParserTest {
 
+    private Settings settings;
+
     private static class DummyBeanGson {
         @SuppressWarnings("unused")
         private int privateField;
+    }
+
+    @Before
+    public void before() {
+        settings = TestUtils.settings();
+        settings.jsonLibrary = JsonLibrary.gson;
     }
 
     @Test
@@ -32,13 +41,22 @@ public class GsonParserTest {
 
     @Test
     public void testPrivateFieldGenerated() {
-        final Settings settings = TestUtils.settings();
-        settings.jsonLibrary = JsonLibrary.gson;
         final String output = generate(settings, DummyBeanGson.class);
-        assertTrue(output, output.contains("privateField"));
+        Assert.assertTrue(output, output.contains("privateField"));
     }
 
-    private String generate(final Settings settings, Class<DummyBeanGson> cls) {
+    private static class DummyBeanSerializedName {
+        @SerializedName("bar")
+        int foo;
+    }
+
+    @Test
+    public void testSerializedName() {
+        final String output = generate(settings, DummyBeanSerializedName.class);
+        Assert.assertTrue(output, output.contains("bar"));
+    }
+
+    private String generate(final Settings settings, Class<?> cls) {
         return new TypeScriptGenerator(settings).generateTypeScript(Input.from(cls));
     }
 


### PR DESCRIPTION
Add support for the GSON @SerializedName annotation.

This changes the property names in the generated typescript code. Is this how the other libraries handle things?