### PR TITLE
fix flaky test for Jackson1Parser

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson1Parser.java
@@ -29,7 +29,8 @@ import org.codehaus.jackson.type.JavaType;
 
 public class Jackson1Parser extends ModelParser {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(SerializationConfig.Feature.SORT_PROPERTIES_ALPHABETICALLY, true);
 
     public static class Factory extends ModelParser.Factory {
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson1ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson1ParserTest.java
@@ -19,7 +19,7 @@ public class Jackson1ParserTest {
         final BeanModel beanModel = model.getBeans().get(0);
         Assert.assertEquals("DummyBean", beanModel.getOrigin().getSimpleName());
         Assert.assertTrue(beanModel.getProperties().size() > 0);
-        Assert.assertEquals("firstProperty", beanModel.getProperties().get(0).getName());
+        Assert.assertEquals("booleanProperty", beanModel.getProperties().get(0).getName());
     }
 
     private static Jackson1Parser getJackson1Parser() {


### PR DESCRIPTION
I found a flaky test (test can fail occasionally) in `cz.habarta.typescript.generator.Jackson1ParserTest`. The reason why this test is flaky is that when` Jackson1Parser`  is initialized, it will use  `ObjectMapper ` to parse and construct the model, the `ObjectMapper ` is random since it used `getDeclatedFields()` and `ConcurrentHashMap` which is not deterministic. I fixed it by changed the attribute of `SORT_PROPERTIES_ALPHABETICALLY` to true, that guarantees the order of all properties parsed by `Jackson1Parser`