### PR TITLE
Javadoc generation : use class field's javadoc as a default when no javadoc is found on getter/setter

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -90,8 +90,8 @@ public class Javadoc {
     }
 
     private PropertyModel enrichProperty(PropertyModel property, List<Field> dFields, List<Method> dMethods) {
-        final String propertyComment;
-        final List<TagInfo> tags;
+        String propertyComment = null;
+        List<TagInfo> tags = null;
         if (property.getOriginalMember() instanceof java.lang.reflect.Method) {
             final Method dMethod = findJavadocMethod(property.getOriginalMember().getName(), dMethods);
             propertyComment = dMethod != null ? dMethod.getComment() : null;
@@ -100,7 +100,9 @@ public class Javadoc {
             final Field dField = findJavadocField(property.getOriginalMember().getName(), dFields);
             propertyComment = dField != null ? dField.getComment() : null;
             tags = dField != null ? dField.getTag() : null;
-        } else {
+        } 
+        if (propertyComment == null )  {
+            //give a chance for comments on fields but not on getter setters
             final Field dField = findJavadocField(property.getName(), dFields);
             propertyComment = dField != null ? dField.getComment() : null;
             tags = dField != null ? dField.getTag() : null;


### PR DESCRIPTION
just lovin this plugin <3

I use it to generate typescript and pasted like a monkey the (very good and working) tutorial to generate Javadoc from one project to another and works like a charm but i'm just facing one problem : 
I use lombok getter/setter generation so i write Javadoc directly on class attributes.
The Javadoc is well generated (just added a `<show>private</show>` in maven-javadoc-plugin configuration) when i inspect javadoc.xml ait is not inserted in typescript.

I think it would be nice to search for javadoc on getters/setters if any but to fallback to property's javadoc

This is the content of this pull request

Thx for your work !