### PR TITLE
Issue #569: excludePropertyAnnotations not respected when using gson

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
@@ -9,8 +9,6 @@ import cz.habarta.typescript.generator.ExcludingTypeProcessor;
 import cz.habarta.typescript.generator.GsonConfiguration;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TypeProcessor;
-
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -18,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 public class GsonParser extends ModelParser {
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/GsonParser.java
@@ -1,5 +1,7 @@
 package cz.habarta.typescript.generator.parser;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
@@ -7,6 +9,8 @@ import cz.habarta.typescript.generator.ExcludingTypeProcessor;
 import cz.habarta.typescript.generator.GsonConfiguration;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TypeProcessor;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -14,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class GsonParser extends ModelParser {
 
@@ -50,6 +55,17 @@ public class GsonParser extends ModelParser {
             : Modifier.STATIC | Modifier.TRANSIENT;
         this.gson = new GsonBuilder()
             .excludeFieldsWithModifiers(modifiers)
+            .setExclusionStrategies(new ExclusionStrategy() {
+                @Override
+                public boolean shouldSkipField(FieldAttributes fieldAttributes) {
+                    return !isAnnotatedPropertyIncluded(fieldAttributes::getAnnotation, fieldAttributes.getDeclaringClass().getName() + "." + fieldAttributes.getName());
+                }
+
+                @Override
+                public boolean shouldSkipClass(Class<?> aClass) {
+                    return false;
+                }
+            })
             .create();
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
@@ -4,16 +4,38 @@ package cz.habarta.typescript.generator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 
 @SuppressWarnings("unused")
+@RunWith(Parameterized.class)
 public class IncludeExcludePropertyTest {
+
+    @Parameterized.Parameters(name = "{index} - {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.stream(JsonLibrary.values())
+                .filter(library -> library != JsonLibrary.jackson1 && library != JsonLibrary.jsonb)
+                .map(library -> new Object[]{library})
+                .collect(Collectors.toList());
+    }
+
+    private final JsonLibrary library;
+
+    public IncludeExcludePropertyTest(JsonLibrary library) {
+        this.library = library;
+    }
+
 
     @Test
     public void testInclude() {
         final Settings settings = TestUtils.settings();
+        settings.jsonLibrary = library;
         settings.includePropertyAnnotations = Arrays.asList(MyInclude.class);
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithAnnotatedProperties.class));
         Assert.assertTrue(!output.contains("property1"));
@@ -25,6 +47,7 @@ public class IncludeExcludePropertyTest {
     @Test
     public void testExclude() {
         final Settings settings = TestUtils.settings();
+        settings.jsonLibrary = library;
         settings.excludePropertyAnnotations = Arrays.asList(MyExclude.class);
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithAnnotatedProperties.class));
         Assert.assertTrue(output.contains("property1"));
@@ -36,6 +59,8 @@ public class IncludeExcludePropertyTest {
     @Test
     public void testBoth() {
         final Settings settings = TestUtils.settings();
+        settings.jsonLibrary = library;
+
         settings.includePropertyAnnotations = Arrays.asList(MyInclude.class);
         settings.excludePropertyAnnotations = Arrays.asList(MyExclude.class);
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithAnnotatedProperties.class));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
@@ -6,7 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
The excludePropertyAnnotations property is not respected when using gson
as JsonLibrary.

* Configured an exclusion strategy on the GsonParser to fix the issue
* Adjusted the IncludeExcludePropertyTest to reveal the issue and check
the fix.