### PR TITLE
Feature: allow nullable constructor parameter

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -91,6 +91,7 @@ public class Settings {
     public List<String> mapClassesAsClassesPatterns;
     private Predicate<String> mapClassesAsClassesFilter = null;
     public boolean generateConstructors = false;
+    public boolean allowNullableConstructorParameter = false;
     public List<Class<? extends Annotation>> disableTaggedUnionAnnotations = new ArrayList<>();
     public boolean disableTaggedUnions = false;
     public boolean generateReadonlyAndWriteonlyJSDocTags = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -541,7 +541,7 @@ public class ModelCompiler {
                 if (!inheritedProperties.containsKey(property.getName())) {
                     body.add(new TsExpressionStatement(new TsAssignmentExpression(
                             new TsMemberExpression(new TsThisExpression(), property.name),
-                            new TsMemberExpression(new TsIdentifierReference("data"), property.name)
+                            new TsMemberExpression(new TsIdentifierReference("data" + (settings.allowNullableConstructorParameter ? "?" : "")), property.name)
                     )));
                 }
             }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
@@ -275,6 +275,22 @@ public class ClassesTest {
         settings.generateConstructors = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FooBar.class));
         Assertions.assertTrue(output.contains("constructor(data: FooBar)"));
+        Assertions.assertTrue(output.contains("this.foo = data.foo;"));
+        Assertions.assertTrue(output.contains("this.bar = data.bar;"));
+    }
+
+    @Test
+    public void testConstructorWithNullableParameter() {
+        final Settings settings = TestUtils.settings();
+        settings.optionalAnnotations = Arrays.asList(Nullable.class);
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.mapClasses = ClassMapping.asClasses;
+        settings.generateConstructors = true;
+        settings.allowNullableConstructorParameter = true;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(FooBar.class));
+        Assertions.assertTrue(output.contains("constructor(data: FooBar)"));
+        Assertions.assertTrue(output.contains("this.foo = data?.foo;"));
+        Assertions.assertTrue(output.contains("this.bar = data?.bar;"));
     }
 
     @Test

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -88,6 +88,7 @@ public class GenerateTask extends DefaultTask {
     public ClassMapping mapClasses;
     public List<String> mapClassesAsClassesPatterns;
     public boolean generateConstructors;
+    public boolean allowNullableConstructorParameter;
     public List<String> disableTaggedUnionAnnotations;
     public boolean disableTaggedUnions;
     public boolean generateReadonlyAndWriteonlyJSDocTags;
@@ -178,6 +179,7 @@ public class GenerateTask extends DefaultTask {
         settings.mapClasses = mapClasses;
         settings.mapClassesAsClassesPatterns = mapClassesAsClassesPatterns;
         settings.generateConstructors = generateConstructors;
+        settings.allowNullableConstructorParameter = allowNullableConstructorParameter;
         settings.loadDisableTaggedUnionAnnotations(classLoader, disableTaggedUnionAnnotations);
         settings.disableTaggedUnions = disableTaggedUnions;
         settings.generateReadonlyAndWriteonlyJSDocTags = generateReadonlyAndWriteonlyJSDocTags;

--- a/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
+++ b/typescript-generator-maven-plugin/src/main/java/cz/habarta/typescript/generator/maven/GenerateMojo.java
@@ -512,6 +512,14 @@ public class GenerateMojo extends AbstractMojo {
     private boolean generateConstructors;
 
     /**
+     * If <code>true</code> the constructor can handle a parameter, which is null. Must go together with <code>generateConstructors</code>
+     * That means the values are only assigned to the class-properties, when the provided constructor-parameter is not null.
+     * If set to <code>false<code/> the constructor will throw an exception if the constructor-parameter is null.
+     */
+    @Parameter
+    private boolean allowNullableConstructorParameter;
+
+    /**
      * Specifies annotations used for disabling tagged union created from classes.
      * In case of Jackson2 library this means class hierarchy formed using <code>@JsonTypeInfo</code> and <code>@JsonSubTypes</code> annotations.
      * While <code>disableTaggedUnions</code> parameter only disables creation of TypeScript discriminated union types
@@ -947,6 +955,7 @@ public class GenerateMojo extends AbstractMojo {
         settings.mapClasses = mapClasses;
         settings.mapClassesAsClassesPatterns = mapClassesAsClassesPatterns;
         settings.generateConstructors = generateConstructors;
+        settings.allowNullableConstructorParameter = allowNullableConstructorParameter;
         settings.loadDisableTaggedUnionAnnotations(classLoader, disableTaggedUnionAnnotations);
         settings.disableTaggedUnions = disableTaggedUnions;
         settings.generateReadonlyAndWriteonlyJSDocTags = generateReadonlyAndWriteonlyJSDocTags;


### PR DESCRIPTION
We are working together with the library https://github.com/typestack/class-transformer
This library does not provide all required values with the constructor, but instead sets the values after instantiation of the class.
Unfortunately this is not compatible, how typescript-generator works as default.
This PR adds the flag `allowNullableConstructorParameter` to the settings. By default this is false and keeps the current behaviour. If set to true a null-check is added the the constructor assignments.