### PR TITLE
Update generic type arguments while transforming bean properties

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -1280,7 +1280,23 @@ public class ModelCompiler {
                 final TsType newReturnType = TsType.transformTsType(context, method.getReturnType(), transformer);
                 newMethods.add(new TsMethodModel(method.getName(), method.getModifiers(), method.getTypeParameters(), newParameters, newReturnType, method.getBody(), method.getComments()));
             }
-            newBeans.add(bean.withProperties(newProperties).withMethods(newMethods));
+            final List<TsType> newImplements = new ArrayList<>();
+            for (TsType type: bean.getImplementsList()) {
+                if (type instanceof TsType.GenericBasicType || type instanceof TsType.GenericReferenceType) {
+                    newImplements.add(TsType.transformTsType(context, type, transformer));
+                } else {
+                    newImplements.add(type);
+                }
+            }
+            final List<TsType> newExtends = new ArrayList<>();
+            for (TsType type: bean.getExtendsList()) {
+                if (type instanceof TsType.GenericBasicType || type instanceof TsType.GenericReferenceType) {
+                    newExtends.add(TsType.transformTsType(context, type, transformer));
+                } else {
+                    newExtends.add(type);
+                }
+            }
+            newBeans.add(bean.withProperties(newProperties).withMethods(newMethods).withImplements(newImplements).withExtends(newExtends));
         }
         return tsModel.withBeans(newBeans);
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBeanModel.java
@@ -160,9 +160,17 @@ public class TsBeanModel extends TsDeclarationModel {
     public boolean isJaxrsApplicationClientBean() {
         return category == TsBeanCategory.Service && isClass;
     }
-    
+
     public boolean isDataClass() {
         return category == TsBeanCategory.Data && isClass;
     }
-    
+
+    public TsBeanModel withImplements(List<TsType> implementsList) {
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+    }
+
+    public TsBeanModel withExtends(List<TsType> extendsList) {
+        return new TsBeanModel(origin, category, isClass, decorators, name, typeParameters, parent, extendsList, implementsList, taggedUnionClasses, discriminantProperty, discriminantLiteral, taggedUnionAlias, properties, constructor, methods, comments);
+    }
+
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericCustomTypeMappingsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericCustomTypeMappingsTest.java
@@ -154,4 +154,27 @@ public class GenericCustomTypeMappingsTest {
         Assertions.assertTrue(output.contains("specialData: SpecialString"), output);
     }
 
+    @Test
+    public void testGenericSuperType() {
+        final Settings settings = TestUtils.settings();
+        settings.mapDate = DateMapping.asString;
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Class3.class));
+        Assertions.assertTrue(output.contains("Interface<DateAsString>"));
+        Assertions.assertTrue(output.contains("interfaceValue: DateAsString;"));
+        Assertions.assertTrue(output.contains("AbstractClass<DateAsString>"));
+        Assertions.assertTrue(output.contains("abstractValue: DateAsString;"));
+    }
+
+    private interface Interface<T> {
+        T getInterfaceValue();
+    }
+
+    private static abstract class AbstractClass<T> {
+        public abstract T getAbstractValue();
+    }
+
+    private static abstract class Class3 extends AbstractClass<Date> implements Interface<Date>{
+    }
+
+
 }


### PR DESCRIPTION
Currently the type arguments of implemented generic interfaces or extended generic classes are not updated when transforming the properties of a bean. If a property is defined by a getter with generic return type this leads to an invalid ts file because the implementation does not match the interface/superclass.