### PR TITLE
support multiple names for jackson subtype

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -306,8 +306,10 @@ public class ModelCompiler {
                     isTaggedUnion = false;
                     isDisciminantProperty = false;
                 }
-                if (descendant.getDiscriminantLiteral() != null) {
-                    literals.add(new TsType.StringLiteralType(descendant.getDiscriminantLiteral()));
+                if (descendant.getDiscriminantLiterals() != null && !descendant.getDiscriminantLiterals().isEmpty()) {
+                    for (String discriminantLiteral : descendant.getDiscriminantLiterals()) {
+                        literals.add(new TsType.StringLiteralType(discriminantLiteral));
+                    }
                 }
             }
             final List<BeanModel> descendants = selfAndDescendants.subList(1, selfAndDescendants.size());
@@ -339,7 +341,7 @@ public class ModelCompiler {
                 /*methods*/ null,
                 bean.getComments());
         return isTaggedUnion
-                ? tsBean.withTaggedUnion(bean.getTaggedUnionClasses(), bean.getDiscriminantProperty(), bean.getDiscriminantLiteral())
+                ? tsBean.withTaggedUnion(bean.getTaggedUnionClasses(), bean.getDiscriminantProperty(), bean.getDiscriminantLiterals())
                 : tsBean;
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -367,7 +367,9 @@ public class Emitter implements EmitterExtension.Writer {
         writeIndentedLine("switch (" + switchStatement.getExpression().format(settings) + ") {");
         indent++;
         for (TsSwitchCaseClause caseClause : switchStatement.getCaseClauses()) {
-            writeIndentedLine("case " + caseClause.getExpression().format(settings) + ":");
+            for (TsExpression expression : caseClause.getExpressions()) {
+                writeIndentedLine("case " + expression.format(settings) + ":");
+            }
             indent++;
             emitStatements(caseClause.getStatements());
             indent--;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -18,7 +18,7 @@ public class TsBeanModel extends TsDeclarationModel {
     private final List<TsType> implementsList;
     private final List<Class<?>> taggedUnionClasses;
     private final String discriminantProperty;
-    private final String discriminantLiteral;
+    private final List<String> discriminantLiterals;
     private final TsAliasModel taggedUnionAlias;
     private final List<TsPropertyModel> properties;
     private final TsConstructorModel constructor;
@@ -52,7 +52,7 @@ public class TsBeanModel extends TsDeclarationModel {
             List<TsType> implementsList,
             List<Class<?>> taggedUnionClasses,
             String discriminantProperty,
-            String discriminantLiteral,
+            List<String> discriminantLiterals,
             TsAliasModel taggedUnionAlias,
             List<TsPropertyModel> properties,
             TsConstructorModel constructor,
@@ -67,7 +67,7 @@ public class TsBeanModel extends TsDeclarationModel {
         this.implementsList = Utils.listFromNullable(implementsList);
         this.taggedUnionClasses = Utils.listFromNullable(taggedUnionClasses);
         this.discriminantProperty = discriminantProperty;
-        this.discriminantLiteral = discriminantLiteral;
+        this.discriminantLiterals = discriminantLiterals;
         this.taggedUnionAlias = taggedUnionAlias;
         this.properties = Utils.listFromNullable(properties);
         this.constructor = constructor;
@@ -83,7 +83,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withDecorators(List<TsDecorator> decorators) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public List<TsType.GenericVariableType> getTypeParameters() {
@@ -117,12 +117,12 @@ public class TsBeanModel extends TsDeclarationModel {
         return discriminantProperty;
     }
 
-    public String getDiscriminantLiteral() {
-        return discriminantLiteral;
+    public List<String> getDiscriminantLiterals() {
+        return discriminantLiterals;
     }
 
-    public TsBeanModel withTaggedUnion(List<Class<?>> taggedUnionClasses, String discriminantProperty, String discriminantLiteral) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+    public TsBeanModel withTaggedUnion(List<Class<?>> taggedUnionClasses, String discriminantProperty, List<String> discriminantLiterals) {
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public TsAliasModel getTaggedUnionAlias() {
@@ -130,7 +130,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withTaggedUnionAlias(TsAliasModel taggedUnionAlias) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public List<TsPropertyModel> getProperties() {
@@ -138,7 +138,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withProperties(List<TsPropertyModel> properties) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public TsConstructorModel getConstructor() {
@@ -146,7 +146,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withConstructor(TsConstructorModel constructor) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public List<TsMethodModel> getMethods() {
@@ -154,7 +154,7 @@ public class TsBeanModel extends TsDeclarationModel {
     }
 
     public TsBeanModel withMethods(List<TsMethodModel> methods) {
-        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiterals, taggedUnionAlias, properties, constructor, methods, comments);
     }
 
     public boolean isJaxrsApplicationClientBean() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchCaseClause.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchCaseClause.java
@@ -6,16 +6,16 @@ import java.util.List;
 
 public class TsSwitchCaseClause extends TsStatement {
 
-    private final TsExpression expression;
+    private final List<TsExpression> expressions;
     private final List<TsStatement> statements;
 
-    public TsSwitchCaseClause(TsExpression expression, List<TsStatement> statements) {
-        this.expression = expression;
+    public TsSwitchCaseClause(List<TsExpression> expressions, List<TsStatement> statements) {
+        this.expressions = expressions;
         this.statements = statements;
     }
 
-    public TsExpression getExpression() {
-        return expression;
+    public List<TsExpression> getExpressions() {
+        return expressions;
     }
 
     public List<TsStatement> getStatements() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/JsonDeserializationExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/JsonDeserializationExtension.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public class JsonDeserializationExtension extends Extension {
@@ -321,7 +322,7 @@ public class JsonDeserializationExtension extends Extension {
         for (Class<?> cls : bean.getTaggedUnionClasses()) {
             final TsBeanModel tuBean = tsModel.getBean(cls);
             caseClauses.add(new TsSwitchCaseClause(
-                    new TsStringLiteral(tuBean.getDiscriminantLiteral()),
+                    tuBean.getDiscriminantLiterals().stream().map(TsStringLiteral::new).collect(Collectors.toList()),
                     Arrays.<TsStatement>asList(new TsReturnStatement(
                             new TsCallExpression(
                                     new TsMemberExpression(new TsTypeReferenceExpression(new TsType.ReferenceType(symbolTable.getSymbol(cls))), "fromData"),

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
@@ -13,16 +13,16 @@ public class BeanModel extends DeclarationModel {
     private final Type parent;
     private final List<Class<?>> taggedUnionClasses;
     private final String discriminantProperty;
-    private final String discriminantLiteral;
+    private final List<String> discriminantLiterals;
     private final List<Type> interfaces;
     private final List<PropertyModel> properties;
 
-    public BeanModel(Class<?> origin, Type parent, List<Class<?>> taggedUnionClasses, String discriminantProperty, String discriminantLiteral, List<Type> interfaces, List<PropertyModel> properties, List<String> comments) {
+    public BeanModel(Class<?> origin, Type parent, List<Class<?>> taggedUnionClasses, String discriminantProperty, List<String> discriminantLiterals, List<Type> interfaces, List<PropertyModel> properties, List<String> comments) {
         super(origin, comments);
         this.parent = parent;
         this.taggedUnionClasses = taggedUnionClasses;
         this.discriminantProperty = discriminantProperty;
-        this.discriminantLiteral = discriminantLiteral;
+        this.discriminantLiterals = discriminantLiterals;
         this.interfaces = Utils.listFromNullable(interfaces);
         this.properties = properties;
     }
@@ -39,8 +39,8 @@ public class BeanModel extends DeclarationModel {
         return discriminantProperty;
     }
 
-    public String getDiscriminantLiteral() {
-        return discriminantLiteral;
+    public List<String> getDiscriminantLiterals() {
+        return discriminantLiterals;
     }
 
     public List<Type> getInterfaces() {
@@ -68,12 +68,12 @@ public class BeanModel extends DeclarationModel {
     }
 
     public BeanModel withProperties(List<PropertyModel> properties) {
-        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiterals, interfaces, properties, comments);
     }
 
     @Override
     public BeanModel withComments(List<String> comments) {
-        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, comments);
+        return new BeanModel(origin, parent, taggedUnionClasses, discriminantProperty, discriminantLiterals, interfaces, properties, comments);
     }
 
     @Override

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -296,7 +296,7 @@ public class Jackson2Parser extends ModelParser {
 
         final String discriminantProperty;
         final boolean syntheticDiscriminantProperty;
-        final String discriminantLiteral;
+        final List<String> discriminantLiterals;
 
         final Pair<Class<?>, JsonTypeInfo> classWithJsonTypeInfo = Pair.of(sourceClass.type, sourceClass.type.getAnnotation(JsonTypeInfo.class));
         final Pair<Class<?>, JsonTypeInfo> parentClassWithJsonTypeInfo;
@@ -305,18 +305,18 @@ public class Jackson2Parser extends ModelParser {
             final JsonTypeInfo jsonTypeInfo = classWithJsonTypeInfo.getValue2();
             discriminantProperty = getDiscriminantPropertyName(jsonTypeInfo);
             syntheticDiscriminantProperty = isDiscriminantPropertySynthetic(jsonTypeInfo);
-            discriminantLiteral = isInterfaceOrAbstract(sourceClass.type) ? null : getTypeName(sourceClass.type);
+            discriminantLiterals = isInterfaceOrAbstract(sourceClass.type) ? null : getTypeNames(sourceClass.type);
         } else if (isTaggedUnion(parentClassWithJsonTypeInfo = getAnnotationRecursive(sourceClass.type, JsonTypeInfo.class))) {
             // this is child class
             final JsonTypeInfo parentJsonTypeInfo = parentClassWithJsonTypeInfo.getValue2();
             discriminantProperty = getDiscriminantPropertyName(parentJsonTypeInfo);
             syntheticDiscriminantProperty = isDiscriminantPropertySynthetic(parentJsonTypeInfo);
-            discriminantLiteral = getTypeName(sourceClass.type);
+            discriminantLiterals = getTypeNames(sourceClass.type);
         } else {
             // not part of explicit hierarchy
             discriminantProperty = null;
             syntheticDiscriminantProperty = false;
-            discriminantLiteral = null;
+            discriminantLiterals = null;
         }
 
         if (discriminantProperty != null) {
@@ -355,7 +355,7 @@ public class Jackson2Parser extends ModelParser {
         for (Type aInterface : interfaces) {
             addBeanToQueue(new SourceType<>(aInterface, sourceClass.type, "<interface>"));
         }
-        return new BeanModel(sourceClass.type, superclass, taggedUnionClasses, discriminantProperty, discriminantLiteral, interfaces, properties, classComments);
+        return new BeanModel(sourceClass.type, superclass, taggedUnionClasses, discriminantProperty, discriminantLiterals, interfaces, properties, classComments);
     }
 
     private static Integer getCreatorIndex(BeanProperty beanProperty) {
@@ -443,12 +443,7 @@ public class Jackson2Parser extends ModelParser {
                 : jsonTypeInfo.property();
     }
 
-    private String getTypeName(Class<?> cls) {
-        final List<String> typeNames = getTypeNamesOrEmptyOrNull(cls);
-        return typeNames != null && !typeNames.isEmpty() ? typeNames.get(0) : null;
-    }
-
-    private List<String> getTypeNamesOrEmptyOrNull(Class<?> cls) {
+    private List<String> getTypeNames(Class<?> cls) {
         try {
             final SerializationConfig config = objectMapper.getSerializationConfig();
             final JavaType javaType = config.constructType(cls);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -97,10 +97,10 @@ public class Jackson2ParserTest {
         Assertions.assertNull(bean2.getTaggedUnionClasses());
         Assertions.assertNull(bean3.getTaggedUnionClasses());
         Assertions.assertEquals("kind", bean0.getDiscriminantProperty());
-        Assertions.assertEquals("explicit-name1", bean1.getDiscriminantLiteral());
-        Assertions.assertEquals("SubType2", bean2.getDiscriminantLiteral());
-        Assertions.assertEquals("Jackson2ParserTest$SubTypeDiscriminatedByName3", bean3.getDiscriminantLiteral());
-        Assertions.assertEquals("Jackson2ParserTest$SubTypeDiscriminatedByName4", bean4.getDiscriminantLiteral());
+        Assertions.assertEquals(Arrays.asList("explicit-name1", "SubType1"), bean1.getDiscriminantLiterals());
+        Assertions.assertEquals(Arrays.asList("SubType2"), bean2.getDiscriminantLiterals());
+        Assertions.assertEquals(Arrays.asList("Jackson2ParserTest$SubTypeDiscriminatedByName3"), bean3.getDiscriminantLiterals());
+        Assertions.assertEquals(Arrays.asList("Jackson2ParserTest$SubTypeDiscriminatedByName4"), bean4.getDiscriminantLiterals());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class Jackson2ParserTest {
         final Jackson2Parser jacksonParser = getJackson2Parser();
         final Model model = jacksonParser.parseModel(SubTypeDiscriminatedByName5.class);
         final BeanModel bean5 = model.getBean(SubTypeDiscriminatedByName5.class);
-        Assertions.assertEquals("NamedByModule", bean5.getDiscriminantLiteral());
+        Assertions.assertEquals(Arrays.asList("NamedByModule"), bean5.getDiscriminantLiterals());
     }
 
     static Jackson2Parser getJackson2Parser() {
@@ -132,7 +132,7 @@ public class Jackson2ParserTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = SubTypeDiscriminatedByName1.class, name = "SubType1"), // value from @JsonTypeName is used
+        @JsonSubTypes.Type(value = SubTypeDiscriminatedByName1.class, name = "SubType1"),
         @JsonSubTypes.Type(value = SubTypeDiscriminatedByName2.class, name = "SubType2"),
         @JsonSubTypes.Type(value = SubTypeDiscriminatedByName3.class),
         @JsonSubTypes.Type(value = SubTypeDiscriminatedByName4.class),

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
@@ -165,7 +165,7 @@ public class JsonDeserializationTest {
     @JsonSubTypes({
         @JsonSubTypes.Type(Square.class),
         @JsonSubTypes.Type(Rectangle.class),
-        @JsonSubTypes.Type(Circle.class),
+        @JsonSubTypes.Type(value = Circle.class, name = "circle2"),
     })
     private abstract static class Shape {
         public ShapeMetadata metadata;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -689,4 +689,44 @@ public class TaggedUnionsTest {
         Assertions.assertEquals(expected.trim(), output.trim());
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = LongDto.class, names = {"Long1", "Long2"}),
+            @JsonSubTypes.Type(value = BoolDto.class, names = {"Bool1", "Bool2"}),
+    })
+    private static abstract class AbstractDto {
+        public String type;
+    }
+
+    private static class LongDto extends AbstractDto {
+        public long value;
+    }
+
+    private static class BoolDto extends AbstractDto {
+        public boolean value;
+    }
+
+    @Test
+    public void testMultipleDiscriminantLiterals() {
+        final Settings settings = TestUtils.settings();
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AbstractDto.class));
+        final String expected = ""
+                + "interface AbstractDto {\n"
+                + "    type: \"Long1\" | \"Long2\" | \"Bool1\" | \"Bool2\";\n"
+                + "}\n"
+                + "\n"
+                + "interface LongDto extends AbstractDto {\n"
+                + "    type: \"Long1\" | \"Long2\";\n"
+                + "    value: number;\n"
+                + "}\n"
+                + "\n"
+                + "interface BoolDto extends AbstractDto {\n"
+                + "    type: \"Bool1\" | \"Bool2\";\n"
+                + "    value: boolean;\n"
+                + "}\n"
+                + "\n"
+                + "type AbstractDtoUnion = LongDto | BoolDto;\n"
+                + "";
+        Assertions.assertEquals(expected.trim(), output.trim());
+    }
 }

--- a/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTest-expected.ts
+++ b/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTest-expected.ts
@@ -92,7 +92,7 @@ export class Order {
 }
 
 export class Shape {
-    kind: "square" | "rectangle" | "circle";
+    kind: "square" | "rectangle" | "circle" | "circle2";
     metadata: ShapeMetadata;
 
     static fromData(data: Shape, target?: Shape): Shape {
@@ -115,6 +115,7 @@ export class Shape {
             case "rectangle":
                 return Rectangle.fromData(data);
             case "circle":
+            case "circle2":
                 return Circle.fromData(data);
         }
     }
@@ -166,7 +167,7 @@ export class Rectangle extends Shape {
 }
 
 export class Circle extends Shape {
-    kind: "circle";
+    kind: "circle" | "circle2";
     radius: number;
 
     static fromData(data: Circle, target?: Circle): Circle {

--- a/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTestWithConstructors-expected.ts
+++ b/typescript-generator-core/src/test/resources/cz/habarta/typescript/generator/JsonDeserializationTestWithConstructors-expected.ts
@@ -126,7 +126,7 @@ export class Order {
 }
 
 export class Shape {
-    kind: "square" | "rectangle" | "circle";
+    kind: "square" | "rectangle" | "circle" | "circle2";
     metadata: ShapeMetadata;
 
     constructor(data: Shape) {
@@ -154,6 +154,7 @@ export class Shape {
             case "rectangle":
                 return Rectangle.fromData(data);
             case "circle":
+            case "circle2":
                 return Circle.fromData(data);
         }
     }
@@ -220,7 +221,7 @@ export class Rectangle extends Shape {
 }
 
 export class Circle extends Shape {
-    kind: "circle";
+    kind: "circle" | "circle2";
     radius: number;
 
     constructor(data: Circle) {


### PR DESCRIPTION
fixes #796 

resolves all subtype names instead of only the first one