### PR TITLE
gradle-plugin: don't propagate gradle dependency

### DIFF
--- a/typescript-generator-gradle-plugin/pom.xml
+++ b/typescript-generator-gradle-plugin/pom.xml
@@ -21,21 +21,25 @@
             <groupId>org.gradle</groupId>
             <artifactId>gradle-core</artifactId>
             <version>${gradle.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-base-services</artifactId>
             <version>${gradle.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-base-services-groovy</artifactId>
             <version>${gradle.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.gradle</groupId>
             <artifactId>gradle-logging</artifactId>
             <version>${gradle.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Changing the scope to "provided" makes sure that the gradle api
dependency does not leak into the consumers of the plugin.

The issue came up in a gradle project: since typescript-generator has a dependency on Gradle API 3, this dependency leaked into the runtime classpath of my build script which caused issues. 

Since the plugin can only be used in a gradle build, the gradle api should already be part of the runtime classpath and doesn't need to propagated.