### PR TITLE
Add ability to use record types instead of index signatures

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -140,6 +140,7 @@ public class Settings {
     public boolean jackson2ModuleDiscovery = false;
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
+    public boolean useRecordType = false;
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -181,7 +181,11 @@ public abstract class TsType implements Emittable {
 
         @Override
         public String format(Settings settings) {
-            return "{ [index: " + indexType.format(settings) + "]: " + elementType.format(settings) + " }";
+            if (settings.useRecordType) {
+                return "Record<" + indexType.format(settings) + ", " + elementType.format(settings) + ">";
+            } else {
+                return "{ [index: " + indexType.format(settings) + "]: " + elementType.format(settings) + " }";
+            }
         }
 
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
@@ -40,6 +40,14 @@ public class TsTypeTest {
     }
 
     @Test
+    public void testRecordType() {
+        final Settings settings = TestUtils.settings();
+        settings.useRecordType = true;
+        assertEquals("Record<string, number>", new IndexedArrayType(String, Number).format(settings));
+
+    }
+
+    @Test
     public void testObjectType() {
         final Settings settings = TestUtils.settings();
         assertEquals("{ a: string; b: string | number; c: {}; d: { x: string; }; }", new TsType.ObjectType(Arrays.asList(

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -133,6 +133,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> jackson2Modules;
     @Deprecated public boolean debug;
     public Logger.Level loggingLevel;
+    public boolean useRecordType;
 
     @SuppressWarnings("deprecation")
     private Settings createSettings(URLClassLoader classLoader) {
@@ -222,6 +223,7 @@ public class GenerateTask extends DefaultTask {
         settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
         settings.loadJackson2Modules(classLoader, jackson2Modules);
         settings.classLoader = classLoader;
+        settings.useRecordType = useRecordType;
         return settings;
     }
 

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -883,6 +883,13 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter
     private Logger.Level loggingLevel;
 
+    /**
+     * If <code>true</code>, will use <code>Record<T, V></code> instead of
+     * <code>{ [index: T]: V}</code> when typing Maps
+     */
+    @Parameter
+    private boolean useRecordType;
+
     @Parameter(property = "typescript.generator.skip")
     private boolean skip;
 
@@ -980,6 +987,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
         settings.loadJackson2Modules(classLoader, jackson2Modules);
         settings.classLoader = classLoader;
+        settings.useRecordType = useRecordType;
         return settings;
     }
 


### PR DESCRIPTION
My team uses `Record<string, number>` syntax instead of `{ [index: string]: number }` syntax. Here is a PR to allow use of this syntax instead. Not very experienced in this codebase so I'm open to feedback and changes.