### PR TITLE
fix flaky test in GsonParserTest

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
@@ -13,6 +13,9 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +44,8 @@ public class GsonParserTest {
         final BeanModel beanModel = model.getBeans().get(0);
         Assert.assertEquals("DummyBean", beanModel.getOrigin().getSimpleName());
         Assert.assertTrue(beanModel.getProperties().size() > 0);
-        Assert.assertEquals("firstProperty", beanModel.getProperties().get(0).getName());
+        beanModel.getProperties().sort((p1, p2) -> (p1.getName().compareTo(p2.getName())));
+        Assert.assertEquals("booleanProperty", beanModel.getProperties().get(0).getName());
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/GsonParserTest.java
@@ -13,9 +13,6 @@ import cz.habarta.typescript.generator.TypeScriptGenerator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
I found a flaky test in `cz.habarta.typescript.generator.parser.GsonParserTest#test`. The reason why this test is flaky is that `GsonParser `is non-deterministic, it used `getDeclatedFields()` for constructing `Gson `oject. Since it doesn't have direct configuration to set properties' order, I chose to sort the property list by their name, which is not optimal though, it fixed the flakiness of this test.