### PR TITLE
Tagged Unions with Generic Parameters

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
@@ -14,7 +14,7 @@ public class TsAliasModel extends TsDeclarationModel {
 
     public TsAliasModel(Class<?> origin, Symbol name, List<TsType.GenericVariableType> typeParameters, TsType definition, List<String> comments) {
         super(origin, null, name, comments);
-        this.typeParameters = typeParameters != null ? typeParameters : Collections.<TsType.GenericVariableType>emptyList();
+        this.typeParameters = typeParameters != null ? typeParameters : Collections.emptyList();
         this.definition = definition;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
@@ -6,6 +6,7 @@ import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
@@ -83,6 +84,25 @@ public class GenericsResolverTest {
     static class P123<A, B, C> extends P12<C, List<B>> {
     }
     static class P123Number extends P123<String, Number, Boolean> {
+    }
+
+    @Test
+    public void testGenericVariableMappingToBase1() {
+        final List<String> mappedTypeParameters = GenericsResolver.mapGenericVariablesToBase(R123.class, R1.class);
+        Assert.assertEquals(Arrays.asList(null, null, "T"), mappedTypeParameters);
+    }
+
+    @Test
+    public void testGenericVariableMappingToBase2() {
+        final List<String> mappedTypeParameters = GenericsResolver.mapGenericVariablesToBase(R12.class, R1.class);
+        Assert.assertEquals(Arrays.asList("T", "S"), mappedTypeParameters);
+    }
+
+    static class R1<S, T> {
+    }
+    static class R12<U, V> extends R1<V, U> {
+    }
+    static class R123<A, B, C> extends R12<C, List<B>> {
     }
 
     private static <D extends GenericDeclaration> TypeVariable<D> createTypeVariable(D genericDeclaration, String name) {


### PR DESCRIPTION
This change adds support for tagged unions with generic parameters. Description of _non-generic_ tagged unions (also called _discriminated unions_ or _polymorphic types_) is in pull request #81. Let's see some example of _generic_ tagged union:

Java classes:
``` java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@JsonSubTypes({
        @JsonSubTypes.Type(value = InProgressResult.class, name = "in-progress"),
        @JsonSubTypes.Type(value = FinishedResult.class, name = "finished"),
        @JsonSubTypes.Type(value = FailedResult.class, name = "error")
})
public abstract class AsyncOperationResult<T> {
}
public class InProgressResult<T> extends AsyncOperationResult<T> {
    public double progress;
}
public class FinishedResult<T> extends AsyncOperationResult<T> {
    public T value;  // <- generic parameter is needed here
}
public class FailedResult<T> extends AsyncOperationResult<T> {
    public String error;
}

public class AsyncUsage {
    // AsyncOperationResult can be used in REST service, here is just property of JSON class
    public AsyncOperationResult<String> result;
}
```

Generated TypeScript types:
``` typescript
export interface AsyncOperationResult<T> {
    type: "in-progress" | "finished" | "error";
}
export interface InProgressResult<T> extends AsyncOperationResult<T> {
    type: "in-progress";
    progress: number;
}
export interface FinishedResult<T> extends AsyncOperationResult<T> {
    type: "finished";
    value: T;
}
export interface FailedResult<T> extends AsyncOperationResult<T> {
    type: "error";
    error: string;
}

// generated tagged union
export type AsyncOperationResultUnion<T> = InProgressResult<T> | FinishedResult<T> | FailedResult<T>;

export interface AsyncUsage {
    // tagged union usage
    result: AsyncOperationResultUnion<string>;
}
```

Java class is considered tagged union if all descendants have only generic parameters from abstract base class (don't add any _unrelated_ generic parameter).