### PR TITLE
Check exclude filter when parsing spring controller methods

### DIFF
--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -186,7 +186,11 @@ public class SpringApplicationParser extends RestApplicationParser {
         final List<Method> methods = getAllRequestMethods(controllerClass);
         methods.sort(Utils.methodComparator());
         for (Method method : methods) {
-            parseControllerMethod(result, context, controllerClass, method);
+            // Do not use default Method.toString since that will include parameter types
+            String fullMethodName = String.format("%s.%s", method.getDeclaringClass(), method.getName());
+            if (!settings.getExcludeFilter().test(fullMethodName)) {
+                parseControllerMethod(result, context, controllerClass, method);
+            }
         }
     }
 

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -167,6 +167,28 @@ public class SpringTest {
         Assert.assertFalse(output.contains("uriEncoding`test/b`"));
     }
 
+    @Test
+    public void testExclusion1() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        settings.setExcludeFilter(null, Arrays.asList("**.doSomethingElseAgain"));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
+        Assert.assertTrue(output.contains("doSomethingElse(id: number): RestResponse<number>"));
+        Assert.assertFalse(output.contains("doSomethingElseAgain(): RestResponse<number>"));
+    }
+
+    @Test
+    public void testExclusion2() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        settings.setExcludeFilter(null, Arrays.asList("**Controller6.*Again"));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
+        Assert.assertTrue(output.contains("doSomethingElse(id: number): RestResponse<number>"));
+        Assert.assertFalse(output.contains("doSomethingElseAgain(): RestResponse<number>"));
+    }
+
     @RestController
     @RequestMapping("/owners/{ownerId}")
     public static class Controller1 {


### PR DESCRIPTION
We're running into a scenario where some mock controller methods are being included that we'd rather exclude. Currently there doesn't seem to be a way to exclude individual controller methods (or even individual controllers?) via the excludeClassPattern setting, so this is an attempt to add that functionality.

Just let me know if this functionality already exists in some form or if this is the wrong approach and I can make any needed changes 😄 