### PR TITLE
Support @Deprecated #since & #forRemoval in comment's generation

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
@@ -5,7 +5,10 @@ import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -14,6 +17,8 @@ import java.util.stream.Collectors;
 
 public class DeprecationEnricher {
 
+    public static final String DEPRECATED = "@deprecated";
+
     public Model enrichModel(Model model) {
         final List<BeanModel> beans = mapList(model.getBeans(), this::enrichBean);
         final List<EnumModel> enums = mapList(model.getEnums(), this::enrichEnum);
@@ -21,14 +26,14 @@ public class DeprecationEnricher {
         return new Model(beans, enums, restApplications);
     }
 
-    private BeanModel enrichBean(BeanModel bean) {
+    public BeanModel enrichBean(BeanModel bean) {
         final List<PropertyModel> properties = mapList(bean.getProperties(), property -> enrichProperty(property));
         return bean
                 .withProperties(properties)
                 .withComments(addDeprecation(bean.getComments(), bean.getOrigin()));
     }
 
-    private PropertyModel enrichProperty(PropertyModel property) {
+    public PropertyModel enrichProperty(PropertyModel property) {
         if (property.getOriginalMember() instanceof Method) {
             final Method method = (Method) property.getOriginalMember();
             return enrichMethodProperty(property, method);
@@ -40,46 +45,90 @@ public class DeprecationEnricher {
         }
     }
 
-    private PropertyModel enrichFieldProperty(PropertyModel property, Field field) {
+    public PropertyModel enrichFieldProperty(PropertyModel property, Field field) {
         return property
                 .withComments(addDeprecation(property.getComments(), field));
     }
 
-    private PropertyModel enrichMethodProperty(PropertyModel property, Method method) {
+    public PropertyModel enrichMethodProperty(PropertyModel property, Method method) {
         return property
                 .withComments(addDeprecation(property.getComments(), method));
     }
 
-    private EnumModel enrichEnum(EnumModel enumModel) {
+    public EnumModel enrichEnum(EnumModel enumModel) {
         final List<EnumMemberModel> members = mapList(enumModel.getMembers(), enumMember -> enrichEnumMember(enumMember));
         return enumModel
                 .withMembers(members)
                 .withComments(addDeprecation(enumModel.getComments(), enumModel.getOrigin()));
     }
 
-    private EnumMemberModel enrichEnumMember(EnumMemberModel enumMember) {
+    public EnumMemberModel enrichEnumMember(EnumMemberModel enumMember) {
         return enumMember
                 .withComments(addDeprecation(enumMember.getComments(), enumMember.getOriginalField()));
     }
 
-    private RestApplicationModel enrichRestApplication(RestApplicationModel restApplicationModel) {
+    public RestApplicationModel enrichRestApplication(RestApplicationModel restApplicationModel) {
         final List<RestMethodModel> enrichedRestMethods = mapList(restApplicationModel.getMethods(), restMethod -> enrichRestMethod(restMethod));
         return restApplicationModel.withMethods(enrichedRestMethods);
     }
 
-    private RestMethodModel enrichRestMethod(RestMethodModel method) {
+    public RestMethodModel enrichRestMethod(RestMethodModel method) {
         return method
                 .withComments(addDeprecation(method.getComments(), method.getOriginalMethod()));
     }
 
-    private static <R, T> List<R> mapList(List<T> list, Function<T, R> mapper) {
-        return list.stream().map(mapper).collect(Collectors.toList());
+    public List<String> addDeprecation(List<String> comments, AnnotatedElement annotatedElement) {
+        if (annotatedElement == null || !annotatedElement.isAnnotationPresent(Deprecated.class) || containsDeprecatedTag(comments)) {
+            return comments;
+        }
+
+        String deprecatedComment = convertToComment(annotatedElement.getAnnotation(Deprecated.class));
+        return Utils.concat(comments, Collections.singletonList(deprecatedComment));
     }
 
-    private static List<String> addDeprecation(List<String> comments, AnnotatedElement annotatedElement) {
-        return annotatedElement != null && annotatedElement.isAnnotationPresent(Deprecated.class) && !containsDeprecatedTag(comments)
-                ? Utils.concat(comments, Collections.singletonList("@deprecated"))
-                : comments;
+    protected String convertToComment(Deprecated deprecated) {
+        // support for java 9+ syntax
+        String since = getSince(deprecated);
+        boolean forRemoval = getForRemoval(deprecated);
+
+        List<String> additional = new ArrayList<>();
+        if (!"".equals(since)) {
+            additional.add("since: " + since);
+        }
+        if (forRemoval) {
+            additional.add("forRemoval: true");
+        }
+        return additional.isEmpty() ? DEPRECATED : (DEPRECATED + " " + String.join("; ", additional));
+    }
+
+    protected String getSince(Deprecated deprecated) {
+        return Arrays.stream(deprecated.getClass().getMethods())
+            .filter(m -> m.getName().equals("since"))
+            .map(m -> {
+                try {
+                    return (String) m.invoke(deprecated);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    return "";
+                }
+            })
+            .findFirst().orElse("");
+    }
+
+    protected boolean getForRemoval(Deprecated deprecated) {
+        return Arrays.stream(deprecated.getClass().getMethods())
+            .filter(m -> m.getName().equals("forRemoval"))
+            .map(m -> {
+                try {
+                    return (boolean) m.invoke(deprecated);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    return false;
+                }
+            })
+            .findFirst().orElse(false);
+    }
+
+    private static <R, T> List<R> mapList(List<T> list, Function<T, R> mapper) {
+        return list.stream().map(mapper).collect(Collectors.toList());
     }
 
     private static boolean containsDeprecatedTag(List<String> comments) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
@@ -2,13 +2,11 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+import cz.habarta.typescript.generator.util.DeprecationUtils;
 import cz.habarta.typescript.generator.util.Utils;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -17,8 +15,6 @@ import java.util.stream.Collectors;
 
 public class DeprecationEnricher {
 
-    public static final String DEPRECATED = "@deprecated";
-
     public Model enrichModel(Model model) {
         final List<BeanModel> beans = mapList(model.getBeans(), this::enrichBean);
         final List<EnumModel> enums = mapList(model.getEnums(), this::enrichEnum);
@@ -26,14 +22,14 @@ public class DeprecationEnricher {
         return new Model(beans, enums, restApplications);
     }
 
-    public BeanModel enrichBean(BeanModel bean) {
+    private BeanModel enrichBean(BeanModel bean) {
         final List<PropertyModel> properties = mapList(bean.getProperties(), property -> enrichProperty(property));
         return bean
                 .withProperties(properties)
                 .withComments(addDeprecation(bean.getComments(), bean.getOrigin()));
     }
 
-    public PropertyModel enrichProperty(PropertyModel property) {
+    private PropertyModel enrichProperty(PropertyModel property) {
         if (property.getOriginalMember() instanceof Method) {
             final Method method = (Method) property.getOriginalMember();
             return enrichMethodProperty(property, method);
@@ -45,95 +41,54 @@ public class DeprecationEnricher {
         }
     }
 
-    public PropertyModel enrichFieldProperty(PropertyModel property, Field field) {
+    private PropertyModel enrichFieldProperty(PropertyModel property, Field field) {
         return property
                 .withComments(addDeprecation(property.getComments(), field));
     }
 
-    public PropertyModel enrichMethodProperty(PropertyModel property, Method method) {
+    private PropertyModel enrichMethodProperty(PropertyModel property, Method method) {
         return property
                 .withComments(addDeprecation(property.getComments(), method));
     }
 
-    public EnumModel enrichEnum(EnumModel enumModel) {
+    private EnumModel enrichEnum(EnumModel enumModel) {
         final List<EnumMemberModel> members = mapList(enumModel.getMembers(), enumMember -> enrichEnumMember(enumMember));
         return enumModel
                 .withMembers(members)
                 .withComments(addDeprecation(enumModel.getComments(), enumModel.getOrigin()));
     }
 
-    public EnumMemberModel enrichEnumMember(EnumMemberModel enumMember) {
+    private EnumMemberModel enrichEnumMember(EnumMemberModel enumMember) {
         return enumMember
                 .withComments(addDeprecation(enumMember.getComments(), enumMember.getOriginalField()));
     }
 
-    public RestApplicationModel enrichRestApplication(RestApplicationModel restApplicationModel) {
+    private RestApplicationModel enrichRestApplication(RestApplicationModel restApplicationModel) {
         final List<RestMethodModel> enrichedRestMethods = mapList(restApplicationModel.getMethods(), restMethod -> enrichRestMethod(restMethod));
         return restApplicationModel.withMethods(enrichedRestMethods);
     }
 
-    public RestMethodModel enrichRestMethod(RestMethodModel method) {
+    private RestMethodModel enrichRestMethod(RestMethodModel method) {
         return method
                 .withComments(addDeprecation(method.getComments(), method.getOriginalMethod()));
-    }
-
-    public List<String> addDeprecation(List<String> comments, AnnotatedElement annotatedElement) {
-        if (annotatedElement == null || !annotatedElement.isAnnotationPresent(Deprecated.class) || containsDeprecatedTag(comments)) {
-            return comments;
-        }
-
-        String deprecatedComment = convertToComment(annotatedElement.getAnnotation(Deprecated.class));
-        return Utils.concat(comments, Collections.singletonList(deprecatedComment));
-    }
-
-    protected String convertToComment(Deprecated deprecated) {
-        // support for java 9+ syntax
-        String since = getSince(deprecated);
-        boolean forRemoval = getForRemoval(deprecated);
-
-        List<String> additional = new ArrayList<>();
-        if (!"".equals(since)) {
-            additional.add("since: " + since);
-        }
-        if (forRemoval) {
-            additional.add("forRemoval: true");
-        }
-        return additional.isEmpty() ? DEPRECATED : (DEPRECATED + " " + String.join("; ", additional));
-    }
-
-    protected String getSince(Deprecated deprecated) {
-        return Arrays.stream(deprecated.getClass().getMethods())
-            .filter(m -> m.getName().equals("since"))
-            .map(m -> {
-                try {
-                    return (String) m.invoke(deprecated);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    return "";
-                }
-            })
-            .findFirst().orElse("");
-    }
-
-    protected boolean getForRemoval(Deprecated deprecated) {
-        return Arrays.stream(deprecated.getClass().getMethods())
-            .filter(m -> m.getName().equals("forRemoval"))
-            .map(m -> {
-                try {
-                    return (boolean) m.invoke(deprecated);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    return false;
-                }
-            })
-            .findFirst().orElse(false);
     }
 
     private static <R, T> List<R> mapList(List<T> list, Function<T, R> mapper) {
         return list.stream().map(mapper).collect(Collectors.toList());
     }
 
+    private static List<String> addDeprecation(List<String> comments, AnnotatedElement annotatedElement) {
+        if (annotatedElement == null || !annotatedElement.isAnnotationPresent(Deprecated.class) || containsDeprecatedTag(comments)) {
+            return comments;
+        }
+
+        String deprecatedComment = DeprecationUtils.convertToComment(annotatedElement.getAnnotation(Deprecated.class));
+        return Utils.concat(comments, Collections.singletonList(deprecatedComment));
+    }
+
     private static boolean containsDeprecatedTag(List<String> comments) {
         return comments != null
-                ? comments.stream().anyMatch(comment -> comment.startsWith("@deprecated"))
+                ? comments.stream().anyMatch(comment -> comment.startsWith(DeprecationUtils.DEPRECATED))
                 : false;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/DeprecationUtils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/DeprecationUtils.java
@@ -1,0 +1,24 @@
+package cz.habarta.typescript.generator.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DeprecationUtils {
+
+    public static final String DEPRECATED = "@deprecated";
+
+    public static String convertToComment(Deprecated deprecated) {
+        // support for java 9+ syntax
+        String since = Utils.getAnnotationElementValue(deprecated, "since", String.class);
+        Boolean forRemoval = Utils.getAnnotationElementValue(deprecated, "forRemoval", Boolean.class);
+
+        List<String> additional = new ArrayList<>();
+        if (since != null && !since.isEmpty()) {
+            additional.add("since: " + since);
+        }
+        if (forRemoval != null && forRemoval) {
+            additional.add("forRemoval: true");
+        }
+        return additional.isEmpty() ? DEPRECATED : (DEPRECATED + " " + String.join("; ", additional));
+    }
+}


### PR DESCRIPTION
Hi!
I supported methods `since` and `forRemoval` in `@Deprecated` annotation, which are only introduced in java9.
#603