### PR TITLE
Support for Vavr collections and Option type

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>js-scriptengine</artifactId>
             <version>${graalvm.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>0.10.3</version>
+        </dependency>
         <!--test dependencies-->
         <dependency>
             <groupId>junit</groupId>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -5,6 +5,8 @@ import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.type.JTypeWithNullability;
 import cz.habarta.typescript.generator.type.JUnionType;
 import cz.habarta.typescript.generator.util.Utils;
+import io.vavr.collection.LinearSeq;
+import io.vavr.control.Option;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -58,11 +60,11 @@ public class DefaultTypeProcessor implements TypeProcessor {
             if (javaClass.isEnum()) {
                 return new Result(new TsType.EnumReferenceType(context.getSymbol(javaClass)), javaClass);
             }
-            if (Collection.class.isAssignableFrom(javaClass)) {
+            if (Collection.class.isAssignableFrom(javaClass) || LinearSeq.class.isAssignableFrom(javaClass)) {
                 final Result result = context.processTypeInsideCollection(Object.class);
                 return new Result(new TsType.BasicArrayType(result.getTsType()), result.getDiscoveredClasses());
             }
-            if (Map.class.isAssignableFrom(javaClass)) {
+            if (Map.class.isAssignableFrom(javaClass) || io.vavr.collection.Map.class.isAssignableFrom(javaClass)) {
                 final Result result = context.processTypeInsideCollection(Object.class);
                 return new Result(new TsType.IndexedArrayType(TsType.String, result.getTsType()), result.getDiscoveredClasses());
             }
@@ -89,11 +91,11 @@ public class DefaultTypeProcessor implements TypeProcessor {
             final ParameterizedType parameterizedType = (ParameterizedType) javaType;
             if (parameterizedType.getRawType() instanceof Class) {
                 final Class<?> javaClass = (Class<?>) parameterizedType.getRawType();
-                if (Collection.class.isAssignableFrom(javaClass)) {
+                if (Collection.class.isAssignableFrom(javaClass) || LinearSeq.class.isAssignableFrom(javaClass)) {
                     final Result result = context.processTypeInsideCollection(parameterizedType.getActualTypeArguments()[0]);
                     return new Result(new TsType.BasicArrayType(result.getTsType()), result.getDiscoveredClasses());
                 }
-                if (Map.class.isAssignableFrom(javaClass)) {
+                if (Map.class.isAssignableFrom(javaClass) || io.vavr.collection.Map.class.isAssignableFrom(javaClass)) {
                     final Result keyResult = context.processType(parameterizedType.getActualTypeArguments()[0]);
                     final Result valueResult = context.processTypeInsideCollection(parameterizedType.getActualTypeArguments()[1]);
                     if (keyResult.getTsType() instanceof TsType.EnumReferenceType) {
@@ -108,7 +110,7 @@ public class DefaultTypeProcessor implements TypeProcessor {
                         );
                     }
                 }
-                if (Optional.class.isAssignableFrom(javaClass)) {
+                if (Optional.class.isAssignableFrom(javaClass) || Option.class.isAssignableFrom(javaClass)) {
                     final Result result = context.processType(parameterizedType.getActualTypeArguments()[0]);
                     return new Result(result.getTsType().optional(), result.getDiscoveredClasses());
                 }


### PR DESCRIPTION
[Vavr](https://www.vavr.io/) is a functional programming library for Java. Unlike Guava, Vavr collections do not inherit from standard Java collection API. Therefor `typescript-generator` does not recognize them. This PR adds support for Vavr types so they are treated as collections or optional types.