### PR TITLE
Add support for required @RequestParam

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -669,7 +669,7 @@ public class ModelCompiler {
                 if (restQueryParam instanceof RestQueryParam.Single) {
                     final MethodParameterModel queryParam = ((RestQueryParam.Single) restQueryParam).getQueryParam();
                     final TsType type = typeFromJava(symbolTable, queryParam.getType(), method.getName(), method.getOriginClass());
-                    currentSingles.add(new TsProperty(queryParam.getName(), new TsType.OptionalType(type)));
+                    currentSingles.add(new TsProperty(queryParam.getName(), restQueryParam.required ? type : new TsType.OptionalType(type)));
                 }
                 if (restQueryParam instanceof RestQueryParam.Bean) {
                     final BeanModel queryBean = ((RestQueryParam.Bean) restQueryParam).getBean();
@@ -695,7 +695,9 @@ public class ModelCompiler {
                 }
             }
             flushSingles.run();
-            queryParameter = new TsParameterModel("queryParams", new TsType.OptionalType(new TsType.IntersectionType(types)));
+            boolean allQueryParamsOptional = queryParams.stream().noneMatch(queryParam -> queryParam.required);
+            TsType.IntersectionType queryParamType = new TsType.IntersectionType(types);
+            queryParameter = new TsParameterModel("queryParams", allQueryParamsOptional ? new TsType.OptionalType(queryParamType) : queryParamType);
             parameters.add(queryParameter);
         } else {
             queryParameter = null;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -173,7 +173,7 @@ public class JaxrsApplicationParser extends RestApplicationParser {
             for (Parameter param : method.getParameters()) {
                 final QueryParam queryParamAnnotation = param.getAnnotation(QueryParam.class);
                 if (queryParamAnnotation != null) {
-                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel(queryParamAnnotation.value(), param.getParameterizedType())));
+                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel(queryParamAnnotation.value(), param.getParameterizedType()), false));
                     foundType(result, param.getParameterizedType(), resourceClass, method.getName());
                 }
                 final BeanParam beanParamAnnotation = param.getAnnotation(BeanParam.class);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestQueryParam.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestQueryParam.java
@@ -4,10 +4,17 @@ package cz.habarta.typescript.generator.parser;
 
 public abstract class RestQueryParam {
 
+    public boolean required;
+
+    RestQueryParam(boolean required) {
+        this.required = required;
+    }
+
     public static class Single extends RestQueryParam {
         private final MethodParameterModel queryParam;
 
-        public Single(MethodParameterModel queryParam) {
+        public Single(MethodParameterModel queryParam, boolean required) {
+            super(required);
             this.queryParam = queryParam;
         }
 
@@ -19,7 +26,9 @@ public abstract class RestQueryParam {
     public static class Bean extends RestQueryParam {
         private final BeanModel bean;
 
+        // Only used in JAX-Rs, so optional
         public Bean(BeanModel bean) {
+            super(false);
             this.bean = bean;
         }
 

--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ValueConstants;
 
 public class SpringApplicationParser extends RestApplicationParser {
 
@@ -285,7 +286,7 @@ public class SpringApplicationParser extends RestApplicationParser {
                     final RequestParam requestParamAnnotation = AnnotationUtils.findAnnotation(parameter, RequestParam.class);
                     if (requestParamAnnotation != null) {
 
-                        final boolean isRequired = requestParamAnnotation.required();
+                        final boolean isRequired = requestParamAnnotation.required() && requestParamAnnotation.defaultValue().equals(ValueConstants.DEFAULT_NONE);
 
                         queryParams.add(new RestQueryParam.Single(new MethodParameterModel(firstOf(
                             requestParamAnnotation.value(),

--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -273,21 +273,24 @@ public class SpringApplicationParser extends RestApplicationParser {
             final List<RestQueryParam> queryParams = new ArrayList<>();
             for (Parameter parameter : method.getParameters()) {
                 if (parameter.getType() == Pageable.class) {
-                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("page", Long.class)));
+                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("page", Long.class), false));
                     foundType(result, Long.class, controllerClass, method.getName());
 
-                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("size", Long.class)));
+                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("size", Long.class), false));
                     foundType(result, Long.class, controllerClass, method.getName());
 
-                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("sort", String.class)));
+                    queryParams.add(new RestQueryParam.Single(new MethodParameterModel("sort", String.class), false));
                     foundType(result, String.class, controllerClass, method.getName());
                 } else {
                     final RequestParam requestParamAnnotation = AnnotationUtils.findAnnotation(parameter, RequestParam.class);
                     if (requestParamAnnotation != null) {
+
+                        final boolean isRequired = requestParamAnnotation.required();
+
                         queryParams.add(new RestQueryParam.Single(new MethodParameterModel(firstOf(
                             requestParamAnnotation.value(),
                             parameter.getName()
-                        ), parameter.getParameterizedType())));
+                        ), parameter.getParameterizedType()), isRequired));
                         foundType(result, parameter.getParameterizedType(), controllerClass, method.getName());
                     }
                 }

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -55,7 +55,7 @@ public class SpringTest {
         settings.classLoader = Thread.currentThread().getContextClassLoader();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SpringTestApplication.class));
         Assert.assertTrue(output.contains("interface RestApplication"));
