### PR TITLE
Feature/inherited json identity info

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -367,6 +367,20 @@ public class Jackson2Parser extends ModelParser {
         }
     }
 
+    private <T extends Annotation> T findClassAnnotation(Class<?> cls, Class<T> annotation) {
+        T identityInfo = cls.getAnnotation(annotation);
+
+        if (identityInfo == null) {
+            Class<?> parent = cls.getSuperclass();
+
+            if (parent != null) {
+                return findClassAnnotation(parent, annotation);
+            }
+        }
+
+        return identityInfo;
+    }
+
     // @JsonIdentityInfo and @JsonIdentityReference
     private Type processIdentity(Type propertyType, BeanProperty beanProperty) {
 
@@ -375,13 +389,13 @@ public class Jackson2Parser extends ModelParser {
         final Class<?> cls = clsT != null ? clsT : clsW;
 
         if (cls != null) {
-            final JsonIdentityInfo identityInfoC = cls.getAnnotation(JsonIdentityInfo.class);
+            final JsonIdentityInfo identityInfoC = this.findClassAnnotation(cls, JsonIdentityInfo.class);
             final JsonIdentityInfo identityInfoP = beanProperty.getAnnotation(JsonIdentityInfo.class);
             final JsonIdentityInfo identityInfo = identityInfoP != null ? identityInfoP : identityInfoC;
             if (identityInfo == null) {
                 return null;
             }
-            final JsonIdentityReference identityReferenceC = cls.getAnnotation(JsonIdentityReference.class);
+            final JsonIdentityReference identityReferenceC = this.findClassAnnotation(cls, JsonIdentityReference.class);
             final JsonIdentityReference identityReferenceP = beanProperty.getAnnotation(JsonIdentityReference.class);
             final JsonIdentityReference identityReference = identityReferenceP != null ? identityReferenceP : identityReferenceC;
             final boolean alwaysAsId = identityReference != null && identityReference.alwaysAsId();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
@@ -124,14 +124,15 @@ public class ObjectAsIdTest {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Wrapper.class));
         Assertions.assertTrue(output.contains("testObjectA1: string"));
-        Assertions.assertTrue(output.contains("testObjectSubA: TestObjectSubA"));
+        Assertions.assertTrue(output.contains("testObjectSubA: string"));
         Assertions.assertTrue(output.contains("testObjectB1: TestObjectB | string"));
         Assertions.assertTrue(output.contains("testObjectC1: TestObjectC<string> | string"));
         Assertions.assertTrue(output.contains("testObjectD1: string"));
         Assertions.assertTrue(output.contains("testObjectE1: string"));
         Assertions.assertTrue(output.contains("testObjectE2: TestObjectE | string"));
         Assertions.assertTrue(output.contains("testObjectE3: TestObjectE"));
-        Assertions.assertTrue(output.contains("interface TestObjectA"));
+        Assertions.assertTrue(!output.contains("interface TestObjectA"));
+        Assertions.assertTrue(!output.contains("interface TestObjectSubA"));
         Assertions.assertTrue(output.contains("interface TestObjectB"));
         Assertions.assertTrue(output.contains("interface TestObjectC<T>"));
         Assertions.assertTrue(!output.contains("interface TestObjectD"));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
@@ -26,6 +26,7 @@ public class ObjectAsIdTest {
     @Test
     public void testJackson() throws JsonProcessingException {
         final TestObjectA testObjectA = new TestObjectA();
+        final TestObjectSubA testObjectSubA = new TestObjectSubA();
         final TestObjectB testObjectB = new TestObjectB();
         final TestObjectC<String> testObjectC = new TestObjectC<>("valueC");
         final TestObjectD testObjectD = new TestObjectD();
@@ -33,6 +34,7 @@ public class ObjectAsIdTest {
         final Wrapper wrapper = new Wrapper();
         wrapper.testObjectA1 = testObjectA;
         wrapper.testObjectA2 = testObjectA;
+        wrapper.testObjectSubA = testObjectSubA;
         wrapper.testObjectB1 = testObjectB;
         wrapper.testObjectB2 = testObjectB;
         wrapper.testObjectC1 = testObjectC;
@@ -47,6 +49,7 @@ public class ObjectAsIdTest {
         final String json = objectMapper.writeValueAsString(wrapper);
         Assertions.assertTrue(json.contains("\"testObjectA1\": \"id1\""));
         Assertions.assertTrue(json.contains("\"testObjectA2\": \"id1\""));
+        Assertions.assertTrue(json.contains("\"testObjectSubA\": \"id1\""));
         Assertions.assertTrue(json.contains("\"testObjectB1\": {"));
         Assertions.assertTrue(json.contains("\"testObjectB2\": \"id2\""));
         Assertions.assertTrue(json.contains("\"testObjectC1\": {"));
@@ -121,13 +124,14 @@ public class ObjectAsIdTest {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Wrapper.class));
         Assertions.assertTrue(output.contains("testObjectA1: string"));
+        Assertions.assertTrue(output.contains("testObjectSubA: TestObjectSubA"));
         Assertions.assertTrue(output.contains("testObjectB1: TestObjectB | string"));
         Assertions.assertTrue(output.contains("testObjectC1: TestObjectC<string> | string"));
         Assertions.assertTrue(output.contains("testObjectD1: string"));
         Assertions.assertTrue(output.contains("testObjectE1: string"));
         Assertions.assertTrue(output.contains("testObjectE2: TestObjectE | string"));
         Assertions.assertTrue(output.contains("testObjectE3: TestObjectE"));
-        Assertions.assertTrue(!output.contains("interface TestObjectA"));
+        Assertions.assertTrue(output.contains("interface TestObjectA"));
         Assertions.assertTrue(output.contains("interface TestObjectB"));
         Assertions.assertTrue(output.contains("interface TestObjectC<T>"));
         Assertions.assertTrue(!output.contains("interface TestObjectD"));
@@ -195,6 +199,10 @@ public class ObjectAsIdTest {
         public String myIdentification = "id1";
 
         public String myProperty = "valueA";
+    }
+
+    private static class TestObjectSubA extends TestObjectA {
+        public String subProperty = "valueSubA";
     }
 
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "@@@id")
@@ -277,6 +285,7 @@ public class ObjectAsIdTest {
     private static class Wrapper {
         public TestObjectA testObjectA1;
         public TestObjectA testObjectA2;
+        public TestObjectSubA testObjectSubA;
         public TestObjectB testObjectB1;
         public TestObjectB testObjectB2;
         public TestObjectC<String> testObjectC1;


### PR DESCRIPTION
Jackson serializes subclasses of classes annotated with `JsonIdentityInfo` as if the class itself were annotated with `JsonIdentityInfo`.  See the updates to `ObjectAsIdTest.testJackson` to prove this is the case.  The TypeScript generator was not producing correct interface definitions because it was not properly recognizing all `JsonIdentityInfo` cases.  `JsonIdentityInfo` isn't `Inherited`, even if it were `Class.getAnnotation` doesn't return inherited annotations.  We need to manually walk the target class upward looking for `JsonIdentityInfo`.

This PR adds an example of this problem to the test cases.  First making the test cases pass with the current behavior.  Next making the test cases fail using the expected behavior.  Finally updating `Jackson2Parser` to make the tests pass.

I simply added a utility method in `Jackson2Parser` to support this change.  I see you have some utilities classes, but was unsure of your style for that.  The method should be easy to move wherever you feel is best.  Thanks.