### PR TITLE
ensure JSON-B parser makes attributes optional when not final

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JsonbParser.java
@@ -158,14 +158,16 @@ public class JsonbParser extends ModelParser {
             return Stream.of(constructor.getParameters())
                     .map(it -> {
                         final Type type = it.getParameterizedType();
+                        final Optional<JsonbProperty> property = Optional.ofNullable(it.getAnnotation(JsonbProperty.class));
                         return new PropertyModel(
-                                Optional.ofNullable(it.getAnnotation(JsonbProperty.class))
+                                property
                                     .map(JsonbProperty::value)
                                     .filter(p -> !p.isEmpty())
                                     .orElseGet(it::getName),
                                 type,
                                 isOptional(type) || OptionalInt.class == type ||
-                                        OptionalLong.class == type || OptionalDouble.class == type,
+                                        OptionalLong.class == type || OptionalDouble.class == type ||
+                                        property.map(JsonbProperty::nillable).orElse(false),
                                 new ParameterMember(it),
                                 null, null, null);
                     });

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -25,19 +25,82 @@ public class JsonbParserTest {
         int foo;
     }
 
+    private static class OverridenPropertyNameOnGetter {
+        int foo;
+
+        @JsonbProperty("$foo")
+        public int getFoo() {
+            return foo;
+        }
+    }
+
     public static class DirectName {
         public int foo;
+    }
+
+    public static class OptionalWithGetter {
+        private int foo;
+
+        public int getFoo() {
+            return foo;
+        }
+    }
+
+    public static class Required {
+        public final int foo;
+
+        public Required(int foo) {
+            this.foo = foo;
+        }
+    }
+
+    public static class RequiredWithGetter {
+        private final int foo;
+
+        public RequiredWithGetter(int foo) {
+            this.foo = foo;
+        }
+
+        public int getFoo() {
+            return foo;
+        }
     }
 
     @Test
     public void tesJsonbProperty() {
         final String output = generate(settings, OverridenPropertyName.class);
-        Assert.assertTrue(output, output.contains(" $foo"));
+        Assert.assertTrue(output, output.contains(" $foo?:"));
+    }
+
+    @Test
+    public void tesJsonbPropertyOnMethod() {
+        final String output = generate(settings, OverridenPropertyNameOnGetter.class);
+        Assert.assertTrue(output, output.contains(" $foo?:"));
+        Assert.assertFalse(output, output.contains(" foo?:"));
     }
     @Test
     public void tesImplicitName() {
         final String output = generate(settings, DirectName.class);
-        Assert.assertTrue(output, output.contains(" foo"));
+        Assert.assertTrue(output, output.contains(" foo?:"));
+    }
+    @Test
+    public void optionality() {
+        {
+            final String output = generate(settings, DirectName.class);
+            Assert.assertTrue(output, output.contains(" foo?: number"));
+        }
+        {
+            final String output = generate(settings, OptionalWithGetter.class);
+            Assert.assertTrue(output, output.contains(" foo?: number"));
+        }
+        {
+            final String output = generate(settings, Required.class);
+            Assert.assertTrue(output, output.contains(" foo: number"));
+        }
+        {
+            final String output = generate(settings, RequiredWithGetter.class);
+            Assert.assertTrue(output, output.contains(" foo: number"));
+        }
     }
 
     private String generate(final Settings settings, Class<?> cls) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -102,6 +102,14 @@ public class JsonbParserTest {
         public String bar;
     }
 
+    public static class ObjectWithRequiredPropertyAndConstructor {
+        public String foo;
+        public String bar;
+
+        @JsonbCreator
+        public ObjectWithRequiredPropertyAndConstructor(@RequiredAnnotation final String foo, final String bar) {}
+    }
+
     @Retention(RetentionPolicy.RUNTIME)
     public @interface RequiredAnnotation {
     }
@@ -111,6 +119,15 @@ public class JsonbParserTest {
         settings.optionalProperties = OptionalProperties.useSpecifiedAnnotations;
         settings.requiredAnnotations.add(RequiredAnnotation.class);
         final String output = generate(settings, ObjecWithRequiredProperty.class);
+        Assert.assertTrue(output, output.contains(" foo:"));
+        Assert.assertTrue(output, output.contains(" bar?:"));
+    }
+
+    @Test
+    public void testRequiredPropertyMarkedByAnnotationAndConstructorFactory() {
+        settings.optionalProperties = OptionalProperties.useSpecifiedAnnotations;
+        settings.requiredAnnotations.add(RequiredAnnotation.class);
+        final String output = generate(settings, ObjectWithRequiredPropertyAndConstructor.class);
         Assert.assertTrue(output, output.contains(" foo:"));
         Assert.assertTrue(output, output.contains(" bar?:"));
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -83,6 +83,19 @@ public class JsonbParserTest {
         }
     }
 
+    public static class NillableConstructorParameter {
+        private final int foo;
+
+        @JsonbCreator // we agree it is a stupid case but generator must respect user choice
+        public NillableConstructorParameter(@JsonbProperty(value = "foo", nillable = true) final int foo) {
+            this.foo = foo;
+        }
+
+        public int getFoo() {
+            return foo;
+        }
+    }
+
     public static class ObjecWithRequiredProperty {
         @RequiredAnnotation
         public String foo;
@@ -139,6 +152,10 @@ public class JsonbParserTest {
         }
         {
             final String output = generate(settings, RequiredOptional.class);
+            Assert.assertTrue(output, output.contains(" foo?: number"));
+        }
+        {
+            final String output = generate(settings, NillableConstructorParameter.class);
             Assert.assertTrue(output, output.contains(" foo?: number"));
         }
     }


### PR DESCRIPTION
Small enhancement to enable JSON-B parser to also handle optional attributes.

This PR assumes final fields means not optional (until settings are configured explicitly). This is not 100% true in java (except for primitives) but I assume it is a good compromise overall.

Let me know if you think we should make all objects optional.