### PR TITLE
Add `usePeerDeps` option to module dependency.

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModuleDependency.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModuleDependency.java
@@ -15,25 +15,27 @@ public class ModuleDependency {
     public File infoJson;
     public String npmPackageName;
     public String npmVersionRange;
+    public boolean usePeerDeps;
 
     public ModuleDependency() {
     }
 
-    private ModuleDependency(boolean global, String importFrom, String importAs, File infoJson, String npmPackageName, String npmVersionRange) {
+    private ModuleDependency(boolean global, String importFrom, String importAs, File infoJson, String npmPackageName, String npmVersionRange, boolean usePeerDeps) {
         this.global = global;
         this.importFrom = importFrom;
         this.importAs = importAs;
         this.infoJson = infoJson;
         this.npmPackageName = npmPackageName;
         this.npmVersionRange = npmVersionRange;
+        this.usePeerDeps = usePeerDeps;
     }
 
     public static ModuleDependency module(String importFrom, String importAs, File infoJson, String npmPackageName, String npmVersionRange) {
-        return new ModuleDependency(false, importFrom, importAs, infoJson, npmPackageName, npmVersionRange);
+        return new ModuleDependency(false, importFrom, importAs, infoJson, npmPackageName, npmVersionRange, false);
     }
 
     public static ModuleDependency global(File infoJson) {
-        return new ModuleDependency(true, null, null, infoJson, null, null);
+        return new ModuleDependency(true, null, null, infoJson, null, null, false);
     }
 
     @Override

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -118,7 +118,11 @@ public class TypeScriptGenerator {
             npmPackageJson.peerDependencies = new LinkedHashMap<>();
             if (settings.moduleDependencies != null) {
                 for (ModuleDependency dependency : settings.moduleDependencies) {
-                    npmPackageJson.dependencies.put(dependency.npmPackageName, dependency.npmVersionRange);
+                    if (dependency.usePeerDeps) {
+                        npmPackageJson.peerDependencies.put(dependency.npmPackageName, dependency.npmVersionRange);
+                    } else {
+                        npmPackageJson.dependencies.put(dependency.npmPackageName, dependency.npmVersionRange);
+                    }
                 }
             }
             if (settings.outputFileType == TypeScriptFileType.implementationFile) {


### PR DESCRIPTION
Normal dependencies can cause type mismatches if the dependency versions
are different.  This means that our dependency and every other library
or application depending on the same dependency need to use compatible
versions.  This is where `peerDependencies` is better.  The dependency
is only managed once at the top-level.