### PR TITLE
feature: add the ability to remove the timestamp from the file comment

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -113,6 +113,7 @@ public class Settings {
     public boolean sortDeclarations = false;
     public boolean sortTypeDeclarations = false;
     public boolean noFileComment = false;
+    public boolean noTimestampInFileComment = false;
     public boolean noTslintDisable = false;
     public boolean noEslintDisable = false;
     public boolean tsNoCheck = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -59,8 +59,8 @@ public class Emitter implements EmitterExtension.Writer {
             writeIndentedLine("// @ts-nocheck");
         }
         if (!settings.noFileComment) {
-            final String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
-            writeIndentedLine("// Generated using typescript-generator version " + TypeScriptGenerator.Version + " on " + timestamp + ".");
+            final String timestampMessage = settings.noTimestampInFileComment ? "" : " on " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+            writeIndentedLine("// Generated using typescript-generator version " + TypeScriptGenerator.Version + timestampMessage + ".");
         }
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestUtils.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestUtils.java
@@ -18,6 +18,7 @@ public class TestUtils {
         settings.outputKind = TypeScriptOutputKind.global;
         settings.jsonLibrary = JsonLibrary.jackson2;
         settings.noFileComment = true;
+        settings.noTimestampInFileComment = true;
         settings.noTslintDisable = true;
         settings.noEslintDisable = true;
         settings.newline = "\n";

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/RequiredPropertyConstructorExtensionTest.java
@@ -166,6 +166,7 @@ public class RequiredPropertyConstructorExtensionTest {
         settings.outputKind = TypeScriptOutputKind.module;
         settings.mapClasses = ClassMapping.asClasses;
         settings.noFileComment = true;
+        settings.noTimestampInFileComment = true;
         settings.noEslintDisable = true;
         return settings;
     }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -105,6 +105,7 @@ public class GenerateTask extends DefaultTask {
     public boolean sortDeclarations;
     public boolean sortTypeDeclarations;
     public boolean noFileComment;
+    public boolean noTimestampInFileComment;
     public boolean noTslintDisable;
     public boolean noEslintDisable;
     public boolean tsNoCheck;
@@ -194,6 +195,7 @@ public class GenerateTask extends DefaultTask {
         settings.sortDeclarations = sortDeclarations;
         settings.sortTypeDeclarations = sortTypeDeclarations;
         settings.noFileComment = noFileComment;
+        settings.noTimestampInFileComment = noTimestampInFileComment;
         settings.noTslintDisable = noTslintDisable;
         settings.noEslintDisable = noEslintDisable;
         settings.tsNoCheck = tsNoCheck;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -646,6 +646,15 @@ public class GenerateMojo extends AbstractMojo {
     private boolean noFileComment;
 
     /**
+     * If <code>true</code> the generated file's top comment will not contain a timestamp.
+     * By default there is a comment with a timestamp and the typescript-generator version.
+     * If the file is in source control, but one still wants to have the 'auto-generated file' comment,
+     * it might be useful to suppress the timestamp.
+     */
+    @Parameter
+    private boolean noTimestampInFileComment;
+
+    /**
      * If <code>true</code> generated file will not be prevented from linting by TSLint.
      * By default there is a {@code tslint:disable} comment that will force TSLint to ignore the generated file.
      * This can be enabled to suppress this comment so that the file can be linted by TSLint.


### PR DESCRIPTION
## What is the problem?
At the moment, if one is using the generator in source control and using a build tool, there is a problem with the generated timestamp at the file comment (different in every run).
To avoid the above problem one can remove the entire comment (`noFileComment=true`) but that means losing other data on that statement ("_generated using typescript-generator version_") which might be valuable.

note: the `noFileComment` is false by default

## The fix
Add a `noTimestampInFileComment` prop that when set to true will omit the timestamp from the top of the file comment.
