### PR TITLE
add skip option for a more modular configuration

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -128,6 +128,7 @@ public class Settings {
     public boolean jackson2ModuleDiscovery = false;
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
+    public boolean skip = false;
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -71,6 +71,10 @@ public class TypeScriptGenerator {
     }
 
     public void generateTypeScript(Input input, Output output) {
+        if (settings.skip) {
+            TypeScriptGenerator.getLogger().info("Skipping plugin execution");
+            return;
+        }
         generateTypeScript(input, output, false, 0);
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SkipTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SkipTest.java
@@ -1,0 +1,20 @@
+package cz.habarta.typescript.generator;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class SkipTest {
+    @Test
+    public void skippingShouldNotDoAnything() throws IOException {
+        final Settings settings = TestUtils.settings();
+        settings.skip = true;
+        final File actualFile = new File("target/skipTests-actual.ts");
+        new TypeScriptGenerator(settings).generateTypeScript(Input.from(String.class), Output.to(actualFile));
+
+        assertEquals(0, Files.readAllBytes(actualFile.toPath()).length);
+    }
+}

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -787,6 +787,9 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.directory}", readonly = true, required = true)
     private String projectBuildDirectory;
 
+    @Parameter
+    private boolean skip;
+
     @SuppressWarnings("deprecation")
     private Settings createSettings(URLClassLoader classLoader) {
         final Settings settings = new Settings();
@@ -866,6 +869,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
         settings.loadJackson2Modules(classLoader, jackson2Modules);
         settings.classLoader = classLoader;
+        settings.skip = skip;
         return settings;
     }
 


### PR DESCRIPTION
Hello !

`skip` parameter is supported by core maven plugins. It allows to easily configure large multi-module project using the parameter inheritance rather than the complex plugins configured by profile inheritance.

As the PR shows, the implementation is pretty straight forward and it would be appreciated by some of maven users.

I am not sure the `TypeScriptGenerator#generateTypeScript` I considered the entrypoint is the right one. Maybe you can see a better place to do it.

Thanks!