### PR TITLE
Improve Spring support

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -112,7 +112,7 @@ public class Utils {
                 .collect(Collectors.toList());
     }
 
-    private static Stream<Class<?>> getInheritanceChain(Class<?> cls) {
+    public static Stream<Class<?>> getInheritanceChain(Class<?> cls) {
         return generateStream(cls, c -> c != null, (Class<?> c) -> c.getSuperclass())
                 .collect(toReversedCollection())
                 .stream();

--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -1,8 +1,6 @@
 
 package cz.habarta.typescript.generator.spring;
 
-import static cz.habarta.typescript.generator.util.Utils.getInheritanceChain;
-
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TsType;
 import cz.habarta.typescript.generator.TypeProcessor;
@@ -18,6 +16,19 @@ import cz.habarta.typescript.generator.parser.RestQueryParam;
 import cz.habarta.typescript.generator.parser.SourceType;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Utils;
+import static cz.habarta.typescript.generator.util.Utils.getInheritanceChain;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,20 +42,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 
 public class SpringApplicationParser extends RestApplicationParser {
 

--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -76,8 +76,6 @@ public class SpringApplicationParser extends RestApplicationParser {
 
     }
 
-    ;
-
     public SpringApplicationParser(Settings settings, TypeProcessor commonTypeProcessor) {
         super(settings, commonTypeProcessor, new RestApplicationModel(RestApplicationType.Spring));
     }

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -9,7 +9,10 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -70,6 +73,17 @@ public class SpringTest {
     }
 
     @Test
+    public void testPathParametersWithoutValue() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller5.class));
+        Assert.assertTrue(output.contains("findPet(ownerId: number, petId: number): RestResponse<Pet>"));
+        Assert.assertTrue(output.contains("uriEncoding`owners2/${ownerId}/pets2/${petId}`"));
+        Assert.assertTrue(output.contains("interface Pet"));
+    }
+
+    @Test
     public void testQueryParameters() {
         final Settings settings = TestUtils.settings();
         settings.outputFileType = TypeScriptFileType.implementationFile;
@@ -96,6 +110,25 @@ public class SpringTest {
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller4.class));
         Assert.assertTrue(output.contains("getEntity(): RestResponse<Data2>"));
         Assert.assertTrue(output.contains("interface Data2"));
+    }
+
+    @Test
+    public void testGenerics() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
+        Assert.assertTrue(output.contains("doSomething(input: number[]): RestResponse<{ [P in Controller6Enum]?: any }[]>"));
+        Assert.assertTrue(output.contains("type Controller6Enum"));
+    }
+
+    @Test
+    public void testInheritance() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
+        Assert.assertTrue(output.contains("doSomethingElse(id: number): RestResponse<number>"));
     }
 
     @RestController
@@ -133,6 +166,45 @@ public class SpringTest {
         @RequestMapping(path = "/data2", method = RequestMethod.GET)
         public ResponseEntity<Data2> getEntity() {
             return null;
+        }
+    }
+
+    @RestController
+    @RequestMapping("/owners2/{ownerId}")
+    public static class Controller5 {
+        @GetMapping("/pets2/{petId}")
+        public Pet findPet(
+                @PathVariable Long ownerId,
+                @PathVariable Long petId
+        ) {
+            return null;
+        }
+    }
+
+    private enum Controller6Enum {
+        A,
+        B
+    }
+
+    @RestController
+    @RequestMapping("/test")
+    public static class Controller6 extends Controller6Super<Controller6Enum, Integer> {
+        @Override
+        int doSomethingElse(@PathVariable long id) {
+            return 3;
+        }
+    }
+
+    static abstract class Controller6Super<A extends Enum<A>, B> {
+
+        @PostMapping("a")
+        List<Map<A, ?>> doSomething(@RequestBody List<B> input) {
+            return null;
+        }
+
+        @GetMapping("/{id}")
+        int doSomethingElse(@PathVariable long id) {
+            return 1;
         }
     }
 

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -9,10 +9,8 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -129,6 +127,9 @@ public class SpringTest {
         settings.generateSpringApplicationClient = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
         Assert.assertTrue(output.contains("doSomethingElse(id: number): RestResponse<number>"));
+        Assert.assertTrue(output.contains("doSomethingElseAgain(): RestResponse<number>"));
+        Assert.assertTrue(output.contains("uriEncoding`test/c`"));
+        Assert.assertFalse(output.contains("uriEncoding`test/b`"));
     }
 
     @RestController
@@ -193,6 +194,12 @@ public class SpringTest {
         int doSomethingElse(@PathVariable long id) {
             return 3;
         }
+
+        @GetMapping("/c")
+        @Override
+        int doSomethingElseAgain() {
+            return super.doSomethingElseAgain();
+        }
     }
 
     static abstract class Controller6Super<A extends Enum<A>, B> {
@@ -204,6 +211,11 @@ public class SpringTest {
 
         @GetMapping("/{id}")
         int doSomethingElse(@PathVariable long id) {
+            return 1;
+        }
+
+        @GetMapping("/b")
+        int doSomethingElseAgain() {
             return 1;
         }
     }


### PR DESCRIPTION
This will improve Spring support a lot. Closes #437.

The following cases are improved:
- Generics resolving in both the return type and method arguments. I did this by switching from the Spring resolver to Typescript Generator's own generic resolver. This also fixed the fact that enum mapping didn't yet work (#421)
- `PathVariable` being string when used without value. In Spring it is possible to use `PathVariable` without a value if the URI part is the same as the variable name. Now this wasn't checked, leading to `PathVariable`s which were `string` (default) instead of the required type
- Inheritance giving double methods (could be useful for JAX-Rs too), I did this by looking in the inheritance chain and looking which methods override other methods and add a `RequestMapping` annotation. If they do that, use it, else use the method of the child type.
