### PR TITLE
Recognize Swagger Api annotation as RestController contract

### DIFF
--- a/typescript-generator-spring/pom.xml
+++ b/typescript-generator-spring/pom.xml
@@ -61,7 +61,6 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>1.6.4</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
+++ b/typescript-generator-spring/src/main/java/cz/habarta/typescript/generator/spring/SpringApplicationParser.java
@@ -22,6 +22,7 @@ import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
 import static cz.habarta.typescript.generator.util.Utils.getInheritanceChain;
+import io.swagger.annotations.Api;
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -123,7 +124,8 @@ public class SpringApplicationParser extends RestApplicationParser {
 
         // controller
         final Component component = AnnotationUtils.findAnnotation(cls, Component.class);
-        if (component != null) {
+        final Api api = AnnotationUtils.findAnnotation(cls, Api.class);
+        if (component != null || api != null) {
             TypeScriptGenerator.getLogger().verbose("Parsing Spring component: " + cls.getName());
             final JaxrsApplicationParser.Result result = new JaxrsApplicationParser.Result();
             final RequestMapping requestMapping = AnnotatedElementUtils.findMergedAnnotation(cls, RequestMapping.class);

--- a/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
+++ b/typescript-generator-spring/src/test/java/cz/habarta/typescript/generator/spring/SpringTest.java
@@ -7,6 +7,7 @@ import cz.habarta.typescript.generator.TestUtils;
 import cz.habarta.typescript.generator.TypeScriptFileType;
 import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Utils;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.Operation;
 import java.lang.annotation.Retention;
@@ -488,4 +489,27 @@ public class SpringTest {
         }
     }
 
+    @Api(value = "customer")
+    public interface OpenApiGeneratorCreatedApi {
+
+        @RequestMapping(
+            method = RequestMethod.GET,
+            value = "/generated/api",
+            produces = {"application/json"}
+        )
+        ResponseEntity<String> getGeneratedApi();
+    }
+
+    @Test
+    void testOpenApiGeneratorCreatedInterfacesAreIncluded() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.generateSpringApplicationClient = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(
+            Input.from(OpenApiGeneratorCreatedApi.class));
+        Assertions.assertTrue(output.contains(
+            "getGeneratedApi(): RestResponse<string> {\n"
+                + "        return this.httpClient.request({ method: \"GET\", url: uriEncoding`generated/api` });\n"
+                + "    }"));
+    }
 }


### PR DESCRIPTION
-adapt implementation to recognize Swagger Api annotation as RestController contract so the generator is compatible with current openapi-generator (https://github.com/openapitools/openapi-generator)