### PR TITLE
Constructors with "named parameters"

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -80,6 +80,7 @@ public class Settings {
     public ClassMapping mapClasses; // default is ClassMapping.asInterfaces
     public List<String> mapClassesAsClassesPatterns;
     private Predicate<String> mapClassesAsClassesFilter = null;
+    public boolean generateConstructors = false;
     public boolean disableTaggedUnions = false;
     public boolean ignoreSwaggerAnnotations = false;
     public boolean generateJaxrsApplicationInterface = false;
@@ -330,6 +331,9 @@ public class Settings {
         }
         if (mapClassesAsClassesPatterns != null && mapClasses != ClassMapping.asClasses) {
             throw new RuntimeException("'mapClassesAsClassesPatterns' parameter can only be used when 'mapClasses' parameter is set to 'asClasses'.");
+        }
+        if (generateConstructors && mapClasses != ClassMapping.asClasses) {
+            throw new RuntimeException("'generateConstructors' parameter can only be used when 'mapClasses' parameter is set to 'asClasses'.");
         }
         for (Class<? extends Annotation> annotation : optionalAnnotations) {
             final Target target = annotation.getAnnotation(Target.class);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -262,6 +263,43 @@ public class ClassesTest {
     }
 
     private static abstract class Derived2 extends Derived1 {
+    }
+
+    @Test
+    public void testConstructor() {
+        final Settings settings = TestUtils.settings();
+        settings.optionalAnnotations = Arrays.asList(Nullable.class);
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.generateConstructors = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FooBar.class));
+        Assert.assertTrue(output.contains("constructor(data: FooBar)"));
+    }
+
+    private static class FooBar {
+        @Nullable
+        public String foo;
+        public int bar;
+    }
+
+    @Test
+    public void testConstructorWithGenericsAndInheritance() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.generateConstructors = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassB.class));
+        Assert.assertTrue(output.contains("constructor(data: ClassA<T>)"));
+        Assert.assertTrue(output.contains("constructor(data: ClassB)"));
+        Assert.assertTrue(output.contains("super(data);"));
+    }
+
+    private static class ClassA<T> {
+        public String a;
+    }
+
+    private static class ClassB extends ClassA<String> {
+        public String b;
     }
 
 }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -77,6 +77,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> nonConstEnumAnnotations;
     public ClassMapping mapClasses;
     public List<String> mapClassesAsClassesPatterns;
+    public boolean generateConstructors;
     public boolean disableTaggedUnions;
     public boolean ignoreSwaggerAnnotations;
     public boolean generateJaxrsApplicationInterface;
@@ -177,6 +178,7 @@ public class GenerateTask extends DefaultTask {
             settings.loadNonConstEnumAnnotations(classLoader, nonConstEnumAnnotations);
             settings.mapClasses = mapClasses;
             settings.mapClassesAsClassesPatterns = mapClassesAsClassesPatterns;
+            settings.generateConstructors = generateConstructors;
             settings.disableTaggedUnions = disableTaggedUnions;
             settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;
             settings.generateJaxrsApplicationInterface = generateJaxrsApplicationInterface;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -410,7 +410,8 @@ public class GenerateMojo extends AbstractMojo {
      * </ul>
      * Default value is <code>asInterfaces</code>.<br>
      * Value <code>asClasses</code> can only be used in implementation files (.ts).
-     * It is also possible to generate mix of classes and interfaces by setting this parameter to <code>asClasses</code> value
+     * In this case it is also possible to generate constructors by setting <code>generateConstructors</code> parameter to <code>true</code>.
+     * It is also possible to generate mix of classes and interfaces by setting <code>mapClasses</code> parameter to <code>asClasses</code> value
      * and specifying which classes should be mapped as classes using <code>mapClassesAsClassesPatterns</code> parameter.
      */
     @Parameter
@@ -423,6 +424,14 @@ public class GenerateMojo extends AbstractMojo {
      */
     @Parameter
     private List<String> mapClassesAsClassesPatterns;
+
+    /**
+     * If <code>true</code> generated classes will also have constructors.
+     * Generated constructors use "named parameters" pattern so when calling such constructor parameters need to be wrapped in "options" object.
+     * This parameter can only be used when <code>mapClasses</code> parameter is set to <code>asClasses</code> value.
+     */
+    @Parameter
+    private boolean generateConstructors;
 
     /**
      * If <code>true</code> tagged unions will not be generated for Jackson 2 polymorphic types.
@@ -795,6 +804,7 @@ public class GenerateMojo extends AbstractMojo {
             settings.loadNonConstEnumAnnotations(classLoader, nonConstEnumAnnotations);
             settings.mapClasses = mapClasses;
             settings.mapClassesAsClassesPatterns = mapClassesAsClassesPatterns;
+            settings.generateConstructors = generateConstructors;
             settings.disableTaggedUnions = disableTaggedUnions;
             settings.ignoreSwaggerAnnotations = ignoreSwaggerAnnotations;
             settings.generateJaxrsApplicationInterface = generateJaxrsApplicationInterface;


### PR DESCRIPTION
When generating classes it is now possible to also generate constructors. This feature can be turned on using `generateConstructors` parameter.

Here is some example Java class:
``` java
class FooBar {
    public @Nullable String foo;
    public int bar;
}
```

and corresponding TypeScript class with constructor:
``` typescript
class FooBar {
    foo?: string;
    bar: number;

    constructor(data: FooBar) {
        this.foo = data.foo;
        this.bar = data.bar;
    }
}
```

Generated constructor uses pattern similar to _[named parameters](https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/#convert-parameters-to-destructured-object)_ (also called _options object_) so it is called like this:
``` typescript
new FooBar({ bar: 42 })
```

> Note: without constructors generated TypeScript classes are not valid in _strict_ mode (unless they only have optional properties). But unfortunately this feature cannot be turned on by default because of compatibility.