### PR TITLE
Fix support for nullability in Kotlin interfaces and abstract classes

### DIFF
--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTest.kt
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTest.kt
@@ -21,25 +21,102 @@ class KotlinTest {
     @Test
     fun testClassBody() {
         testOutput(A::class.java,
-                "class A<T> {\n" +
+                "class Abstract<T> {\n" +
+                        "    dataFromAbstract?: T;\n" +
+                        "    nonNullableBooleanFromAbstract: boolean;\n" +
+                        "    nonNullableFlagFromAbstract: boolean;\n" +
+                        "    nonNullableStringFromAbstract: string;\n" +
+                        "    nullableArrayFromAbstract?: (string | undefined)[];\n" +
+                        "    nullableBooleanFromAbstract?: boolean;\n" +
+                        "    nullableFlagFromAbstract?: boolean;\n" +
+                        "    nullableGenericArrayFromAbstract?: (T | undefined)[];\n" +
+                        "    nullableGenericTypeFromAbstract?: T;\n" +
+                        "    nullableListFromAbstract?: (string | undefined)[];\n" +
+                        "    nullableStringFromAbstract?: string;\n" +
+                        "    testFromAbstract: string;\n" +
+                        "    testNullableFromAbstract?: string;\n" +
+                        "}\n" +
+                        "\n" +
+                        "class A<T> extends Abstract<T> implements Interface<T> {\n" +
                         "    data?: T;\n" +
+                        "    dataFromInterface?: T;\n" +
                         "    nonNullableBoolean: boolean;\n" +
+                        "    nonNullableBooleanFromInterface: boolean;\n" +
                         "    nonNullableFlag: boolean;\n" +
+                        "    nonNullableFlagFromInterface: boolean;\n" +
                         "    nonNullableString: string;\n" +
+                        "    nonNullableStringFromInterface: string;\n" +
                         "    nullableArray?: (string | undefined)[];\n" +
+                        "    nullableArrayFromInterface?: (string | undefined)[];\n" +
                         "    nullableBoolean?: boolean;\n" +
+                        "    nullableBooleanFromInterface?: boolean;\n" +
                         "    nullableFlag?: boolean;\n" +
+                        "    nullableFlagFromInterface?: boolean;\n" +
                         "    nullableGenericArray?: (T | undefined)[];\n" +
+                        "    nullableGenericArrayFromInterface?: (T | undefined)[];\n" +
                         "    nullableGenericType?: T;\n" +
+                        "    nullableGenericTypeFromInterface?: T;\n" +
                         "    nullableList?: (string | undefined)[];\n" +
+                        "    nullableListFromInterface?: (string | undefined)[];\n" +
                         "    nullableString?: string;\n" +
+                        "    nullableStringFromInterface?: string;\n" +
                         "    test: string;\n" +
+                        "    testFromInterface: string;\n" +
                         "    testNullable?: string;\n" +
+                        "    testNullableFromInterface?: string;\n" +
+                        "}\n" +
+                        "\n" +
+                        "interface Interface<T> {\n" +
+                        "    dataFromInterface?: T;\n" +
+                        "    nonNullableBooleanFromInterface: boolean;\n" +
+                        "    nonNullableFlagFromInterface: boolean;\n" +
+                        "    nonNullableStringFromInterface: string;\n" +
+                        "    nullableArrayFromInterface?: (string | undefined)[];\n" +
+                        "    nullableBooleanFromInterface?: boolean;\n" +
+                        "    nullableFlagFromInterface?: boolean;\n" +
+                        "    nullableGenericArrayFromInterface?: (T | undefined)[];\n" +
+                        "    nullableGenericTypeFromInterface?: T;\n" +
+                        "    nullableListFromInterface?: (string | undefined)[];\n" +
+                        "    nullableStringFromInterface?: string;\n" +
+                        "    testFromInterface: string;\n" +
+                        "    testNullableFromInterface?: string;\n" +
                         "}"
         )
     }
 
-    private class A<T> {
+    private interface Interface<T> {
+        val nullableStringFromInterface: String?
+        val nonNullableStringFromInterface: String
+        val nullableListFromInterface: List<String?>?
+        val nullableArrayFromInterface: Array<String?>?
+        val nullableGenericArrayFromInterface: Array<T?>?
+        val nullableGenericTypeFromInterface: T?
+        val nullableBooleanFromInterface: Boolean?
+        val nonNullableBooleanFromInterface: Boolean
+        val isNullableFlagFromInterface: Boolean?
+        val isNonNullableFlagFromInterface: Boolean
+        fun <B: T> getDataFromInterface(): B?
+        fun getTestFromInterface(): String
+        fun getTestNullableFromInterface(): String?
+    }
+
+    private abstract class Abstract<T> {
+        abstract val nullableStringFromAbstract: String?
+        abstract val nonNullableStringFromAbstract: String
+        abstract val nullableListFromAbstract: List<String?>?
+        abstract val nullableArrayFromAbstract: Array<String?>?
+        abstract val nullableGenericArrayFromAbstract: Array<T?>?
+        abstract val nullableGenericTypeFromAbstract: T?
+        abstract val nullableBooleanFromAbstract: Boolean?
+        abstract val nonNullableBooleanFromAbstract: Boolean
+        abstract val isNullableFlagFromAbstract: Boolean?
+        abstract val isNonNullableFlagFromAbstract: Boolean
+        abstract fun <B: T> getDataFromAbstract(): B?
+        abstract fun getTestFromAbstract(): String
+        abstract fun getTestNullableFromAbstract(): String?
+    }
+
+    private class A<T> : Abstract<T>(), Interface<T> {
         val nullableString: String? = null
         val nonNullableString: String = ""
         val nullableList: List<String?>? = null
@@ -50,18 +127,37 @@ class KotlinTest {
         val nonNullableBoolean: Boolean = false
         val isNullableFlag: Boolean? = false
         val isNonNullableFlag: Boolean = false
+        fun <B: T> getData(): B? = null
+        fun getTest(): String = ""
+        fun getTestNullable(): String? = ""
 
-        fun <B: T> getData(): B? {
-            return null;
-        }
+        override val nullableStringFromAbstract: String? = null
+        override val nonNullableStringFromAbstract: String = ""
+        override val nullableListFromAbstract: List<String?>? = null
+        override val nullableArrayFromAbstract: Array<String?>? = null
+        override val nullableGenericArrayFromAbstract: Array<T?>? = null
+        override val nullableGenericTypeFromAbstract: T? = null
+        override val nullableBooleanFromAbstract: Boolean? = null
+        override val nonNullableBooleanFromAbstract: Boolean = false
+        override val isNullableFlagFromAbstract: Boolean? = false
+        override val isNonNullableFlagFromAbstract: Boolean = false
+        override fun <B: T> getDataFromAbstract(): B? = null
+        override fun getTestFromAbstract(): String = ""
+        override fun getTestNullableFromAbstract(): String? = ""
 
-        fun getTest(): String {
-            return ""
-        }
-
-        fun getTestNullable(): String? {
-            return ""
-        }
+        override val nullableStringFromInterface: String? = null
+        override val nonNullableStringFromInterface: String = ""
+        override val nullableListFromInterface: List<String?>? = null
+        override val nullableArrayFromInterface: Array<String?>? = null
+        override val nullableGenericArrayFromInterface: Array<T?>? = null
+        override val nullableGenericTypeFromInterface: T? = null
+        override val nullableBooleanFromInterface: Boolean? = null
+        override val nonNullableBooleanFromInterface: Boolean = false
+        override val isNullableFlagFromInterface: Boolean? = false
+        override val isNonNullableFlagFromInterface: Boolean = false
+        override fun <B: T> getDataFromInterface(): B? = null
+        override fun getTestFromInterface(): String = ""
+        override fun getTestNullableFromInterface(): String? = ""
     }
 
     @Path("")

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTest.kt
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTest.kt
@@ -21,66 +21,67 @@ class KotlinTest {
     @Test
     fun testClassBody() {
         testOutput(A::class.java,
-                "class Abstract<T> {\n" +
-                        "    dataFromAbstract?: T;\n" +
-                        "    nonNullableBooleanFromAbstract: boolean;\n" +
-                        "    nonNullableFlagFromAbstract: boolean;\n" +
-                        "    nonNullableStringFromAbstract: string;\n" +
-                        "    nullableArrayFromAbstract?: (string | undefined)[];\n" +
-                        "    nullableBooleanFromAbstract?: boolean;\n" +
-                        "    nullableFlagFromAbstract?: boolean;\n" +
-                        "    nullableGenericArrayFromAbstract?: (T | undefined)[];\n" +
-                        "    nullableGenericTypeFromAbstract?: T;\n" +
-                        "    nullableListFromAbstract?: (string | undefined)[];\n" +
-                        "    nullableStringFromAbstract?: string;\n" +
-                        "    testFromAbstract: string;\n" +
-                        "    testNullableFromAbstract?: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "class A<T> extends Abstract<T> implements Interface<T> {\n" +
-                        "    data?: T;\n" +
-                        "    dataFromInterface?: T;\n" +
-                        "    nonNullableBoolean: boolean;\n" +
-                        "    nonNullableBooleanFromInterface: boolean;\n" +
-                        "    nonNullableFlag: boolean;\n" +
-                        "    nonNullableFlagFromInterface: boolean;\n" +
-                        "    nonNullableString: string;\n" +
-                        "    nonNullableStringFromInterface: string;\n" +
-                        "    nullableArray?: (string | undefined)[];\n" +
-                        "    nullableArrayFromInterface?: (string | undefined)[];\n" +
-                        "    nullableBoolean?: boolean;\n" +
-                        "    nullableBooleanFromInterface?: boolean;\n" +
-                        "    nullableFlag?: boolean;\n" +
-                        "    nullableFlagFromInterface?: boolean;\n" +
-                        "    nullableGenericArray?: (T | undefined)[];\n" +
-                        "    nullableGenericArrayFromInterface?: (T | undefined)[];\n" +
-                        "    nullableGenericType?: T;\n" +
-                        "    nullableGenericTypeFromInterface?: T;\n" +
-                        "    nullableList?: (string | undefined)[];\n" +
-                        "    nullableListFromInterface?: (string | undefined)[];\n" +
-                        "    nullableString?: string;\n" +
-                        "    nullableStringFromInterface?: string;\n" +
-                        "    test: string;\n" +
-                        "    testFromInterface: string;\n" +
-                        "    testNullable?: string;\n" +
-                        "    testNullableFromInterface?: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface Interface<T> {\n" +
-                        "    dataFromInterface?: T;\n" +
-                        "    nonNullableBooleanFromInterface: boolean;\n" +
-                        "    nonNullableFlagFromInterface: boolean;\n" +
-                        "    nonNullableStringFromInterface: string;\n" +
-                        "    nullableArrayFromInterface?: (string | undefined)[];\n" +
-                        "    nullableBooleanFromInterface?: boolean;\n" +
-                        "    nullableFlagFromInterface?: boolean;\n" +
-                        "    nullableGenericArrayFromInterface?: (T | undefined)[];\n" +
-                        "    nullableGenericTypeFromInterface?: T;\n" +
-                        "    nullableListFromInterface?: (string | undefined)[];\n" +
-                        "    nullableStringFromInterface?: string;\n" +
-                        "    testFromInterface: string;\n" +
-                        "    testNullableFromInterface?: string;\n" +
-                        "}"
+                """
+                class Abstract<T> {
+                    dataFromAbstract?: T;
+                    nonNullableBooleanFromAbstract: boolean;
+                    nonNullableFlagFromAbstract: boolean;
+                    nonNullableStringFromAbstract: string;
+                    nullableArrayFromAbstract?: (string | undefined)[];
+                    nullableBooleanFromAbstract?: boolean;
+                    nullableFlagFromAbstract?: boolean;
+                    nullableGenericArrayFromAbstract?: (T | undefined)[];
+                    nullableGenericTypeFromAbstract?: T;
+                    nullableListFromAbstract?: (string | undefined)[];
+                    nullableStringFromAbstract?: string;
+                    testFromAbstract: string;
+                    testNullableFromAbstract?: string;
+                }
+                
+                class A<T> extends Abstract<T> implements Interface<T> {
+                    data?: T;
+                    dataFromInterface?: T;
+                    nonNullableBoolean: boolean;
+                    nonNullableBooleanFromInterface: boolean;
+                    nonNullableFlag: boolean;
+                    nonNullableFlagFromInterface: boolean;
+                    nonNullableString: string;
+                    nonNullableStringFromInterface: string;
+                    nullableArray?: (string | undefined)[];
+                    nullableArrayFromInterface?: (string | undefined)[];
+                    nullableBoolean?: boolean;
+                    nullableBooleanFromInterface?: boolean;
+                    nullableFlag?: boolean;
+                    nullableFlagFromInterface?: boolean;
+                    nullableGenericArray?: (T | undefined)[];
+                    nullableGenericArrayFromInterface?: (T | undefined)[];
+                    nullableGenericType?: T;
+                    nullableGenericTypeFromInterface?: T;
+                    nullableList?: (string | undefined)[];
+                    nullableListFromInterface?: (string | undefined)[];
+                    nullableString?: string;
+                    nullableStringFromInterface?: string;
+                    test: string;
+                    testFromInterface: string;
+                    testNullable?: string;
+                    testNullableFromInterface?: string;
+                }
+                
+                interface Interface<T> {
+                    dataFromInterface?: T;
+                    nonNullableBooleanFromInterface: boolean;
+                    nonNullableFlagFromInterface: boolean;
+                    nonNullableStringFromInterface: string;
+                    nullableArrayFromInterface?: (string | undefined)[];
+                    nullableBooleanFromInterface?: boolean;
+                    nullableFlagFromInterface?: boolean;
+                    nullableGenericArrayFromInterface?: (T | undefined)[];
+                    nullableGenericTypeFromInterface?: T;
+                    nullableListFromInterface?: (string | undefined)[];
+                    nullableStringFromInterface?: string;
+                    testFromInterface: string;
+                    testNullableFromInterface?: string;
+                }""".trimIndent()
         )
     }
 


### PR DESCRIPTION
When encountering a Kotlin property the type parser attempts to find the backing java field:
https://github.com/vojtechhabarta/typescript-generator/blob/7a33aa0d8b4ce9e0a7d6626e65195b4c995b2871/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/TypeParser.java#L193

However, in interfaces and abstract classes a property might not have a Java field. In this case the parser falls back to the Java type parser which doesn't know about Kotlin nullability:
https://github.com/vojtechhabarta/typescript-generator/blob/7a33aa0d8b4ce9e0a7d6626e65195b4c995b2871/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/TypeParser.java#L200

This PR fixes #708 by changing the behavior to directly use the return type of the Kotlin property.