### PR TITLE
Sort constructor property assignments when sortDeclarations is true

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -121,7 +121,7 @@ public class ModelCompiler {
         tsModel = removeInheritedProperties(symbolTable, tsModel);
         tsModel = addImplementedProperties(symbolTable, tsModel);
         if (settings.generateConstructors) {
-            tsModel = addConstructors(symbolTable, tsModel);
+            tsModel = addConstructors(symbolTable, tsModel, settings.sortDeclarations);
         }
 
         // REST
@@ -493,7 +493,7 @@ public class ModelCompiler {
         return tsModel.withBeans(beans);
     }
 
-    private TsModel addConstructors(SymbolTable symbolTable, TsModel tsModel) {
+    private TsModel addConstructors(SymbolTable symbolTable, TsModel tsModel, Boolean sortDeclarations) {
         final List<TsBeanModel> beans = new ArrayList<>();
         for (TsBeanModel bean : tsModel.getBeans()) {
             final Symbol beanIdentifier = symbolTable.getSymbol(bean.getOrigin());
@@ -510,7 +510,11 @@ public class ModelCompiler {
                         )
                 ));
             }
-            for (TsPropertyModel property : bean.getProperties()) {
+            List<TsPropertyModel> beanProperties = bean.getProperties();
+            if (sortDeclarations) {
+                Collections.sort(beanProperties);
+            }
+            for (TsPropertyModel property : beanProperties) {
                 final Map<String, TsType> inheritedProperties = ModelCompiler.getInheritedProperties(symbolTable, tsModel, Utils.listFromNullable(bean.getParent()));
                 if (!inheritedProperties.containsKey(property.getName())) {
                     body.add(new TsExpressionStatement(new TsAssignmentExpression(

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
@@ -277,6 +277,36 @@ public class ClassesTest {
         Assert.assertTrue(output.contains("constructor(data: FooBar)"));
     }
 
+    @Test
+    public void testSortedConstructor() {
+        final Settings settings = TestUtils.settings();
+        settings.optionalAnnotations = Arrays.asList(Nullable.class);
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.generateConstructors = true;
+        settings.sortDeclarations = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FooBar.class));
+        String sortedPropertyAssignments = "" +
+                "        this.bar = data.bar;" + settings.newline +
+                "        this.foo = data.foo;";
+        Assert.assertTrue(output.contains(sortedPropertyAssignments));
+    }
+
+    @Test
+    public void testUnsortedConstructor() {
+        final Settings settings = TestUtils.settings();
+        settings.optionalAnnotations = Arrays.asList(Nullable.class);
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.generateConstructors = true;
+        settings.sortDeclarations = false;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FooBar.class));
+        String unsortedPropertyAssignments = "" +
+                "        this.foo = data.foo;" + settings.newline +
+                "        this.bar = data.bar;";
+        Assert.assertTrue(output.contains(unsortedPropertyAssignments));
+    }
+
     private static class FooBar {
         @Nullable
         public String foo;


### PR DESCRIPTION
Previously, `sortDeclarations = true` would cause only the generated class properties to be sorted, but the constructor assignment ordering remained unchanged. This defeats one of the main use cases of `sortDeclarations`, which is for generated code to be unchanged when the source code property ordering changes.

When `sortDeclarations = true`:
Before this change:
```typescript
export class FooBar {
	bar: number;
	foo?: string;

	constructor(data: FooBar) {
		this.foo = data.foo;
		this.bar = data.bar;
	}
}
```
After this change (sorted property assignments in constructor):
```typescript
export class FooBar {
	bar: number;
	foo?: string;

	constructor(data: FooBar) {
		this.bar = data.bar;
		this.foo = data.foo;
	}
}
```
