### PR TITLE
add support for JSON-B built-in types in the conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,16 @@
                 <version>2.1.1</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>1.1.4</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.json.bind</groupId>
                 <artifactId>jakarta.json.bind-api</artifactId>
                 <version>2.0.0</version>

--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -72,6 +72,14 @@
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.json.bind</groupId>
             <artifactId>javax.json.bind-api</artifactId>
         </dependency>

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbParserTest.java
@@ -17,6 +17,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.UUID;
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +36,14 @@ public class JsonbParserTest {
         settings = TestUtils.settings();
         settings.jsonLibrary = JsonLibrary.jsonb;
         settings.optionalProperties = OptionalProperties.useLibraryDefinition;
+    }
+
+    private static class JsonTypes {
+        public JsonValue jsonValue;
+        public JsonObject jsonObject;
+        public JsonArray jsonArray;
+        public JsonString jsonString;
+        public JsonNumber jsonNumber;
     }
 
     private static class OverridenPropertyName {
@@ -163,6 +176,19 @@ public class JsonbParserTest {
         public ListOfNullableElementsConstructor(List<@Nullable String> foos) {
             this.foos = foos;
         }
+    }
+
+    @Test
+    public void testJsonTypes() {
+        Assertions.assertEquals(
+                "interface JsonTypes {\n" +
+                "    jsonArray?: any[];\n" +
+                "    jsonNumber?: number;\n" +
+                "    jsonObject?: { [index: string]: any };\n" +
+                "    jsonString?: string;\n" +
+                "    jsonValue?: any;\n" +
+                "}",
+                generate(settings, JsonTypes.class).trim());
     }
 
     @Test


### PR DESCRIPTION
Concretely `JsonValue` children are not supported as of today leading to these types being treated as standard Java types (and they are not in regard of the serialization).
This PR just set some replacement for types to ensure the generator can treat them as expected.