### PR TITLE
enums must be processed, even when comming from a dependency

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
@@ -102,6 +102,9 @@ public class JsonbParser extends ModelParser {
         for (Type aInterface : interfaces) {
             addBeanToQueue(new SourceType<>(aInterface, sourceClass.type, "<interface>"));
         }
+        properties.stream()
+                .filter(p -> Class.class.isInstance(p.getType()) && Class.class.cast(p.getType()).isEnum())
+                .forEach(enumProp -> addBeanToQueue(new SourceType<>(Class.class.cast(enumProp.getType()))));
         return new BeanModel(
                 sourceClass.type, superclass, null, null, null,
                 interfaces, properties, null);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
@@ -103,8 +103,8 @@ public class JsonbParser extends ModelParser {
             addBeanToQueue(new SourceType<>(aInterface, sourceClass.type, "<interface>"));
         }
         properties.stream()
-                .filter(p -> Class.class.isInstance(p.getType()) && Class.class.cast(p.getType()).isEnum())
-                .forEach(enumProp -> addBeanToQueue(new SourceType<>(Class.class.cast(enumProp.getType()))));
+                .filter(p -> Class.class.isInstance(p.getType()))
+                .forEach(p -> addBeanToQueue(new SourceType<>(Class.class.cast(p.getType()))));
         return new BeanModel(
                 sourceClass.type, superclass, null, null, null,
                 interfaces, properties, null);


### PR DESCRIPTION
Issue appears when having A model extending B and B comming from a dependency. If B has some enum then it is not processed. I did the fix for JSON-B but didn't check it affects other libraries.
This is my last blocker to disable manual updates of the model :).