### PR TITLE
add retention policy check to optional annotations

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -393,6 +393,13 @@ public class Settings {
                         "Suggestion: annotation '%s' supports 'TYPE_PARAMETER' or 'TYPE_USE' target. Consider using 'nullableAnnotations' parameter instead of 'optionalAnnotations'.",
                         annotation.getName()));
             }
+           Retention retention = annotation.getAnnotation(Retention.class);
+           if (retention == null) {
+              throw new RuntimeException(annotation + " has no specified retention policy");
+           }
+           if (retention.value() != RetentionPolicy.RUNTIME) {
+              throw new RuntimeException(annotation + " is not marked as runtime annotation");
+           }
         }
         if (!optionalAnnotations.isEmpty() && !requiredAnnotations.isEmpty()) {
             throw new RuntimeException("Only one of 'optionalAnnotations' and 'requiredAnnotations' can be used at the same time.");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.TypeVariable;
 import java.net.URL;


### PR DESCRIPTION
Thanks for the typescript-generator. This is a small PR to check if all optional annotations are usable. It might be extended to the other annotation types.

Using e.g. org.jetbrains.annotation.nullable fails silently, as it has RetentionPolicy.class. This check fails if an annotation with this retention policy is used for optional annotations.