### PR TITLE
Jackson2: Super class did not get type information

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -253,7 +253,7 @@ public class Jackson2Parser extends ModelParser {
         if (isSupported(jsonTypeInfo)) {
             // this is parent
             discriminantProperty = getDiscriminantPropertyName(jsonTypeInfo);
-            discriminantLiteral = null;
+            discriminantLiteral = isInterfaceOrAbstract(sourceClass.type) ? null : getTypeName(jsonTypeInfo, sourceClass.type);
         } else if (isSupported(parentJsonTypeInfo = getAnnotationRecursive(sourceClass.type, JsonTypeInfo.class))) {
             // this is child class
             discriminantProperty = getDiscriminantPropertyName(parentJsonTypeInfo);
@@ -399,10 +399,14 @@ public class Jackson2Parser extends ModelParser {
             }
         }
         // use simplified class name if it's not an interface or abstract
-        if(!cls.isInterface() && !Modifier.isAbstract(cls.getModifiers())) {
+        if(!isInterfaceOrAbstract(cls)) {
             return cls.getName().substring(cls.getName().lastIndexOf(".") + 1);
         }
         return null;
+    }
+
+    private boolean isInterfaceOrAbstract(Class<?> cls) {
+        return cls.isInterface() || Modifier.isAbstract(cls.getModifiers());
     }
 
     private static JsonSubTypes.Type getJsonSubTypeForClass(JsonSubTypes types, Class<?> cls) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2DeserializableRootType.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2DeserializableRootType.java
@@ -1,7 +1,6 @@
 
 package cz.habarta.typescript.generator;
 
-import static org.junit.Assert.assertSame;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,8 +23,8 @@ public class Jackson2DeserializableRootType {
                         .readValue("{\"type\": \"subType\"}",
                                         NonAbstractRoot.class);
 
-        assertSame(NonAbstractRoot.class, nar.getClass());
-        assertSame(NonAbstractRootSub.class, nars.getClass());
+        Assert.assertSame(NonAbstractRoot.class, nar.getClass());
+        Assert.assertSame(NonAbstractRootSub.class, nars.getClass());
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2DeserializableRootType.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2DeserializableRootType.java
@@ -1,0 +1,63 @@
+
+package cz.habarta.typescript.generator;
+
+import static org.junit.Assert.assertSame;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test that root type name in a hirarchy is included iff root type itself is not abstract
+ */
+public class Jackson2DeserializableRootType {
+
+    @Test
+    public void testHowJacksonDeserializes() throws JsonProcessingException {
+        NonAbstractRoot nar = new ObjectMapper()
+                        .readValue("{\"type\": \"rootType\"}",
+                                        NonAbstractRoot.class);
+        NonAbstractRoot nars = new ObjectMapper()
+                        .readValue("{\"type\": \"subType\"}",
+                                        NonAbstractRoot.class);
+
+        assertSame(NonAbstractRoot.class, nar.getClass());
+        assertSame(NonAbstractRootSub.class, nars.getClass());
+    }
+
+    @Test
+    public void testRootTypeIncludedIfNotAbstract() {
+        final String output = new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(NonAbstractRoot.class));
+        Assert.assertTrue(output.contains("\"rootType\""));
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(@JsonSubTypes.Type(NonAbstractRootSub.class))
+    @JsonTypeName("rootType")
+    public static class NonAbstractRoot {
+    }
+
+    @JsonTypeName("subType")
+    public static class NonAbstractRootSub extends NonAbstractRoot {
+    }
+
+    @Test
+    public void testRootTypeNotIncludedIfAbstract() {
+        final String output = new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(AbstractRoot.class));
+        // Root type is abstract and therefore ignored in the type list
+        Assert.assertFalse(output.contains("\"rootType\""));
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(@JsonSubTypes.Type(AbstractRootSub.class))
+    @JsonTypeName("rootType")
+    public static abstract class AbstractRoot {
+    }
+
+    @JsonTypeName("subType")
+    public static class AbstractRootSub extends AbstractRoot {
+    }
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
@@ -148,7 +148,7 @@ public class JsonDeserializationTest {
         @JsonSubTypes.Type(Rectangle.class),
         @JsonSubTypes.Type(Circle.class),
     })
-    private static class Shape {
+    private abstract static class Shape {
         public ShapeMetadata metadata;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -23,7 +23,7 @@ public class TaggedUnionsTest {
         @JsonSubTypes.Type(Rectangle.class),
         @JsonSubTypes.Type(Circle.class),
     })
-    private static class Shape {
+    private abstract static class Shape {
     }
 
     @JsonTypeName("square")
@@ -127,7 +127,7 @@ public class TaggedUnionsTest {
         @JsonSubTypes.Type(DieselCar.class),
         @JsonSubTypes.Type(ElectricCar.class),
     })
-    private static class Car {
+    private abstract static class Car {
         public String name;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/OnePossiblePropertyValueAssigningExtensionTest.java
@@ -18,7 +18,7 @@ public class OnePossiblePropertyValueAssigningExtensionTest {
     private static final String BASE_PATH = "/ext/OnePossiblePropertyValueAssigningExtensionTest-";
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "discriminator")
-    static class BaseClass {
+    abstract static class BaseClass {
 
         @JsonProperty
         private Long field1;


### PR DESCRIPTION
Jackson can (de)serialize instances of the hierarchy root class when using @JsonSubTypes. When generating interface for this java class:

```java
    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
    @JsonSubTypes(@JsonSubTypes.Type(NonAbstractRootSub.class))
    @JsonTypeName("rootType")
    public static class NonAbstractRoot {
    }

    @JsonTypeName("subType")
    public static class NonAbstractRootSub extends NonAbstractRoot {
    }
```

Previously wrong generated code ("rootType" missing):
```ts
interface NonAbstractRoot {
    type: "subType";
}

interface NonAbstractRootSub extends NonAbstractRoot {
    type: "subType";
}

type NonAbstractRootUnion = NonAbstractRootSub;
```

Correct:
```ts
interface NonAbstractRoot {
    type: "rootType" | "subType";
}

interface NonAbstractRootSub extends NonAbstractRoot {
    type: "subType";
}

type NonAbstractRootUnion = NonAbstractRootSub;
```