### PR TITLE
Fix disappearing Spring URL trailing slash

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -50,24 +50,37 @@ public final class Utils {
     }
 
     public static String joinPath(String part1, String part2) {
-        final List<String> parts = new ArrayList<>();
-        addPathPart(parts, part1);
-        addPathPart(parts, part2);
-        return String.join("/", parts);
-    }
-
-    private static void addPathPart(List<String> parts, String part) {
-        if (part != null) {
-            final String trimmed = trimSlash(part);
-            if (!trimmed.isEmpty()) {
-                parts.add(trimmed);
-            }
+        StringBuilder url = new StringBuilder();
+        if (part1 != null) {
+            String path1 = trimTrailing(part1);
+            url.append(path1);
         }
+
+        if (part2 == null) {
+            return url.toString();
+        }
+
+        String path2 = trimTrailing(part2);
+        boolean urlPartHasTrailingSlash = url.length() > 0 && url.charAt(url.length() - 1) == '/';
+
+        if (url.length() > 0 && !path2.isEmpty() && ! path2.equals("/") && ! urlPartHasTrailingSlash) {
+            url.append("/");
+        }
+
+        if (!path2.isEmpty() && ! (path2.equals("/") && urlPartHasTrailingSlash) && !(path2.equals("/") && url.length() == 0)) {
+            url.append(path2);
+        }
+
+        return url.toString();
     }
 
-    private static String trimSlash(String path) {
-        path = path.startsWith("/") ? path.substring(1) : path;
-        path = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+    private static String trimTrailing(String path) {
+        if (path.equals("/")) {
+            return path;
+        }
+        if (path.startsWith("/")) {
+            return path.substring(1);
+        }
         return path;
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
@@ -22,4 +22,25 @@ public class UtilsTest {
         Assert.assertEquals("\\Qcz.habarta.test.\\E[^.\\$]*\\Q\\E", Utils.globsToRegexps(Arrays.asList("cz.habarta.test.*")).get(0).toString());
     }
 
+    @Test
+    public void testPathJoin() {
+        Assert.assertEquals("controller", Utils.joinPath("/controller", null));
+        Assert.assertEquals("controller/", Utils.joinPath("/controller/", null));
+        Assert.assertEquals("path", Utils.joinPath(null, "/path"));
+        Assert.assertEquals("path/", Utils.joinPath(null, "/path/"));
+        Assert.assertEquals("", Utils.joinPath(null, "/"));
+
+        Assert.assertEquals("controller", Utils.joinPath("/controller", ""));
+        Assert.assertEquals("controller/", Utils.joinPath("/controller", "/"));
+        Assert.assertEquals("controller/path", Utils.joinPath("/controller", "/path"));
+        Assert.assertEquals("controller/path", Utils.joinPath("/controller", "path"));
+        Assert.assertEquals("controller/path/", Utils.joinPath("/controller", "/path/"));
+
+        Assert.assertEquals("controller/", Utils.joinPath("/controller/", ""));
+        Assert.assertEquals("controller/", Utils.joinPath("/controller/", "/"));
+        Assert.assertEquals("controller/path", Utils.joinPath("/controller/", "/path"));
+        Assert.assertEquals("controller/path", Utils.joinPath("/controller/", "path"));
+        Assert.assertEquals("controller/path/", Utils.joinPath("/controller/", "/path/"));
+    }
+
 }

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -408,6 +409,27 @@ public class SpringTest {
     @Retention(RetentionPolicy.RUNTIME)
     @Component
     public @interface MyRestController {
+    }
+
+    @Test
+    public void testUrlTrailingSlash() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(TestUrlTrailingSlashController.class));
+        Assert.assertTrue(Pattern.compile("response\\(\\):.*\\n.*uriEncoding`controller/`").matcher(output).find());
+        Assert.assertTrue(Pattern.compile("response2\\(\\):.*\\n.*uriEncoding`controller`").matcher(output).find());
+    }
+
+    @RestController
+    @RequestMapping("/controller")
+    public class TestUrlTrailingSlashController {
+        @GetMapping("/")
+        public void response() {
+        }
+        @GetMapping("")
+        public void response2() {
+        }
     }
 
 }


### PR DESCRIPTION
## Issue
The URL's for the following Controller were incorrectly generated as the trailing slash is always omitted, but it's an important distinction of the URL.
```
    @RestController
    @RequestMapping("/controller")
    public class TestUrlSuffixController {
        @GetMapping("/")
        public void response() {
        }
        @GetMapping("")
        public void response2() {
        }
    }
```

The generated URL controller for both mappings were `controller` instead of `controller/` and `controller` respectively. Having or not having a trailing slash also means a different URL.

## Solution
Rewrite of `Utils.joinPath()`.
Added tests for both the initial issue and the `joinPath` rewrite.

