### PR TITLE
feat: ✨ convert Javadoc anchor tags to TSdoc links

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -256,11 +256,11 @@ public class Javadoc {
                     .replaceAll("\\s*<br />\\s*", nn)
                     .replaceAll("\\s*<p>\\s*", nn)
                     .replaceAll("\\s*</p>\\s*", nn);
-            result.addAll(Utils.splitMultiline(replacedHtmlLines, true));
+            result.addAll(Utils.splitMultiline(convertAnchorToLink(replacedHtmlLines), true));
         }
         if (tags != null) {
             for (TagInfo tag : tags) {
-                result.addAll(Utils.splitMultiline(tag.getName() + " " + tag.getText(), true));
+                result.addAll(Utils.splitMultiline(tag.getName() + " " + convertAnchorToLink(tag.getText()), true));
             }
         }
         return result;
@@ -269,6 +269,16 @@ public class Javadoc {
     private static List<String> combineComments(List<String> firstComments, List<String> secondComments) {
         // consider putting tags (from both comments) after regular comments
         return Utils.concat(firstComments, secondComments);
+    }
+
+    /**
+     * Replaces all anchor tags in the given string with TSdoc-style links.
+     *
+     * @param comment comment to convert
+     * @return comment with Javadoc anchor tags converted to TSdoc links
+     */
+    private static String convertAnchorToLink(String comment) {
+        return comment.replaceAll("<a href=\"([^\"]+)\">([^<]+)</a>", "{@link $1 $2}");
     }
 
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -105,6 +105,13 @@ public class JavadocTest {
             Assertions.assertTrue(!generated.contains("</p>"));
             Assertions.assertTrue(generated.contains("Long\n * paragraph\n * \n * Second\n * paragraph"));
         }
+        {
+            final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithExternalLinks.class));
+            Assertions.assertFalse(generated.contains("<a"));
+            Assertions.assertFalse(generated.contains("</a>"));
+            Assertions.assertTrue(generated.contains("{@link https://github.com/vojtechhabarta/typescript-generator link}"));
+            Assertions.assertTrue(generated.contains("{@link https://github.com/vojtechhabarta/typescript-generator/wiki the wiki}"));
+        }
     }
 
     /**
@@ -215,6 +222,15 @@ public class JavadocTest {
      * paragraph</p>
      */
     public static class ClassWithPElements {
+    }
+
+    /**
+     * Documentation for ClassWithExternalLinks
+     *
+     * This sentence has a <a href="https://github.com/vojtechhabarta/typescript-generator">link</a>!
+     * @see <a href="https://github.com/vojtechhabarta/typescript-generator/wiki">the wiki</a>
+     */
+    public static class ClassWithExternalLinks {
     }
 
 }

--- a/typescript-generator-core/src/test/javadoc/test-javadoc.xml
+++ b/typescript-generator-core/src/test/javadoc/test-javadoc.xml
@@ -2547,6 +2547,14 @@
             <class qualified="java.lang.Object"/>
             <constructor name="ClassWithPElements" signature="()" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithPElements" scope="public" final="false" included="true" native="false" synchronized="false" static="false" varArgs="false"/>
         </class>
+        <class name="JavadocTest.ClassWithExternalLinks" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithExternalLinks" scope="public" abstract="false" error="false" exception="false" externalizable="false" included="true" serializable="false">
+            <comment>Documentation for ClassWithExternalLinks
+
+ This sentence has a &lt;a href="https://github.com/vojtechhabarta/typescript-generator"&gt;link&lt;/a&gt;!</comment>
+            <tag name="@see" text="&lt;a href=&quot;https://github.com/vojtechhabarta/typescript-generator/wiki&quot;&gt;the wiki&lt;/a&gt;"/>
+            <class qualified="java.lang.Object"/>
+            <constructor name="ClassWithExternalLinks" signature="()" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithExternalLinks" scope="public" final="false" included="true" native="false" synchronized="false" static="false" varArgs="false"/>
+        </class>
         <class name="JaxbTest" qualified="cz.habarta.typescript.generator.JaxbTest" scope="public" abstract="false" error="false" exception="false" externalizable="false" included="true" serializable="false">
             <class qualified="java.lang.Object"/>
             <constructor name="JaxbTest" signature="()" qualified="cz.habarta.typescript.generator.JaxbTest" scope="public" final="false" included="true" native="false" synchronized="false" static="false" varArgs="false"/>
@@ -8212,6 +8220,14 @@
  paragraph&lt;/p&gt;</comment>
             <class qualified="java.lang.Object"/>
             <constructor name="ClassWithPElements" signature="()" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithPElements" scope="public" final="false" included="true" native="false" synchronized="false" static="false" varArgs="false"/>
+        </class>
+        <class name="JavadocTest.ClassWithExternalLinks" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithExternalLinks" scope="public" abstract="false" error="false" exception="false" externalizable="false" included="true" serializable="false">
+            <comment>Documentation for ClassWithExternalLinks
+
+ This sentence has a &lt;a href="https://github.com/vojtechhabarta/typescript-generator"&gt;link&lt;/a&gt;!</comment>
+            <tag name="@see" text="&lt;a href=&quot;https://github.com/vojtechhabarta/typescript-generator/wiki&quot;&gt;the wiki&lt;/a&gt;"/>
+            <class qualified="java.lang.Object"/>
+            <constructor name="ClassWithExternalLinks" signature="()" qualified="cz.habarta.typescript.generator.JavadocTest.ClassWithExternalLinks" scope="public" final="false" included="true" native="false" synchronized="false" static="false" varArgs="false"/>
         </class>
         <class name="Jackson2PolymorphismTest" qualified="cz.habarta.typescript.generator.Jackson2PolymorphismTest" scope="public" abstract="false" error="false" exception="false" externalizable="false" included="true" serializable="false">
             <class qualified="java.lang.Object"/>


### PR DESCRIPTION
Fixes #887 

### Example

Given:
```java
/**
 * Represents a hamburger (food) 🍔
 *
 * @see <a href=
 *      "https://en.wikipedia.org/wiki/Hamburger">Hamburger - Wikipedia</a>
 */
@Data
public class Hamburger {
	private String name;
	private @Nullable String description;
	private ArrayList<String> ingredients;
}
```
![image](https://user-images.githubusercontent.com/7477471/191646475-d87f1e6c-5bc0-4eb6-9843-5df43e305a0a.png)


Before:

```ts
/**
 * Represents a hamburger (food) 🍔
 * @see <a href=
 *      "https://en.wikipedia.org/wiki/Hamburger">Hamburger - Wikipedia</a>
 */
interface Hamburger {
  readonly name: string;
  readonly description?: string;
  readonly ingredients: string[];
}
```
![image](https://user-images.githubusercontent.com/7477471/191645776-0db76f3a-bc76-4afb-8311-b6fe2bb6d783.png)


After:

```ts
/**
 * Represents a hamburger (food) 🍔
 * @see {@link https://en.wikipedia.org/wiki/Hamburger Hamburger - Wikipedia}
 */
interface Hamburger {
  readonly name: string;
  readonly description?: string;
  readonly ingredients: string[];
}
```
![image](https://user-images.githubusercontent.com/7477471/191646174-1e70d40c-0da9-4545-a9b5-cda28b82f587.png)