### PR TITLE
Added setting for formatting enum keys in pascal case

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -83,6 +83,7 @@ public class Settings {
     private List<CustomTypeAlias> validatedCustomTypeAliases = null;
     public DateMapping mapDate; // default is DateMapping.asDate
     public EnumMapping mapEnum; // default is EnumMapping.asUnion
+    public boolean pascalCaseEnums = false;
     public boolean nonConstEnums = false;
     public List<Class<? extends Annotation>> nonConstEnumAnnotations = new ArrayList<>();
     public ClassMapping mapClasses; // default is ClassMapping.asInterfaces

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyMixedCaseEnum.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyMixedCaseEnum.java
@@ -1,0 +1,7 @@
+package cz.habarta.typescript.generator;
+
+public enum DummyMixedCaseEnum {
+    camelCaseType,
+    PascalCaseType,
+    UPPER_CASE_TYPE
+}

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -124,6 +124,36 @@ public class EnumTest {
     }
 
     @Test
+    public void testEnumsAsPascalCaseWithClassEnumPattern() {
+        final Settings settings = TestUtils.settings();
+        settings.mapEnum = EnumMapping.asEnum;
+        settings.pascalCaseEnums = true;
+        settings.jsonLibrary = JsonLibrary.jackson2;
+        final ClassEnumExtension classEnumExtension = new ClassEnumExtension();
+        classEnumExtension.setConfiguration(Collections.singletonMap("classEnumPattern", "Enum"));
+        settings.extensions.add(classEnumExtension);
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class, DummyMixedCaseEnum.class));
+        final String expected = (
+                "\ndeclare const enum DummyClassEnum {\n" +
+                        "    Atype = 'ATYPE',\n" +
+                        "    Btype = 'BTYPE',\n" +
+                        "    Ctype = 'CTYPE',\n" +
+                        "}\n" +
+                        "\ndeclare const enum DummyEnum {\n" +
+                        "    Red = 'Red',\n" +
+                        "    Green = 'Green',\n" +
+                        "    Blue = 'Blue',\n" +
+                        "}\n" +
+                        "\ndeclare const enum DummyMixedCaseEnum {\n" +
+                        "    CamelCaseType = 'camelCaseType',\n" +
+                        "    PascalCaseType = 'PascalCaseType',\n" +
+                        "    UpperCaseType = 'UPPER_CASE_TYPE',\n" +
+                        "}\n"
+        ).replace("'", "\"");
+        assertEquals(expected.trim(), output.trim());
+    }
+
+    @Test
     public void testEnumWithJsonPropertyAnnotations() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonPropertyAnnotations.class));


### PR DESCRIPTION
Our API team likes to use UNDERSCORE_CASE enums, but UI team prefers the more readable pascal casing. 

This adds an optional setting to format the keys accordingly.