### PR TITLE
fix flaky test for testJackson

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import cz.habarta.typescript.generator.type.JGenericArrayType;
@@ -433,7 +434,8 @@ public final class Utils {
     }
 
     public static ObjectMapper getObjectMapper() {
-        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectMapper objectMapper = new ObjectMapper()
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         objectMapper.setDefaultPrettyPrinter(new StandardJsonPrettyPrinter("  ", "\n"));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
@@ -59,7 +59,6 @@ public class MapEntryTest {
         final String json = objectMapper.writeValueAsString(classWithEntries);
         final String expectedJson = (""
                 + "{\n"
-                + "  'name': 'ClassWithEntries',\n"
                 + "  'entry1': {\n"
                 + "    'MyBean instance': 'NNN'\n"
                 + "  },\n"
@@ -72,7 +71,8 @@ public class MapEntryTest {
                 + "  },\n"
                 + "  'entry3': {\n"
                 + "    'MyBean instance': 'EEE'\n"
-                + "  }\n"
+                + "  },\n"
+                + "  'name': 'ClassWithEntries'\n"
                 + "}")
                 .replace("'", "\"");
         Assert.assertEquals(expectedJson, json);
@@ -101,7 +101,6 @@ public class MapEntryTest {
         final String json = objectMapper.writeValueAsString(classWithEntries);
         final String expectedJson = (""
                 + "{\n"
-                + "  'name': 'ClassWithEntries',\n"
                 + "  'entry1': {\n"
                 + "    'key': {\n"
                 + "      'f0': 'nnn',\n"
@@ -114,7 +113,8 @@ public class MapEntryTest {
                 + "  },\n"
                 + "  'entry3': {\n"
                 + "    'MyBean instance': 'EEE'\n"
-                + "  }\n"
+                + "  },\n"
+                + "  'name': 'ClassWithEntries'\n"
                 + "}")
                 .replace("'", "\"");
         Assert.assertEquals(expectedJson, json);


### PR DESCRIPTION
I found a flaky test (test can fail occasionally) in `cz.habarta.typescript.generator.ObjectAsIdTest.testJackson`. The reason for its flakiness is the same as the last PR I submitted. the `ObjectMapper `is not deterministic. I fixed it by configure the `ObjectMapper` in `getObjectMapper() `.