### PR TITLE
fix mapPackagesToNamespaces in AxiosClientExtension

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/AxiosClientExtension.java
@@ -45,7 +45,8 @@ public class AxiosClientExtension extends Extension {
         for (TsBeanModel bean : model.getBeans()) {
             if (bean.isJaxrsApplicationClientBean()) {
                 final String clientName = bean.getName().getSimpleName();
-                emitClient(writer, settings, exportKeyword, clientName);
+                final String clientFullName = settings.mapPackagesToNamespaces ? bean.getName().getFullName(): bean.getName().getSimpleName();
+                emitClient(writer, settings, exportKeyword, clientName, clientFullName);
             }
         }
     }
@@ -55,12 +56,13 @@ public class AxiosClientExtension extends Extension {
         Emitter.writeTemplate(writer, settings, template, null);
     }
 
-    private void emitClient(Writer writer, Settings settings, boolean exportKeyword, String clientName) {
+    private void emitClient(Writer writer, Settings settings, boolean exportKeyword, String clientName, String clientFullName) {
         final List<String> template = Utils.readLines(getClass().getResourceAsStream("AxiosClientExtension-client.template.ts"));
         final Map<String, String> replacements = new LinkedHashMap<>();
         replacements.put("\"", settings.quotes);
         replacements.put("/*export*/ ", exportKeyword ? "export " : "");
         replacements.put("$$RestApplicationClient$$", clientName);
+        replacements.put("$$RestApplicationClientFullName$$", clientFullName);
         replacements.put("$$AxiosRestApplicationClient$$", "Axios" + clientName);
         Emitter.writeTemplate(writer, settings, template, replacements);
     }

--- a/typescript-generator-core/src/main/resources/cz/habarta/typescript/generator/ext/AxiosClientExtension-client.template.ts
+++ b/typescript-generator-core/src/main/resources/cz/habarta/typescript/generator/ext/AxiosClientExtension-client.template.ts
@@ -1,5 +1,5 @@
 
-/*export*/ class $$AxiosRestApplicationClient$$ extends $$RestApplicationClient$$<Axios.AxiosRequestConfig> {
+/*export*/ class $$AxiosRestApplicationClient$$ extends $$RestApplicationClientFullName$$<Axios.AxiosRequestConfig> {
 
     constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create()) {
         axiosInstance.defaults.baseURL = baseURL;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
@@ -42,4 +42,31 @@ public class AxiosClientExtensionTest {
         Assertions.assertTrue(output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"), errorMessage);
     }
 
+    @Test
+    public void mapPackagesToNamespaces() {
+        final Settings settings = TestUtils.settings();
+        settings.outputFileType = TypeScriptFileType.implementationFile;
+        settings.outputKind = TypeScriptOutputKind.module;
+        settings.generateJaxrsApplicationClient = true;
+        settings.restNamespacing = RestNamespacing.perResource;
+        settings.mapPackagesToNamespaces = true;
+        settings.extensions.add(new AxiosClientExtension());
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(JaxrsApplicationTest.OrganizationApplication.class));
+        final String errorMessage = "Unexpected output: " + output;
+
+        Assertions.assertTrue(output.contains("interface Organization"), errorMessage);
+        Assertions.assertTrue(output.contains("interface Address"), errorMessage);
+        Assertions.assertTrue(output.contains("interface Person"), errorMessage);
+        Assertions.assertTrue(output.contains("interface HttpClient"), errorMessage);
+
+        Assertions.assertTrue(output.contains("class OrganizationsResourceClient<O>"), errorMessage);
+        Assertions.assertTrue(output.contains("class PersonResourceClient<O>"), errorMessage);
+        Assertions.assertTrue(output.contains("type RestResponse<R> = Promise<Axios.GenericAxiosResponse<R>>"), errorMessage);
+
+        Assertions.assertTrue(output.contains("class AxiosHttpClient implements HttpClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("request<R>(requestConfig: { method: string; url: string; queryParams?: any; data?: any; copyFn?: (data: R) => R; options?: Axios.AxiosRequestConfig; }): RestResponse<R>"), errorMessage);
+        Assertions.assertTrue(output.contains("export class AxiosOrganizationsResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.OrganizationsResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosPersonResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.PersonResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"), errorMessage);
+    }
 }


### PR DESCRIPTION
Wenn setting mapPackagesToNamespaces to true the generated typescript file has an error when using the AxiosClientExtension cause the client uses the class without the namespace