### PR TITLE
Fixing flaky tests

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class ReadOnlyWriteOnlyTest {
     }
 
     @Test
-    public void test() {
+    public void test() throws JsonProcessingException {
         final Settings settings = TestUtils.settings();
         settings.generateReadonlyAndWriteonlyJSDocTags = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ReadOnlyWriteOnlyUser.class));
@@ -93,7 +94,10 @@ public class ReadOnlyWriteOnlyTest {
                 + "     */\n"
                 + "    password2: string;\n"
                 + "}\n";
-        Assert.assertEquals(expected, output);
+        ObjectMapper mapper = JsonMapper.builder()
+                .nodeFactory(new SortingNodeFactory())
+                .build();
+        Assert.assertEquals(mapper.writeValueAsString(mapper.readTree(expected)), mapper.writeValueAsString(mapper.readTree(output)));
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortingNodeFactory.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortingNodeFactory.java
@@ -1,0 +1,12 @@
+package cz.habarta.typescript.generator;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.TreeMap;
+
+public class SortingNodeFactory extends JsonNodeFactory {
+    @Override
+    public ObjectNode objectNode() {
+        return new ObjectNode(this, new TreeMap<>());
+    }
+}


### PR DESCRIPTION
Nondex tool identifies 59 flaky tests in this project. You can find the full list here: http://mir.cs.illinois.edu/flakytests/unfixed.html. 
I see all of the flaky tests can be fixed with a single fix. Here, I am encoding the output back into JSON using a mapper and then writing it back out again but sorted. This removes the test flakiness caused by the order of the json components. This pull request fix a single test. If you accept this, I may fix all of those 59 tests.