-        Assert.assertTrue(output.contains("greeting(queryParams: { name: string; count: number; unnamed: string; }): RestResponse<Greeting>"));
+        Assert.assertTrue(output.contains("greeting(queryParams?: { name?: string; count?: number; unnamed?: string; }): RestResponse<Greeting>"));
         Assert.assertTrue(output.contains("interface Greeting"));
     }
 
@@ -87,7 +87,7 @@ public class SpringTest {
         settings.outputFileType = TypeScriptFileType.implementationFile;
         settings.generateSpringApplicationClient = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller2.class));
-        Assert.assertTrue(output.contains("echo(queryParams: { message: string; count: number; optionalRequestParam?: number; }): RestResponse<string>"));
+        Assert.assertTrue(output.contains("echo(queryParams: { message: string; count?: number; optionalRequestParam?: number; }): RestResponse<string>"));
     }
 
     @Test

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -55,7 +55,7 @@ public class SpringTest {
         settings.classLoader = Thread.currentThread().getContextClassLoader();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SpringTestApplication.class));
         Assert.assertTrue(output.contains("interface RestApplication"));
-        Assert.assertTrue(output.contains("greeting(queryParams?: { name?: string; count?: number; unnamed?: string; }): RestResponse<Greeting>"));
+        Assert.assertTrue(output.contains("greeting(queryParams: { name: string; count: number; unnamed: string; }): RestResponse<Greeting>"));
         Assert.assertTrue(output.contains("interface Greeting"));
     }
 
@@ -87,7 +87,16 @@ public class SpringTest {
         settings.outputFileType = TypeScriptFileType.implementationFile;
         settings.generateSpringApplicationClient = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller2.class));
-        Assert.assertTrue(output.contains("echo(queryParams?: { message?: string; count?: number; }): RestResponse<string>"));
+        Assert.assertTrue(output.contains("echo(queryParams: { message: string; count: number; optionalRequestParam?: number; }): RestResponse<string>"));
+    }
+
+    @Test
+    public void testAllOptionalQueryParameters() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller7.class));
+        Assert.assertTrue(output.contains("echo(queryParams?: { message?: string; }): RestResponse<string>"));
     }
 
     @Test
@@ -149,7 +158,18 @@ public class SpringTest {
         @RequestMapping("/echo")
         public String echo(
                 @RequestParam("message") String message,
-                @RequestParam(name = "count", defaultValue = "1") Integer count
+                @RequestParam(name = "count", defaultValue = "1") Integer count,
+                @RequestParam(required = false) Integer optionalRequestParam
+        ) {
+            return message;
+        }
+    }
+
+    @RestController
+    public static class Controller7 {
+        @RequestMapping("/echo2")
+        public String echo(
+                @RequestParam(required = false) String message
         ) {
             return message;
         }


### PR DESCRIPTION
In Spring, `@RequestParams` are required by default, but this wasn't enforced by Typescript-Generator. Now it uses both `required` and `defaultValue` in order to determine if it is required.

I implemented it in such a way that if 1 query parameter is actually required, the entire `queryParams` object would be required (but individual params can be optional). If no query parameter is required, the entire object can be `undefined`.

This could be breaking, but this does correspond to Spring behaviour:
https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestParam.html