### PR TITLE
Fixed flakiness in MapEntryTest#testDefaultShapes

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
@@ -75,7 +75,7 @@ public class MapEntryTest {
                 + "  }\n"
                 + "}")
                 .replace("'", "\"");
-        Assert.assertEquals(expectedJson, json);
+        Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(json));
 
         final Settings settings = TestUtils.settings();
         settings.setExcludeFilter(
@@ -85,6 +85,10 @@ public class MapEntryTest {
         Assert.assertTrue(output.contains("entry1: { [index: string]: string }"));
         Assert.assertTrue(output.contains("entry2: Entry2<MyBean, string>"));
         Assert.assertTrue(output.contains(""
+                + "interface Entry2<K, V> {\n"
+                + "    value: V;\n"
+                + "    key: K;\n"
+                + "}") || output.contains(""
                 + "interface Entry2<K, V> {\n"
                 + "    key: K;\n"
                 + "    value: V;\n"


### PR DESCRIPTION
This test is flaky since the method `java.lang.Class.getDeclaredFields` is non-deterministic, and `GetDeclaredFilelds`  is used in several methods in the `com.fasterxml.jackson` library (e.g. `objectMapper.writeValueAsString`). 
I changed the test to compare two jsonNode objects generated from the strings, so the specific order of the properties would not affect the result. 
Also, I added checks for both variants of the generated typescript string due to the non-deterministic ordering of properties in the output. 
The other two tests in `MapEntryTest.java` contain the same issues and can be fixed with similar changes in this PR.