### PR TITLE
Export function uriEncoding

### DIFF
--- a/typescript-generator-core/src/main/resources/helpers/uriEncoding.ts
+++ b/typescript-generator-core/src/main/resources/helpers/uriEncoding.ts
@@ -1,4 +1,4 @@
-function uriEncoding(template: TemplateStringsArray, ...substitutions: any[]): string {
+export function uriEncoding(template: TemplateStringsArray, ...substitutions: any[]): string {
 	let result = "";
 	for (let i = 0; i < substitutions.length; i++) {
 		result += template[i];


### PR DESCRIPTION
When it is necessary to request an object, use a cache for example, for a certain path, if the encoded path is different, the result will be different, so it is necessary to handwrite this exactly function elsewhere and export it.

It shouldn't matter to anyone who isn't using it, but to whoever, it's nice to have.