### PR TITLE
@ModelAttribute in Spring

### DIFF
--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -195,6 +196,30 @@ public class SpringTest {
                 @RequestParam(required = false) String message
         ) {
             return message;
+        }
+    }
+
+    @Test
+    public void testQueryParametersWithModel() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ControllerWithModelAttribute.class));
+        System.out.println(output);
+        Assert.assertTrue(output.contains("echoWithModelAttribute(queryParams?: { message?: string; }): RestResponse<string>"));
+    }
+
+    @RestController
+    public static class ControllerWithModelAttribute {
+        @RequestMapping("/echoWithModelAttribute")
+        public String echoWithModelAttribute(@ModelAttribute FilterParams nested) {
+            return nested.getMessage();
+        }
+
+        static class FilterParams {
+            private String message;
+            public String getMessage() { return message; }
+            public void setMessage(String message) { this.message = message; }
         }
     }
 


### PR DESCRIPTION
When using many Query parameters in Spring MVC it is convinient to wrap them into one object instead of multiple @RequestParam annotations

Example is available here, point 9: https://reversecoding.net/spring-mvc-requestparam-binding-request-parameters/

Currently, if we drop annotations generator skips this kind of objects - it would be great to support them.

To prevent some unexpected errors while upgrading , we could force to use @ModelAttribute annotation if we want to enable this behaviour. Said annotation is current default fallback, according to the bottom of this documentation section: https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-arguments

You can find my proposal in PR.
