### PR TITLE
custom annotations for Spring Controllers

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -81,6 +81,7 @@ public class Settings {
     public boolean generateSpringApplicationInterface = false;
     public boolean generateSpringApplicationClient = false;
     public boolean scanSpringApplication;
+    public String springControllerAnnotation;
     @Deprecated public RestNamespacing jaxrsNamespacing;
     @Deprecated public Class<? extends Annotation> jaxrsNamespacingAnnotation = null;
     @Deprecated public String jaxrsNamespacingAnnotationElement;  // default is "value"

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -82,6 +82,7 @@ public class GenerateTask extends DefaultTask {
     public boolean generateSpringApplicationInterface;
     public boolean generateSpringApplicationClient;
     public boolean scanSpringApplication;
+    public String springControllerAnnotation;
     @Deprecated public RestNamespacing jaxrsNamespacing;
     @Deprecated public String jaxrsNamespacingAnnotation;
     public RestNamespacing restNamespacing;
@@ -179,6 +180,7 @@ public class GenerateTask extends DefaultTask {
             settings.generateJaxrsApplicationClient = generateJaxrsApplicationClient;
             settings.generateSpringApplicationInterface = generateSpringApplicationInterface;
             settings.generateSpringApplicationClient = generateSpringApplicationClient;
+            settings.springControllerAnnotation = springControllerAnnotation;
             settings.scanSpringApplication = scanSpringApplication;
             settings.jaxrsNamespacing = jaxrsNamespacing;
             settings.setJaxrsNamespacingAnnotation(classLoader, jaxrsNamespacingAnnotation);

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -448,6 +448,13 @@ public class GenerateMojo extends AbstractMojo {
     private boolean scanSpringApplication;
 
     /**
+     * If defined Spring interface/client will be only generated for classes which possess this annotation.
+     * By default all classes with @RestController annotation are processed.
+     */
+    @Parameter
+    private String springControllerAnnotation;
+
+    /**
      * Deprecated, use {@link #restNamespacing}.
      */
     @Deprecated
@@ -769,6 +776,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.generateSpringApplicationInterface = generateSpringApplicationInterface;
             settings.generateSpringApplicationClient = generateSpringApplicationClient;
             settings.scanSpringApplication = scanSpringApplication;
+            settings.springControllerAnnotation = springControllerAnnotation;
             settings.jaxrsNamespacing = jaxrsNamespacing;
             settings.setJaxrsNamespacingAnnotation(classLoader, jaxrsNamespacingAnnotation);
             settings.restNamespacing = restNamespacing;

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -188,7 +188,7 @@ public class SpringTest {
     }
 
     @RestController
-    public static abstract class AbstractGenerticController<T, R> {
+    public static abstract class AbstractGenericController<T, R> {
         @PostMapping("/generic")
         public R post(@RequestBody T input) {
             return map(input);
@@ -197,7 +197,7 @@ public class SpringTest {
         abstract protected R map(T input);
     }
 
-    public static class ConcreteGenerticController extends AbstractGenerticController<String, Integer> {
+    public static class ConcreteGenerticController extends AbstractGenericController<String, Integer> {
         protected Integer map(String input) {
             return input.length();
         }
@@ -236,4 +236,21 @@ public class SpringTest {
             return ResponseEntity.ok(Arrays.asList( "a" , "b" , "c" ));
         }
     }
+
+    @Test
+    public void testCustomControllerMarkerAnnotation() {
+        final Settings settings = TestUtils.settings();
+        settings.springControllerAnnotation = "cz.habarta.typescript.generator.spring.TestAnnotation";
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FilteredControllerInterface.class));
+        Assert.assertTrue(output.contains(" simple(): RestResponse<string>"));
+    }
+
+    @TestAnnotation
+    public interface FilteredControllerInterface {
+        @RequestMapping("/simple")
+        String simple();
+    }
+
 }

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/TestAnnotation.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/TestAnnotation.java
@@ -1,0 +1,13 @@
+package cz.habarta.typescript.generator.spring;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TestAnnotation {
+}


### PR DESCRIPTION
# Why
The goal with this PR is to support filtering Spring Controllers processed for client generation with Java annotations. I think in some cases this is easier than filtering classes in the configuration.

It also enables using interface-based separation of definitions. Here adding `@RestController` would be superfluous.

E.g.:
```
     @GenTypeScript
     @RequestMapping("/credentials")
     public class LoginApi {

          @GetMapping("/login")
          boolean login(@RequestBody String loginName, @RequestBody String password);
     }

     @RestController
     public class LoginController implement LoginApi {
         @Override
         public boolean login(String loginName, String password) {
             // ...
         }
     }
```

# Implementation
The default implementation was triggered for each controller with `@RestController` present. This change provides a configuration to change the marker annotation which triggers the client generation of a Spring Controller. New setting is named `springControllerAnnotation `.

Only implemented for Spring client generation.
