### PR TITLE
Add parameters make all primitives non nullable

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -123,7 +123,7 @@ public class Settings {
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> requiredAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> nullableAnnotations = new ArrayList<>();
-    public boolean allPrimitivesRequired = false;
+    public boolean primitivePropertiesRequired = false;
     public boolean generateInfoJson = false;
     public boolean generateNpmPackageJson = false;
     public String npmName = null;
@@ -385,8 +385,8 @@ public class Settings {
         if (!optionalAnnotations.isEmpty() && !requiredAnnotations.isEmpty()) {
             throw new RuntimeException("Only one of 'optionalAnnotations' and 'requiredAnnotations' can be used at the same time.");
         }
-        if (allPrimitivesRequired && requiredAnnotations.isEmpty()) {
-            throw new RuntimeException("'allPrimitivesRequired' parameter can only be used with 'requiredAnnotations' parameter.");
+        if (primitivePropertiesRequired && requiredAnnotations.isEmpty()) {
+            throw new RuntimeException("'primitivePropertiesRequired' parameter can only be used with 'requiredAnnotations' parameter.");
         }
         for (Class<? extends Annotation> annotation : nullableAnnotations) {
             final Target target = annotation.getAnnotation(Target.class);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -123,6 +123,7 @@ public class Settings {
     public List<Class<? extends Annotation>> optionalAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> requiredAnnotations = new ArrayList<>();
     public List<Class<? extends Annotation>> nullableAnnotations = new ArrayList<>();
+    public boolean allPrimitivesRequired = false;
     public boolean generateInfoJson = false;
     public boolean generateNpmPackageJson = false;
     public String npmName = null;
@@ -383,6 +384,9 @@ public class Settings {
         }
         if (!optionalAnnotations.isEmpty() && !requiredAnnotations.isEmpty()) {
             throw new RuntimeException("Only one of 'optionalAnnotations' and 'requiredAnnotations' can be used at the same time.");
+        }
+        if (allPrimitivesRequired && requiredAnnotations.isEmpty()) {
+            throw new RuntimeException("'allPrimitivesRequired' parameter can only be used with 'requiredAnnotations' parameter.");
         }
         for (Class<? extends Annotation> annotation : nullableAnnotations) {
             final Target target = annotation.getAnnotation(Target.class);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -184,7 +184,7 @@ public abstract class ModelParser {
             if (!settings.optionalAnnotations.isEmpty()) {
                 return Utils.hasAnyAnnotation(propertyMember::getAnnotation, settings.optionalAnnotations);
             }
-            if (settings.allPrimitivesRequired && propertyMember.isPrimitive()) {
+            if (settings.primitivePropertiesRequired && Utils.isPrimitiveType(propertyMember.getType())) {
                 return false;
             }
             if (!settings.requiredAnnotations.isEmpty()) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -184,6 +184,9 @@ public abstract class ModelParser {
             if (!settings.optionalAnnotations.isEmpty()) {
                 return Utils.hasAnyAnnotation(propertyMember::getAnnotation, settings.optionalAnnotations);
             }
+            if (settings.allPrimitivesRequired && propertyMember.isPrimitive()) {
+                return false;
+            }
             if (!settings.requiredAnnotations.isEmpty()) {
                 return !Utils.hasAnyAnnotation(propertyMember::getAnnotation, settings.requiredAnnotations);
             }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -14,6 +16,7 @@ public class PropertyMember {
     private final Type type;
     private final AnnotatedType annotatedType;
     private final AnnotationGetter annotationGetter;
+    private final List<String> PRIMITIVES = Arrays.asList("byte", "short", "int", "long", "boolean", "float", "double", "char", "void");
 
     public PropertyMember(AnnotatedElement annotatedElement, Type type, AnnotatedType annotatedType, AnnotationGetter annotationGetter) {
         this.annotatedElement = Objects.requireNonNull(annotatedElement);
@@ -33,6 +36,10 @@ public class PropertyMember {
         return annotation != null
                 ? annotation
                 : annotatedType.getAnnotation(annotationClass);
+    }
+
+    public boolean isPrimitive() {
+        return PRIMITIVES.contains(type.getTypeName());
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
@@ -5,8 +5,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 
@@ -16,7 +14,6 @@ public class PropertyMember {
     private final Type type;
     private final AnnotatedType annotatedType;
     private final AnnotationGetter annotationGetter;
-    private final List<String> PRIMITIVES = Arrays.asList("byte", "short", "int", "long", "boolean", "float", "double", "char", "void");
 
     public PropertyMember(AnnotatedElement annotatedElement, Type type, AnnotatedType annotatedType, AnnotationGetter annotationGetter) {
         this.annotatedElement = Objects.requireNonNull(annotatedElement);
@@ -36,10 +33,6 @@ public class PropertyMember {
         return annotation != null
                 ? annotation
                 : annotatedType.getAnnotation(annotationClass);
-    }
-
-    public boolean isPrimitive() {
-        return PRIMITIVES.contains(type.getTypeName());
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -268,6 +268,14 @@ public final class Utils {
                 .toArray(Type[]::new);
     }
 
+    public static boolean isPrimitiveType(Type type) {
+        if (type instanceof Class<?>) {
+            final Class<?> cls = (Class<?>) type;
+            return cls.isPrimitive();
+        }
+        return false;
+    }
+
     public static <T> List<T> concat(List<? extends T> list1, List<? extends T> list2) {
         if (list1 == null && list2 == null) {
             return null;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
@@ -217,7 +217,7 @@ public class OptionalAnnotationTest {
         {
             final Settings settings = TestUtils.settings();
             settings.requiredAnnotations = Arrays.asList(MarkerAnnotation.class);
-            settings.allPrimitivesRequired = true;
+            settings.primitivePropertiesRequired = true;
             final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithPrimitiveField.class));
             Assert.assertTrue(output.contains("charVar1: string;"));
             Assert.assertTrue(output.contains("byteVar1: number;"));
@@ -244,11 +244,11 @@ public class OptionalAnnotationTest {
         try {
             final Settings settings = TestUtils.settings();
             settings.requiredAnnotations = Arrays.asList();
-            settings.allPrimitivesRequired = true;
+            settings.primitivePropertiesRequired = true;
             new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithPrimitiveField.class));
             Assert.fail();
         } catch (Exception e) {
-            // expected - 'allPrimitivesRequired' parameter can only be used with 'requiredAnnotations' parameter
+            // expected - 'primitivePropertiesRequired' parameter can only be used with 'requiredAnnotations' parameter
         }
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
@@ -11,6 +11,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -206,6 +210,70 @@ public class OptionalAnnotationTest {
 
     @Retention(RetentionPolicy.RUNTIME)
     public @interface MarkerAnnotation {
+    }
+
+    @Test
+    public void testPrimitiveFieldRequired() {
+        {
+            final Settings settings = TestUtils.settings();
+            settings.requiredAnnotations = Arrays.asList(MarkerAnnotation.class);
+            settings.allPrimitivesRequired = true;
+            final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithPrimitiveField.class));
+            Assert.assertTrue(output.contains("charVar1: string;"));
+            Assert.assertTrue(output.contains("byteVar1: number;"));
+            Assert.assertTrue(output.contains("shortVar1: number;"));
+            Assert.assertTrue(output.contains("intVar1: number;"));
+            Assert.assertTrue(output.contains("longVar1: number;"));
+            Assert.assertTrue(output.contains("floatVar1: number;"));
+            Assert.assertTrue(output.contains("doubleVar1: number;"));
+            Assert.assertTrue(output.contains("booleanVar1: boolean;"));
+            Assert.assertTrue(output.contains("stringVar?: string;"));
+            Assert.assertTrue(output.contains("charVar2?: string;"));
+            Assert.assertTrue(output.contains("byteVar2?: number;"));
+            Assert.assertTrue(output.contains("shortVar2?: number;"));
+            Assert.assertTrue(output.contains("intVar2?: number;"));
+            Assert.assertTrue(output.contains("longVar2?: number;"));
+            Assert.assertTrue(output.contains("floatVar2?: number;"));
+            Assert.assertTrue(output.contains("doubleVar2?: number;"));
+            Assert.assertTrue(output.contains("booleanVar2?: boolean;"));
+            Assert.assertTrue(output.contains("uuidVar?: string;"));
+            Assert.assertTrue(output.contains("dateVar?: Date;"));
+            Assert.assertTrue(output.contains("collectionVar?: string[];"));
+            Assert.assertTrue(output.contains("mapVar?: { [index: string]: string };"));
+        }
+        try {
+            final Settings settings = TestUtils.settings();
+            settings.requiredAnnotations = Arrays.asList();
+            settings.allPrimitivesRequired = true;
+            new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithPrimitiveField.class));
+            Assert.fail();
+        } catch (Exception e) {
+            // expected - 'allPrimitivesRequired' parameter can only be used with 'requiredAnnotations' parameter
+        }
+    }
+
+    public class ClassWithPrimitiveField {
+        public char charVar1;
+        public byte byteVar1;
+        public short shortVar1;
+        public int intVar1;
+        public long longVar1;
+        public float floatVar1;
+        public double doubleVar1;
+        public boolean booleanVar1;
+        public String stringVar;
+        public Character charVar2;
+        public Byte byteVar2;
+        public Short shortVar2;
+        public Integer intVar2;
+        public Long longVar2;
+        public Float floatVar2;
+        public Double doubleVar2;
+        public Boolean booleanVar2;
+        public UUID uuidVar;
+        public Date dateVar;
+        public Collection<String> collectionVar;
+        public Map<String, String> mapVar;
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
@@ -4,6 +4,10 @@ package cz.habarta.typescript.generator;
 import cz.habarta.typescript.generator.util.Utils;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,6 +47,33 @@ public class UtilsTest {
         Assert.assertEquals("controller/path", Utils.joinPath("/controller/", "/path"));
         Assert.assertEquals("controller/path", Utils.joinPath("/controller/", "path"));
         Assert.assertEquals("controller/path/", Utils.joinPath("/controller/", "/path/"));
+    }
+
+    @Test
+    public void testIsPrimitiveType() {
+        Assert.assertTrue(Utils.isPrimitiveType(char.class));
+        Assert.assertTrue(Utils.isPrimitiveType(byte.class));
+        Assert.assertTrue(Utils.isPrimitiveType(short.class));
+        Assert.assertTrue(Utils.isPrimitiveType(int.class));
+        Assert.assertTrue(Utils.isPrimitiveType(long.class));
+        Assert.assertTrue(Utils.isPrimitiveType(float.class));
+        Assert.assertTrue(Utils.isPrimitiveType(double.class));
+        Assert.assertTrue(Utils.isPrimitiveType(boolean.class));
+        Assert.assertFalse(Utils.isPrimitiveType(String.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Character.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Byte.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Short.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Integer.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Long.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Float.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Double.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Boolean.class));
+        Assert.assertFalse(Utils.isPrimitiveType(UUID.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Date.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Collection.class));
+        Assert.assertFalse(Utils.isPrimitiveType(Map.class));
+        class NewClass{}
+        Assert.assertFalse(Utils.isPrimitiveType(NewClass.class));
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -8,8 +8,12 @@ import cz.habarta.typescript.generator.TestUtils;
 import cz.habarta.typescript.generator.TypeScriptGenerator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Collection;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
+import java.util.UUID;
 import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -104,6 +108,30 @@ public class JsonbParserTest {
         public String bar;
     }
 
+    public static class PrimitiveObjectWithTheOtherObject {
+        public char charVar1;
+        public byte byteVar1;
+        public short shortVar1;
+        public int intVar1;
+        public long longVar1;
+        public float floatVar1;
+        public double doubleVar1;
+        public boolean booleanVar1;
+        public String stringVar;
+        public Character charVar2;
+        public Byte byteVar2;
+        public Short shortVar2;
+        public Integer intVar2;
+        public Long longVar2;
+        public Float floatVar2;
+        public Double doubleVar2;
+        public Boolean booleanVar2;
+        public UUID uuidVar;
+        public Date dateVar;
+        public Collection<String> collectionVar;
+        public Map<String, String> mapVar;
+    }
+
     public static class ObjectWithRequiredPropertyAndConstructor {
         public String foo;
         public String bar;
@@ -173,6 +201,35 @@ public class JsonbParserTest {
         final String output = generate(settings, ObjectWithRequiredPropertyAndConstructor.class);
         Assert.assertTrue(output, output.contains(" foo:"));
         Assert.assertTrue(output, output.contains(" bar?:"));
+    }
+
+    @Test
+    public void testRequiredPropertyMarkedByAnnotationWithAllPrimitivesRequired() {
+        settings.optionalProperties = OptionalProperties.useSpecifiedAnnotations;
+        settings.requiredAnnotations.add(RequiredAnnotation.class);
+        settings.allPrimitivesRequired = true;
+        final String output = generate(settings, PrimitiveObjectWithTheOtherObject.class);
+        Assert.assertTrue(output.contains("charVar1: string;"));
+        Assert.assertTrue(output.contains("byteVar1: number;"));
+        Assert.assertTrue(output.contains("shortVar1: number;"));
+        Assert.assertTrue(output.contains("intVar1: number;"));
+        Assert.assertTrue(output.contains("longVar1: number;"));
+        Assert.assertTrue(output.contains("floatVar1: number;"));
+        Assert.assertTrue(output.contains("doubleVar1: number;"));
+        Assert.assertTrue(output.contains("booleanVar1: boolean;"));
+        Assert.assertTrue(output.contains("stringVar?: string;"));
+        Assert.assertTrue(output.contains("charVar2?: string;"));
+        Assert.assertTrue(output.contains("byteVar2?: number;"));
+        Assert.assertTrue(output.contains("shortVar2?: number;"));
+        Assert.assertTrue(output.contains("intVar2?: number;"));
+        Assert.assertTrue(output.contains("longVar2?: number;"));
+        Assert.assertTrue(output.contains("floatVar2?: number;"));
+        Assert.assertTrue(output.contains("doubleVar2?: number;"));
+        Assert.assertTrue(output.contains("booleanVar2?: boolean;"));
+        Assert.assertTrue(output.contains("uuidVar?: string;"));
+        Assert.assertTrue(output.contains("dateVar?: Date;"));
+        Assert.assertTrue(output.contains("collectionVar?: string[];"));
+        Assert.assertTrue(output.contains("mapVar?: { [index: string]: string };"));
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -204,10 +204,10 @@ public class JsonbParserTest {
     }
 
     @Test
-    public void testRequiredPropertyMarkedByAnnotationWithAllPrimitivesRequired() {
+    public void testRequiredPropertyMarkedByAnnotationWithPrimitivePropertiesRequired() {
         settings.optionalProperties = OptionalProperties.useSpecifiedAnnotations;
         settings.requiredAnnotations.add(RequiredAnnotation.class);
-        settings.allPrimitivesRequired = true;
+        settings.primitivePropertiesRequired = true;
         final String output = generate(settings, PrimitiveObjectWithTheOtherObject.class);
         Assert.assertTrue(output.contains("charVar1: string;"));
         Assert.assertTrue(output.contains("byteVar1: number;"));

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -115,6 +115,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> optionalAnnotations;
     public List<String> requiredAnnotations;
     public List<String> nullableAnnotations;
+    public boolean allPrimitivesRequired;
     public boolean generateInfoJson;
     public boolean generateNpmPackageJson;
     public String npmName;
@@ -200,6 +201,7 @@ public class GenerateTask extends DefaultTask {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.loadRequiredAnnotations(classLoader, requiredAnnotations);
         settings.loadNullableAnnotations(classLoader, nullableAnnotations);
+        settings.allPrimitivesRequired = allPrimitivesRequired;
         settings.generateInfoJson = generateInfoJson;
         settings.generateNpmPackageJson = generateNpmPackageJson;
         settings.npmName = npmName == null && generateNpmPackageJson ? getProject().getName() : npmName;

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -115,7 +115,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> optionalAnnotations;
     public List<String> requiredAnnotations;
     public List<String> nullableAnnotations;
-    public boolean allPrimitivesRequired;
+    public boolean primitivePropertiesRequired;
     public boolean generateInfoJson;
     public boolean generateNpmPackageJson;
     public String npmName;
@@ -201,7 +201,7 @@ public class GenerateTask extends DefaultTask {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.loadRequiredAnnotations(classLoader, requiredAnnotations);
         settings.loadNullableAnnotations(classLoader, nullableAnnotations);
-        settings.allPrimitivesRequired = allPrimitivesRequired;
+        settings.primitivePropertiesRequired = primitivePropertiesRequired;
         settings.generateInfoJson = generateInfoJson;
         settings.generateNpmPackageJson = generateNpmPackageJson;
         settings.npmName = npmName == null && generateNpmPackageJson ? getProject().getName() : npmName;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -733,6 +733,13 @@ public class GenerateMojo extends AbstractMojo {
     private List<String> nullableAnnotations;
 
     /**
+     * If <code>true</code> All Java primitives will be treated as non nullable.
+     * Useful when used with {@link #requiredAnnotations} parameter.
+     */
+    @Parameter
+    private boolean allPrimitivesRequired;
+
+    /**
      * If <code>true</code> JSON file describing generated module will be generated.
      * In following typescript-generator run this allows to generate another module which could depend on currently generated module.
      * Generated JSON file contains mapping from Java classes to TypeScript types which typescript-generator needs
@@ -928,6 +935,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.loadRequiredAnnotations(classLoader, requiredAnnotations);
         settings.loadNullableAnnotations(classLoader, nullableAnnotations);
+        settings.allPrimitivesRequired = allPrimitivesRequired;
         settings.generateInfoJson = generateInfoJson;
         settings.generateNpmPackageJson = generateNpmPackageJson;
         settings.npmName = npmName == null && generateNpmPackageJson ? project.getArtifactId() : npmName;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -737,7 +737,7 @@ public class GenerateMojo extends AbstractMojo {
      * Useful when used with {@link #requiredAnnotations} parameter.
      */
     @Parameter
-    private boolean allPrimitivesRequired;
+    private boolean primitivePropertiesRequired;
 
     /**
      * If <code>true</code> JSON file describing generated module will be generated.
@@ -935,7 +935,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.loadOptionalAnnotations(classLoader, optionalAnnotations);
         settings.loadRequiredAnnotations(classLoader, requiredAnnotations);
         settings.loadNullableAnnotations(classLoader, nullableAnnotations);
-        settings.allPrimitivesRequired = allPrimitivesRequired;
+        settings.primitivePropertiesRequired = primitivePropertiesRequired;
         settings.generateInfoJson = generateInfoJson;
         settings.generateNpmPackageJson = generateNpmPackageJson;
         settings.npmName = npmName == null && generateNpmPackageJson ? project.getArtifactId() : npmName;


### PR DESCRIPTION
Add `allPrimitivesRequired` parameter for make all primitives non nullable.(#472 )

I think that we use `requiredAnnotations` to make `String` or some `Class` treat as non nullable. But then primitive properties is created with nullable even though it's not nullable in Java.

So we use some annotation that treat as non nullable for primitive properties now even though it's not necessary in product.
 I want to solve that problem.

It is not breaking change. What do you think?