### PR TITLE
Support for data libraries (guava, joda, vavr)

### DIFF
--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -19,6 +19,7 @@
         <jackson2.version>2.11.1</jackson2.version>
         <jersey.version>2.31</jersey.version>
         <graalvm.version>20.1.0</graalvm.version>
+        <vavr.version>0.10.3</vavr.version>
     </properties>
 
     <dependencies>
@@ -120,6 +121,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson2.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jdk-http</artifactId>
             <version>${jersey.version}</version>
@@ -144,15 +150,46 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!--test dependencies (additional data libraries)-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>29.0-jre</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>${jackson2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.10.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>3.5.0</version>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <version>${vavr.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr-jackson</artifactId>
+            <version>${vavr.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/CustomMappingTypeProcessor.java
@@ -1,24 +1,21 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 
 public class CustomMappingTypeProcessor implements TypeProcessor {
 
-    private final Map<String, Settings.CustomTypeMapping> customMappings;
+    private final List<Settings.CustomTypeMapping> customMappings;
 
     public CustomMappingTypeProcessor(List<Settings.CustomTypeMapping> customMappings) {
-        this.customMappings = customMappings.stream().collect(Collectors.toMap(
-                mapping -> mapping.javaType.rawName,
-                mapping -> mapping));
+        this.customMappings = customMappings;
     }
 
     @Override
@@ -28,15 +25,21 @@ public class CustomMappingTypeProcessor implements TypeProcessor {
             return null;
         }
         final Class<?> rawClass = rawClassAndTypeArguments.getValue1();
-        final List<Type> typeArguments = rawClassAndTypeArguments.getValue2();
-        final Settings.CustomTypeMapping mapping = customMappings.get(rawClass.getName());
+        final Settings.CustomTypeMapping mapping = customMappings.stream()
+                .filter(m -> m.matchSubclasses
+                        ? m.rawClass.isAssignableFrom(rawClass)
+                        : m.rawClass.equals(rawClass)
+                )
+                .findFirst()
+                .orElse(null);
         if (mapping == null) {
             return null;
         }
 
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(mapping.rawClass, javaType);
         final List<Class<?>> discoveredClasses = new ArrayList<>();
         final Function<Integer, TsType> processGenericParameter = index -> {
-            final Type typeArgument = typeArguments.get(index);
+            final Type typeArgument = resolvedTypeParameters.get(index);
             final TypeProcessor.Result typeArgumentResult = context.processType(typeArgument);
             discoveredClasses.addAll(typeArgumentResult.getDiscoveredClasses());
             return typeArgumentResult.getTsType();
@@ -60,7 +63,7 @@ public class CustomMappingTypeProcessor implements TypeProcessor {
                 final TsType tsType = processGenericParameter.apply(index);
                 return new Result(tsType, discoveredClasses);
             } else {
-                return new Result(new TsType.BasicType(mapping.tsType.rawName), discoveredClasses);
+                return new Result(new TsType.VerbatimType(mapping.tsType.rawName), discoveredClasses);
             }
         }
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DataLibraryJson.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DataLibraryJson.java
@@ -1,0 +1,50 @@
+
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
+
+
+public class DataLibraryJson {
+
+    public List<ClassMapping> classMappings;
+    public List<TypeAlias> typeAliases;
+
+    public static class ClassMapping {
+        public String className;
+        public SemanticType semanticType;
+        public String customType;
+    }
+
+    public enum SemanticType {
+        String("string"),
+        Number("number"),
+        Boolean("boolean"),
+        Date("date"),
+        Any("any"),
+        Void("void"),
+        List("list"),
+        Map("map"),
+        Optional("optional"),
+        Wrapper("wrapper"),
+        ;
+
+        private final String name;
+
+        private SemanticType(String name) {
+            this.name = name;
+        }
+
+        @JsonValue
+        public String getName() {
+            return name;
+        }
+
+    }
+
+    public static class TypeAlias {
+        public String name;
+        public String definition;
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedDataLibraries.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedDataLibraries.java
@@ -1,0 +1,93 @@
+
+package cz.habarta.typescript.generator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public class LoadedDataLibraries {
+
+    public final List<Class<?>> stringClasses;
+    public final List<Class<?>> numberClasses;
+    public final List<Class<?>> booleanClasses;
+    public final List<Class<?>> dateClasses;
+    public final List<Class<?>> anyClasses;
+    public final List<Class<?>> voidClasses;
+    public final List<Class<?>> listClasses;
+    public final List<Class<?>> mapClasses;
+    public final List<Class<?>> optionalClasses;
+    public final List<Class<?>> wrapperClasses;
+    public final List<Settings.CustomTypeMapping> typeMappings;
+    public final List<Settings.CustomTypeAlias> typeAliases;
+
+    public LoadedDataLibraries() {
+        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty());
+    }
+
+    private static <T> List<T> empty() {
+        return Collections.emptyList();
+    }
+
+    public LoadedDataLibraries(
+            List<Class<?>> stringClasses,
+            List<Class<?>> numberClasses,
+            List<Class<?>> booleanClasses,
+            List<Class<?>> dateClasses,
+            List<Class<?>> anyClasses,
+            List<Class<?>> voidClasses,
+            List<Class<?>> listClasses,
+            List<Class<?>> mapClasses,
+            List<Class<?>> optionalClasses,
+            List<Class<?>> wrapperClasses,
+            List<Settings.CustomTypeMapping> typeMappings,
+            List<Settings.CustomTypeAlias> typeAliases
+    ) {
+        this.stringClasses = stringClasses;
+        this.numberClasses = numberClasses;
+        this.booleanClasses = booleanClasses;
+        this.dateClasses = dateClasses;
+        this.anyClasses = anyClasses;
+        this.voidClasses = voidClasses;
+        this.listClasses = listClasses;
+        this.mapClasses = mapClasses;
+        this.optionalClasses = optionalClasses;
+        this.wrapperClasses = wrapperClasses;
+        this.typeMappings = typeMappings;
+        this.typeAliases = typeAliases;
+    }
+
+    public static LoadedDataLibraries join(LoadedDataLibraries... jsons) {
+        return join(Arrays.asList(jsons));
+    }
+
+    public static LoadedDataLibraries join(List<LoadedDataLibraries> jsons) {
+        return new LoadedDataLibraries(
+                joinMappedLists(jsons, j -> j.stringClasses),
+                joinMappedLists(jsons, j -> j.numberClasses),
+                joinMappedLists(jsons, j -> j.booleanClasses),
+                joinMappedLists(jsons, j -> j.dateClasses),
+                joinMappedLists(jsons, j -> j.anyClasses),
+                joinMappedLists(jsons, j -> j.voidClasses),
+                joinMappedLists(jsons, j -> j.listClasses),
+                joinMappedLists(jsons, j -> j.mapClasses),
+                joinMappedLists(jsons, j -> j.optionalClasses),
+                joinMappedLists(jsons, j -> j.wrapperClasses),
+                joinMappedLists(jsons, j -> j.typeMappings),
+                joinMappedLists(jsons, j -> j.typeAliases)
+        );
+    }
+
+    private static <T, M> List<M> joinMappedLists(List<T> list, Function<T, List<M>> mapper) {
+        return list.stream()
+                .filter(Objects::nonNull)
+                .map(mapper)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -161,7 +161,7 @@ public class TypeScriptGenerator {
         }
         processors.add(new CustomMappingTypeProcessor(settings.getValidatedCustomTypeMappings()));
         processors.addAll(specificTypeProcessors);
-        processors.add(new DefaultTypeProcessor());
+        processors.add(new DefaultTypeProcessor(settings.getLoadedDataLibraries()));
         final TypeProcessor typeProcessor = new TypeProcessor.Chain(processors);
         return typeProcessor;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/GenericsResolver.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/GenericsResolver.java
@@ -44,6 +44,17 @@ public class GenericsResolver {
         return result;
     }
 
+    public static List<Type> resolveBaseGenericVariables(Class<?> baseClass, Type contextType) {
+        final Pair<Class<?>, List<Type>> rawClassAndTypeArguments = Utils.getRawClassAndTypeArguments(contextType);
+        if (rawClassAndTypeArguments != null) {
+            final ResolvedClass resolvedContextType = new ResolvedClass(null, null, null).resolveAncestor(contextType);
+            final List<ResolvedClass> path = traverseSomeInheritancePath(resolvedContextType, baseClass);
+            final ResolvedClass resolvedClass = path != null && !path.isEmpty() ? path.get(0) : resolvedContextType;
+            return new ArrayList<>(resolvedClass.resolvedTypeParameters.values());
+        }
+        return Arrays.asList(baseClass.getTypeParameters());
+    }
+
     private static String mapGenericVariableToParent(String typeVariableName, ResolvedClass resolvedParent) {
         if (typeVariableName == null) {
             return null;

--- a/typescript-generator-core/src/main/resources/datalibrary/_schema.json
+++ b/typescript-generator-core/src/main/resources/datalibrary/_schema.json
@@ -1,0 +1,109 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "type": "object",
+    "definitions": {
+        "mapping": {
+            "type": "object",
+            "properties": {
+                "className": {
+                    "markdownDescription": "Specifies class (including its subclasses). When mapping generic class to `customType` mapped class name must include generic parameters for example like this: `com.google.common.collect.Range<C>`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "className"
+            ]
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "info": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string"
+                },
+                "jacksonModule": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "classMappings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "oneOf": [
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/mapping"
+                            },
+                            {
+                                "properties": {
+                                    "semanticType": {
+                                        "type": "string",
+                                        "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "date",
+                                            "any",
+                                            "void",
+                                            "list",
+                                            "map",
+                                            "optional",
+                                            "wrapper"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "semanticType"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/mapping"
+                            },
+                            {
+                                "properties": {
+                                    "customType": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "customType"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "typeAliases": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "definition": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "definition"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/typescript-generator-core/src/main/resources/datalibrary/guava.json
+++ b/typescript-generator-core/src/main/resources/datalibrary/guava.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "./_schema.json",
+    "info": {
+        "source": "https://github.com/google/guava",
+        "jacksonModule": "https://github.com/FasterXML/jackson-datatypes-collections/blob/master/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java"
+    },
+    "classMappings": [
+        {
+            "className": "com.google.common.base.Optional",
+            "semanticType": "optional"
+        },
+        {
+            "className": "com.google.common.collect.RangeSet<C>",
+            "customType": "GuavaRangeSet<C>"
+        },
+        {
+            "className": "com.google.common.collect.Range<C>",
+            "customType": "GuavaRange<C>"
+        },
+        {
+            "className": "com.google.common.collect.Table<R, C, V>",
+            "customType": "GuavaTable<V>"
+        },
+        {
+            "className": "com.google.common.net.HostAndPort",
+            "semanticType": "string"
+        },
+        {
+            "className": "com.google.common.net.InternetDomainName",
+            "semanticType": "string"
+        },
+        {
+            "className": "com.google.common.cache.CacheBuilderSpec",
+            "semanticType": "string"
+        },
+        {
+            "className": "com.google.common.cache.CacheBuilder<K, V>",
+            "customType": "string"
+        },
+        {
+            "className": "com.google.common.hash.HashCode",
+            "semanticType": "string"
+        },
+        {
+            "className": "com.google.common.collect.FluentIterable",
+            "semanticType": "list"
+        },
+        {
+            "className": "com.google.common.collect.Multimap<K, V>",
+            "customType": "GuavaMultimap<V>"
+        }
+    ],
+    "typeAliases": [
+        {
+            "name": "GuavaRangeSet<C>",
+            "definition": "GuavaRange<C>[]"
+        },
+        {
+            "name": "GuavaRange<C>",
+            "definition": "{ lowerEndpoint: C, lowerBoundType: 'OPEN' | 'CLOSED', upperEndpoint: C, upperBoundType: 'OPEN' | 'CLOSED' }"
+        },
+        {
+            "name": "GuavaTable<V>",
+            "definition": "{ [index: string]: { [index: string]: V } }"
+        },
+        {
+            "name": "GuavaMultimap<V>",
+            "definition": "{ [index: string]: V[] }"
+        }
+    ]
+}

--- a/typescript-generator-core/src/main/resources/datalibrary/joda.json
+++ b/typescript-generator-core/src/main/resources/datalibrary/joda.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "./_schema.json",
+    "info": {
+        "source": "https://github.com/JodaOrg/joda-time",
+        "jacksonModule": "https://github.com/FasterXML/jackson-datatype-joda/blob/master/src/main/java/com/fasterxml/jackson/datatype/joda/JodaModule.java"
+    },
+    "classMappings": [
+        {
+            "className": "org.joda.time.DateTime",
+            "semanticType": "date"
+        },
+        {
+            "className": "org.joda.time.DateTimeZone",
+            "semanticType": "string"
+        },
+        {
+            "className": "org.joda.time.Duration",
+            "semanticType": "number"
+        },
+        {
+            "className": "org.joda.time.Instant",
+            "semanticType": "date"
+        },
+        {
+            "className": "org.joda.time.LocalDateTime",
+            "semanticType": "date"
+        },
+        {
+            "className": "org.joda.time.LocalDate",
+            "semanticType": "date"
+        },
+        {
+            "className": "org.joda.time.LocalTime",
+            "semanticType": "date"
+        },
+        {
+            "className": "org.joda.time.Period",
+            "semanticType": "string"
+        },
+        {
+            "className": "org.joda.time.Interval",
+            "semanticType": "string"
+        },
+        {
+            "className": "org.joda.time.MonthDay",
+            "semanticType": "string"
+        },
+        {
+            "className": "org.joda.time.YearMonth",
+            "semanticType": "string"
+        },
+        {
+            "className": "org.joda.time.DateMidnight",
+            "semanticType": "date"
+        }
+    ]
+}

--- a/typescript-generator-core/src/main/resources/datalibrary/vavr.json
+++ b/typescript-generator-core/src/main/resources/datalibrary/vavr.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "./_schema.json",
+    "info": {
+        "source": "https://github.com/vavr-io/vavr",
+        "jacksonModule": "https://github.com/vavr-io/vavr-jackson/blob/master/src/main/java/io/vavr/jackson/datatype/VavrModule.java"
+    },
+    "classMappings": [
+        {
+            "className": "io.vavr.Lazy",
+            "semanticType": "wrapper"
+        },
+        {
+            "className": "io.vavr.control.Option",
+            "semanticType": "optional"
+        },
+        {
+            "className": "io.vavr.collection.CharSeq",
+            "semanticType": "string"
+        },
+        {
+            "className": "io.vavr.collection.Seq",
+            "semanticType": "list"
+        },
+        {
+            "className": "io.vavr.collection.Set",
+            "semanticType": "list"
+        },
+        {
+            "className": "io.vavr.collection.PriorityQueue",
+            "semanticType": "list"
+        },
+        {
+            "className": "io.vavr.collection.Map",
+            "semanticType": "map"
+        },
+        {
+            "className": "io.vavr.collection.Multimap<K, V>",
+            "customType": "VavrMultimap<V>"
+        }
+    ],
+    "typeAliases": [
+        {
+            "name": "VavrMultimap<V>",
+            "definition": "{ [index: string]: V[] }"
+        }
+    ]
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -35,17 +36,7 @@ public class DateTest {
         Assert.assertTrue(dts.contains("dateList: Date[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
         Assert.assertTrue(dts.contains("dates: Date[];"));
-    }
-
-    @Test
-    public void testDate_forJodaDateTime() {
-        final Settings settings = TestUtils.settings();
-        settings.customTypeMappings.put("org.joda.time.DateTime", "Date");
-        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
-        Assert.assertTrue(dts.contains("date: Date;"));
-        Assert.assertTrue(dts.contains("dateList: Date[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
-        Assert.assertTrue(dts.contains("dates: Date[];"));
+        Assert.assertTrue(dts.contains("calendar: Date;"));
     }
 
     @Test
@@ -57,19 +48,8 @@ public class DateTest {
         Assert.assertTrue(dts.contains("dateList: DateAsNumber[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsNumber[] };"));
         Assert.assertTrue(dts.contains("dates: DateAsNumber[];"));
+        Assert.assertTrue(dts.contains("calendar: DateAsNumber;"));
         Assert.assertTrue(dts.contains("type DateAsNumber = number;"));
-    }
-
-    @Test
-    public void testDateAsNumber_forJodaDateTime() {
-        final Settings settings = TestUtils.settings();
-        settings.customTypeMappings.put("org.joda.time.DateTime", "number");
-        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
-        Assert.assertTrue(dts.contains("date: number;"));
-        Assert.assertTrue(dts.contains("dateList: number[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: number[] };"));
-        Assert.assertTrue(dts.contains("dates: number[];"));
-        Assert.assertTrue(!dts.contains("type DateAsNumber = number;"));
     }
 
     @Test
@@ -81,19 +61,8 @@ public class DateTest {
         Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
         Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
         Assert.assertTrue(dts.contains("dates: DateAsString[];"));
+        Assert.assertTrue(dts.contains("calendar: DateAsString;"));
         Assert.assertTrue(dts.contains("type DateAsString = string;"));
-    }
-
-    @Test
-    public void testDateAsString_forJodaDateTime() {
-        final Settings settings = TestUtils.settings();
-        settings.customTypeMappings.put("org.joda.time.DateTime", "string");
-        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
-        Assert.assertTrue(dts.contains("date: string;"));
-        Assert.assertTrue(dts.contains("dateList: string[];"));
-        Assert.assertTrue(dts.contains("datesMap: { [index: string]: string[] };"));
-        Assert.assertTrue(dts.contains("dates: string[];"));
-        Assert.assertTrue(!dts.contains("type DateAsString = string;"));
     }
 
     @Test
@@ -118,7 +87,7 @@ public class DateTest {
 
     public static void main(String[] args) throws JsonProcessingException {
         final ObjectMapper objectMapper = new ObjectMapper()
-                .findAndRegisterModules()
+                .registerModule(new JavaTimeModule())
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         final Clock clock = Clock.fixed(Instant.parse("2017-09-02T19:11:00Z"), ZoneId.systemDefault());
         System.out.println(objectMapper.writeValueAsString(new Date()));
@@ -141,13 +110,7 @@ class Dates {
     public List<Date> dateList;
     public Map<String, List<Date>> datesMap;
     public Date[] dates;
-}
-
-class JodaDates {
-    public org.joda.time.DateTime date;
-    public List<org.joda.time.DateTime> dateList;
-    public Map<String, List<org.joda.time.DateTime>> datesMap;
-    public org.joda.time.DateTime[] dates;
+    public Calendar calendar;
 }
 
 class Java8Dates {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
@@ -7,6 +7,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
@@ -52,6 +53,13 @@ public class DefaultTypeProcessorTest {
 
     public static TypeProcessor.Context getTestContext(final TypeProcessor typeProcessor) {
         return new TypeProcessor.Context(new SymbolTable(TestUtils.settings()), typeProcessor, null);
+    }
+
+    @Test
+    public void testRawTypes() {
+        final String output = new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(DummyBean.class));
+        Assert.assertTrue(output.contains("rawListProperty: any[]"));
+        Assert.assertTrue(output.contains("rawMapProperty: { [index: string]: any }"));
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -101,6 +102,39 @@ public class GenericsResolverTest {
     static class R12<U, V> extends R1<V, U> {
     }
     static class R123<A, B, C> extends R12<C, List<B>> {
+    }
+
+    @Test
+    public void testResolvingGenericVariablesInContextType1() throws NoSuchFieldException {
+        final Type contextType = MyClass.class.getField("property1").getGenericType();
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        Assert.assertEquals(Arrays.asList("java.lang.String", "java.lang.Integer"), resolvedTypeParameters.stream().map(Type::getTypeName).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testResolvingGenericVariablesInContextType3() throws NoSuchFieldException {
+        final Type contextType = MyClass.class.getField("property3").getGenericType();
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        Assert.assertEquals(Arrays.asList("java.lang.Integer", "java.lang.Boolean"), resolvedTypeParameters.stream().map(Type::getTypeName).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testResolvingGenericVariablesInContextTypeBase() throws NoSuchFieldException {
+        final Type contextType = MyClass.class.getField("propertyBase").getGenericType();
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        Assert.assertEquals(Arrays.asList("java.lang.Integer", "java.lang.String"), resolvedTypeParameters.stream().map(Type::getTypeName).collect(Collectors.toList()));
+    }
+
+    static class BaseClass<A, B> {}
+
+    static class SubClass1<B> extends BaseClass<String, B> {}
+
+    static class SubClass3<X, Y, Z> extends BaseClass<Z, Y> {}
+
+    static class MyClass {
+        public SubClass1<Integer> property1;
+        public SubClass3<String, Boolean, Integer> property3;
+        public BaseClass<Integer, String> propertyBase;
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/GuavaTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/GuavaTest.java
@@ -1,0 +1,110 @@
+
+package cz.habarta.typescript.generator.library;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ForwardingTable;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import com.google.common.hash.HashCode;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InternetDomainName;
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.Jackson2ConfigurationResolved;
+import cz.habarta.typescript.generator.Logger;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TestUtils;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.util.Utils;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+@SuppressWarnings("unused")
+public class GuavaTest {
+
+    @Test
+    public void testGuavaInJackson() throws JsonProcessingException {
+        final ObjectMapper objectMapper = Utils.getObjectMapper();
+        objectMapper.registerModule(new GuavaModule());
+        final String json = objectMapper.writeValueAsString(new GuavaSerializedClasses());
+//        System.out.println(json);
+    }
+
+    @Test
+    public void testGuava() {
+        TypeScriptGenerator.setLogger(new Logger(Logger.Level.Verbose));
+        final Settings settings = TestUtils.settings();
+        settings.jackson2Configuration = new Jackson2ConfigurationResolved();
+        settings.additionalDataLibraries = Arrays.asList("guava");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(GuavaSerializedClasses.class));
+        Assert.assertTrue(output.contains("rangeSet: GuavaRangeSet<string>"));
+        Assert.assertTrue(output.contains("type GuavaRangeSet<C>"));
+        Assert.assertTrue(output.contains("range: GuavaRange<Named>"));
+        Assert.assertTrue(output.contains("type GuavaRange<C>"));
+        Assert.assertTrue(output.contains("table: GuavaTable<boolean>"));
+        Assert.assertTrue(output.contains("type GuavaTable<V>"));
+        Assert.assertTrue(output.contains("hostAndPort: string"));
+        Assert.assertTrue(output.contains("internetDomainName: string"));
+        Assert.assertTrue(output.contains("cacheBuilderSpec: string"));
+        Assert.assertTrue(output.contains("cacheBuilder: string"));
+        Assert.assertTrue(output.contains("hashCode: string"));
+        Assert.assertTrue(output.contains("fluentIterable: string[]"));
+        Assert.assertTrue(output.contains("multimap: GuavaMultimap<number>"));
+        Assert.assertTrue(output.contains("type GuavaMultimap<V>"));
+    }
+
+    private static class GuavaSerializedClasses {
+        public ImmutableRangeSet<String> rangeSet = ImmutableRangeSet.of(Range.closedOpen("a", "d"));
+        public Range<Named> range = Range.closedOpen(new Named("a"), new Named("f"));
+        public Table<Character, Integer, Boolean> table = ImmutableTable.<Character, Integer, Boolean>builder()
+                .put(Tables.immutableCell('a', 1, false))
+                .put(Tables.immutableCell('b', 3, true))
+                .build();
+        public NamedTable namedTable = new NamedTable();
+        public HostAndPort hostAndPort = HostAndPort.fromParts("habarta.cz", 80);
+        public InternetDomainName internetDomainName = InternetDomainName.from("habarta.cz");
+        public CacheBuilderSpec cacheBuilderSpec = CacheBuilderSpec.parse("initialCapacity=5,expireAfterWrite=60s");
+        public CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                .initialCapacity(5)
+                .expireAfterWrite(60, TimeUnit.SECONDS);
+        public HashCode hashCode = HashCode.fromInt(45);
+        public FluentIterable<String> fluentIterable = FluentIterable.of("a", "b", "c");
+        public Multimap<String, Integer> multimap = ImmutableMultimap.of("a", 1, "b", 2);
+    }
+
+    private static class Named implements Comparable<Named> {
+        public final String name;
+
+        public Named(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public int compareTo(Named o) {
+            return this.name.compareTo(o.name);
+        }
+    }
+
+    private static class NamedTable extends ForwardingTable<String, String, Named> {
+        @Override
+        protected Table<String, String, Named> delegate() {
+            return ImmutableTable.<String, String, Named>builder()
+                .put(Tables.immutableCell("a", "1", new Named("a1")))
+                .put(Tables.immutableCell("b", "3", new Named("b3")))
+                .build();
+        }
+    }
+
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/JodaTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/JodaTest.java
@@ -1,0 +1,133 @@
+
+package cz.habarta.typescript.generator.library;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import cz.habarta.typescript.generator.DateMapping;
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TestUtils;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.util.Utils;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.joda.time.DateMidnight;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.Interval;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
+import org.joda.time.MonthDay;
+import org.joda.time.Period;
+import org.joda.time.YearMonth;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class JodaTest {
+
+    @Test
+    public void testDate_forJodaDateTime() {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeMappings.put("org.joda.time.DateTime", "Date");
+        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: Date;"));
+        Assert.assertTrue(dts.contains("dateList: Date[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: Date[] };"));
+        Assert.assertTrue(dts.contains("dates: Date[];"));
+    }
+
+    @Test
+    public void testDateAsNumber_forJodaDateTime() {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeMappings.put("org.joda.time.DateTime", "number");
+        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: number;"));
+        Assert.assertTrue(dts.contains("dateList: number[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: number[] };"));
+        Assert.assertTrue(dts.contains("dates: number[];"));
+        Assert.assertTrue(!dts.contains("type DateAsNumber = number;"));
+    }
+
+    @Test
+    public void testDateAsString_forJodaDateTime() {
+        final Settings settings = TestUtils.settings();
+        settings.customTypeMappings.put("org.joda.time.DateTime", "string");
+        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: string;"));
+        Assert.assertTrue(dts.contains("dateList: string[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: string[] };"));
+        Assert.assertTrue(dts.contains("dates: string[];"));
+        Assert.assertTrue(!dts.contains("type DateAsString = string;"));
+    }
+
+    @Test
+    public void testDateAsString_forJodaDateTime_usingDataLibrary() {
+        final Settings settings = TestUtils.settings();
+        settings.additionalDataLibraries = Arrays.asList("joda");
+        settings.mapDate = DateMapping.asString;
+        final String dts = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaDates.class));
+        Assert.assertTrue(dts.contains("date: DateAsString;"));
+        Assert.assertTrue(dts.contains("dateList: DateAsString[];"));
+        Assert.assertTrue(dts.contains("datesMap: { [index: string]: DateAsString[] };"));
+        Assert.assertTrue(dts.contains("dates: DateAsString[];"));
+        Assert.assertTrue(dts.contains("type DateAsString = string;"));
+    }
+
+    @Test
+    public void testJodaInJackson() throws Exception {
+        final ObjectMapper objectMapper = Utils.getObjectMapper();
+        objectMapper.registerModule(new JodaModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        final String json = objectMapper.writeValueAsString(new JodaSerializedClasses());
+//        System.out.println(json);
+    }
+
+    @Test
+    public void testJodaLibrary() {
+        final Settings settings = TestUtils.settings();
+        settings.additionalDataLibraries = Arrays.asList("joda");
+        settings.mapDate = DateMapping.asString;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JodaSerializedClasses.class));
+        Assert.assertTrue(output.contains("dateTime: DateAsString;"));
+        Assert.assertTrue(output.contains("dateTimeZone: string;"));
+        Assert.assertTrue(output.contains("duration: number;"));
+        Assert.assertTrue(output.contains("instant: DateAsString;"));
+        Assert.assertTrue(output.contains("localDateTime: DateAsString;"));
+        Assert.assertTrue(output.contains("localDate: DateAsString;"));
+        Assert.assertTrue(output.contains("localTime: DateAsString;"));
+        Assert.assertTrue(output.contains("period: string;"));
+        Assert.assertTrue(output.contains("interval: string;"));
+        Assert.assertTrue(output.contains("monthDay: string;"));
+        Assert.assertTrue(output.contains("yearMonth: string;"));
+        Assert.assertTrue(output.contains("dateMidnight: DateAsString;"));
+    }
+
+}
+
+class JodaDates {
+    public org.joda.time.DateTime date;
+    public List<org.joda.time.DateTime> dateList;
+    public Map<String, List<org.joda.time.DateTime>> datesMap;
+    public org.joda.time.DateTime[] dates;
+}
+
+class JodaSerializedClasses {
+    public DateTime dateTime = DateTime.now();
+    public DateTimeZone dateTimeZone = DateTimeZone.UTC;
+    public Duration duration = Duration.ZERO;
+    public Instant instant = Instant.now();
+    public LocalDateTime localDateTime = LocalDateTime.now();
+    public LocalDate localDate = LocalDate.now();
+    public LocalTime localTime = LocalTime.now();
+    public Period period = Period.ZERO;
+    public Interval interval = new Interval(Instant.now(), Instant.now().plus(10));
+    public MonthDay monthDay = MonthDay.now();
+    public YearMonth yearMonth = YearMonth.now();
+    public DateMidnight dateMidnight = DateMidnight.now();
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/VavrTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/VavrTest.java
@@ -1,0 +1,99 @@
+
+package cz.habarta.typescript.generator.library;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cz.habarta.typescript.generator.Input;
+import cz.habarta.typescript.generator.Jackson2ConfigurationResolved;
+import cz.habarta.typescript.generator.Logger;
+import cz.habarta.typescript.generator.Settings;
+import cz.habarta.typescript.generator.TestUtils;
+import cz.habarta.typescript.generator.TypeScriptGenerator;
+import cz.habarta.typescript.generator.util.Utils;
+import io.vavr.Lazy;
+import io.vavr.collection.CharSeq;
+import io.vavr.collection.LinkedHashMap;
+import io.vavr.collection.LinkedHashMultimap;
+import io.vavr.collection.LinkedHashSet;
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import io.vavr.collection.Multimap;
+import io.vavr.collection.PriorityQueue;
+import io.vavr.collection.Set;
+import io.vavr.control.Option;
+import io.vavr.jackson.datatype.VavrModule;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+@SuppressWarnings("unused")
+public class VavrTest {
+
+    @Test
+    public void testVavrInJackson() throws JsonProcessingException {
+        final ObjectMapper objectMapper = Utils.getObjectMapper();
+        objectMapper.registerModule(new VavrModule());
+        final String json = objectMapper.writeValueAsString(new VavrSerializedClasses());
+//        System.out.println(json);
+    }
+
+    @Test
+    public void testVavr() {
+        TypeScriptGenerator.setLogger(new Logger(Logger.Level.Verbose));
+        final Settings settings = TestUtils.settings();
+        settings.jackson2Configuration = new Jackson2ConfigurationResolved();
+        settings.additionalDataLibraries = Arrays.asList("vavr");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(VavrSerializedClasses.class));
+        Assert.assertTrue(output.contains("lazy: number"));
+        Assert.assertTrue(output.contains("option?: number"));
+        Assert.assertTrue(output.contains("charSeq: string"));
+        Assert.assertTrue(output.contains("list: string[]"));
+        Assert.assertTrue(output.contains("set: string[]"));
+        Assert.assertTrue(output.contains("priorityQueue: number[]"));
+        Assert.assertTrue(output.contains("map: { [index: string]: number }"));
+        Assert.assertTrue(output.contains("multimap: VavrMultimap<number>"));
+        Assert.assertTrue(output.contains("multimap2: VavrMultimap<Value>"));
+        Assert.assertTrue(output.contains("type VavrMultimap<V>"));
+    }
+
+    private static final Key aKey = new Key("a");
+    private static final Key bKey = new Key("b");
+
+    private static class VavrSerializedClasses {
+        public Lazy<BigDecimal> lazy = Lazy.of(() -> BigDecimal.ONE);
+        public Option<BigDecimal> option = Option.some(BigDecimal.ONE);
+        public CharSeq charSeq = CharSeq.of("abc");
+        public List<String> list = List.of("a", "b");
+        public Set<String> set = LinkedHashSet.of("a", "b");
+        public PriorityQueue<Integer> priorityQueue = PriorityQueue.of(1, 2, 3);
+        public Map<String, BigInteger> map = LinkedHashMap.of("a", BigInteger.ONE, "b", BigInteger.TEN);
+        public Multimap<String, Integer> multimap = LinkedHashMultimap.withSeq().of("a", 1, "a", 1, "b", 2);
+        public Multimap<Key, Value> multimap2 = LinkedHashMultimap.withSeq().of(aKey, new Value("1"), aKey, new Value("1"), bKey, new Value("2"), bKey, null);
+    }
+
+    private static class Key {
+        public final String key;
+
+        public Key(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String toString() {
+            return key;
+        }
+
+    }
+
+    private static class Value {
+        public final String value;
+
+        public Value(String value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -60,6 +60,7 @@ public class GenerateTask extends DefaultTask {
     public Jackson2Configuration jackson2Configuration;
     public GsonConfiguration gsonConfiguration;
     public JsonbConfiguration jsonbConfiguration;
+    public List<String> additionalDataLibraries;
     @Deprecated public boolean declarePropertiesAsOptional;
     public OptionalProperties optionalProperties;
     public OptionalPropertiesDeclaration optionalPropertiesDeclaration;
@@ -140,6 +141,7 @@ public class GenerateTask extends DefaultTask {
         settings.setJackson2Configuration(classLoader, jackson2Configuration);
         settings.gsonConfiguration = gsonConfiguration;
         settings.jsonbConfiguration = jsonbConfiguration;
+        settings.additionalDataLibraries = additionalDataLibraries;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
         settings.optionalProperties = optionalProperties;
         settings.optionalPropertiesDeclaration = optionalPropertiesDeclaration;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -236,6 +236,20 @@ public class GenerateMojo extends AbstractMojo {
     private JsonbConfiguration jsonbConfiguration;
 
     /**
+     * Allows to add support for specified libraries.
+     * Some libraries have special Jackson serializers and deserializers for their data types so this parameter allows to reflect actual JSON format of those data types.
+     * Note: specified library must be present in project dependencies (typescript-generator itself doesn't depend on those libraries).
+     * Supported libraries are:
+     * <ul>
+     * <li><code>guava</code> (<a href="https://github.com/google/guava">source</a>) (<a href="https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/guava.json">definition</a>)</li>
+     * <li><code>joda</code> (<a href="https://github.com/JodaOrg/joda-time">source</a>) (<a href="https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/joda.json">definition</a>)</li>
+     * <li><code>vavr</code> (<a href="https://github.com/vavr-io/vavr">source</a>) (<a href="https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/vavr.json">definition</a>)</li>
+     * </ul>
+     */
+    @Parameter
+    private List<String> additionalDataLibraries;
+
+    /**
      * <b>Deprecated</b>, use {@link #optionalProperties} parameter.
      */
     @Deprecated
@@ -804,6 +818,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.setJackson2Configuration(classLoader, jackson2Configuration);
         settings.gsonConfiguration = gsonConfiguration;
         settings.jsonbConfiguration = jsonbConfiguration;
+        settings.additionalDataLibraries = additionalDataLibraries;
         settings.declarePropertiesAsOptional = declarePropertiesAsOptional;
         settings.optionalProperties = optionalProperties;
         settings.optionalPropertiesDeclaration = optionalPropertiesDeclaration;


### PR DESCRIPTION
This is implementation of general mechanism for mapping certain Java types from supported library to TypeScript without modifying typescript-generator Java source code and adding dependency on supported library.

Let's first see how these libraries are supported in Jackson2. Jackson2 has concept of modules so for example for [guava](https://github.com/google/guava) library there is a [GuavaModule](https://github.com/FasterXML/jackson-datatypes-collections/blob/master/guava/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java) (in `com.fasterxml.jackson.datatype:jackson-datatype-guava`) that adds support for guava to Jackson2 by adding serializers and deserializers for certain guava data types.

To map those types correctly in typescript-generator previously it was needed to use `customTypeMappings` parameter to add mappings for needed types manually. Instead of this it is now possible to add `guava` mappings using `additionalDataLibraries` parameter. Here is Maven example:

``` xml
<configuration>
    <jsonLibrary>jackson2</jsonLibrary>
    <additionalDataLibraries>
        <library>guava</library>
    </additionalDataLibraries>
    ...
</configuration>
```

Supported libraries are:
- `guava` ([source](https://github.com/google/guava)) ([definition](https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/guava.json))
- `joda` ([source](https://github.com/JodaOrg/joda-time)) ([definition](https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/joda.json))
- `vavr` ([source](https://github.com/vavr-io/vavr)) ([definition](https://github.com/vojtechhabarta/typescript-generator/blob/master/typescript-generator-core/src/main/resources/datalibrary/vavr.json))

Note: typescript-generator doesn't have dependency on those libraries (except for tests) but it needs to load classes from libraries definitions to be able to also recognize their subclasses. So it relies on user project dependencies.

As mentioned this feature processes also subclasses which is different from `customTypeMappings` parameter that can't map subclasses (yet).

This PR also changes how built-in (known) types are handled. Previously there were individual mappings (without subclasses) whereas now there are mappings for supertypes like `Number` (which matches also for example `BigDecimal` and `com.google.common.primitives.UnsignedInteger`) or `Date` (which matches also for example subclasses in `java.sql` package). And also mapping for `Calendar` class was added.

This PR is related to #532 (Vavr support). Difference is that this PR doesn't require adding Vavr dependency. It also adds mapping for more Vavr data types.

This PR is also related to #435 (custom mappings of supertypes). It prepares some logic (subclasses, generics) for easier implementation.