### PR TITLE
Fix some flaky tests in test class `EnumTest`

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -724,7 +724,6 @@ public class Jackson2Parser extends ModelParser {
                 try {
                     return enumClass.getDeclaredField(e.name());
                 } catch (NoSuchFieldException noSuchFieldException) {
-                    noSuchFieldException.printStackTrace();
                     return null;
                 }
             }).collect(Collectors.toList());

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -719,9 +719,15 @@ public class Jackson2Parser extends ModelParser {
 
         final List<EnumMemberModel> enumMembers = new ArrayList<>();
         if (sourceClass.type.isEnum()) {
-            final Class<?> enumClass = (Class<?>) sourceClass.type;
-            final Field[] allEnumFields = enumClass.getDeclaredFields();
-            final List<Field> constants = Arrays.stream(allEnumFields).filter(Field::isEnumConstant).collect(Collectors.toList());
+            final Class<Enum> enumClass = (Class<Enum>) sourceClass.type;
+            final List<Field> constants = Arrays.stream(enumClass.getEnumConstants()).map(e -> {
+                try {
+                    return enumClass.getDeclaredField(e.name());
+                } catch (NoSuchFieldException noSuchFieldException) {
+                    noSuchFieldException.printStackTrace();
+                    return null;
+                }
+            }).collect(Collectors.toList());
             for (Field constant : constants) {
                 Object value;
                 try {


### PR DESCRIPTION
Some of the tests in class EnumTest can fail due to the disorder of Enum objects, for example:
```python
[ERROR]   EnumTest.testSingleEnum:44 expected:<...ection = "North" | "[East" | "South" | "We]st";
> but was:<...ection = "North" | "[West" | "South" | "Ea]st";
>
```
Here's a list of all tests which fail due to this type of error:
```python
cz.habarta.typescript.generator.EnumTest.testEnumAsEnum
cz.habarta.typescript.generator.EnumTest.testEnumAsInlineUnion
cz.habarta.typescript.generator.EnumTest.testEnumAsNumberBasedEnum
cz.habarta.typescript.generator.EnumTest.testEnumAsUnion
cz.habarta.typescript.generator.EnumTest.testEnumMapKeys_asInlineUnion
cz.habarta.typescript.generator.EnumTest.testEnumUsingToString
cz.habarta.typescript.generator.EnumTest.testEnumWithJsonPropertyAnnotations
cz.habarta.typescript.generator.EnumTest.testEnumWithJsonValueFieldAnnotation
cz.habarta.typescript.generator.EnumTest.testEnumWithJsonValueMethodAnnotation
cz.habarta.typescript.generator.EnumTest.testSingleEnum
```
The reason is that according to the [Documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html), the method `Java.lang.Class.getDeclaredField()` returns an array containing Field objects reflecting all the accessible public fields of the class or interface represented by this Class object, while the elements in the array returned are **not sorted** and are **not in any particular order**. 

One way to fix this problem is to use the method `Java.lang.Class.getEnumConstants()`, which returns the elements in the declared order of this enum class.