### PR TITLE
Check exclude filter when parsing spring controller classes by annotation

### DIFF
--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -121,7 +121,7 @@ public class SpringApplicationParser extends RestApplicationParser {
         // controller
         final Component component = AnnotationUtils.findAnnotation(cls, Component.class);
         if (component != null) {
-            if (isClassNameExcluded != null && isClassNameExcluded.test(sourceType.toString())) {
+            if (isClassNameExcluded != null && isClassNameExcluded.test(cls.getName())) {
                 return null;
             }
 

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -174,7 +174,17 @@ public class SpringTest {
         settings.generateSpringApplicationClient = true;
         settings.setExcludeFilter(null, Arrays.asList("**Controller6"));
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
-        Assert.assertFalse(output.contains("Controller6"));
+        Assertions.assertFalse(output.contains("Controller6"));
+    }
+
+    @Test
+    public void testExclusion2() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        settings.setExcludeFilter(null, Arrays.asList("cz.habarta.typescript.generator.spring.SpringTest**"));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Controller6.class));
+        Assertions.assertFalse(output.contains("Controller6"));
     }
 
     @RestController


### PR DESCRIPTION
Adding class exclusion functionality in `SpringApplicationParser` when `scanSpringApplication` is not true (class exclusion is already working when `scanSpringApplication` is true)