### PR TITLE
Revert "Bump maven-plugin-annotations from 3.0 to 3.6.4"

### DIFF
--- a/typescript-generator-maven-plugin/pom.xml
+++ b/typescript-generator-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.4</version>
+            <version>3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts vojtechhabarta/typescript-generator#781
Typescript-generator is intended to work on older Maven versions.