### PR TITLE
do not use @deprecated tag if enum item is deprecated

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -1062,9 +1062,9 @@ public class ModelCompiler {
         if (enumMember.getComments() == null) {
             return "";
         }
-        return " - " + enumMember.getComments().stream()
+        return enumMember.getComments().stream()
             .map(s -> s.startsWith(DeprecationUtils.DEPRECATED) ? s.substring(1) : s)
-            .collect(Collectors.joining(" "));
+            .collect(Collectors.joining(" ", " - ", ""));
     }
 
     private TsModel createAndUseTaggedUnions(final SymbolTable symbolTable, TsModel tsModel) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -1046,9 +1046,7 @@ public class ModelCompiler {
                     Utils.listFromNullable(enumModel.getComments()).stream(),
                     (hasComments ? Stream.of("") : Stream.<String>empty()),
                     Stream.of("Values:"),
-                    enumModel.getMembers().stream()
-                        .map(enumMember -> "- `" + enumMember.getEnumValue() + "`"
-                            + getEnumItemCommentAsString(enumMember))
+                    enumModel.getMembers().stream().map(enumMember -> "- `" + enumMember.getEnumValue() + "`" + getEnumMemberCommentAsString(enumMember))
                 )
                 .flatMap(Function.identity())
                 .collect(Collectors.toList())
@@ -1058,7 +1056,7 @@ public class ModelCompiler {
         }
     }
 
-    private static String getEnumItemCommentAsString(EnumMemberModel enumMember) {
+    private static String getEnumMemberCommentAsString(EnumMemberModel enumMember) {
         if (enumMember.getComments() == null) {
             return "";
         }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -55,6 +55,7 @@ import cz.habarta.typescript.generator.parser.RestApplicationModel;
 import cz.habarta.typescript.generator.parser.RestMethodModel;
 import cz.habarta.typescript.generator.parser.RestQueryParam;
 import cz.habarta.typescript.generator.type.JTypeWithNullability;
+import cz.habarta.typescript.generator.util.DeprecationUtils;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
@@ -72,6 +73,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1046,16 +1048,23 @@ public class ModelCompiler {
                     Stream.of("Values:"),
                     enumModel.getMembers().stream()
                         .map(enumMember -> "- `" + enumMember.getEnumValue() + "`"
-                            + (enumMember.getComments() != null
-                                ? " - " + String.join(" ", enumMember.getComments())
-                                : ""))
+                                + getEnumItemCommentAsString(enumMember))
                 )
-                .flatMap(s -> s)
+                .flatMap(Function.identity())
                 .collect(Collectors.toList())
             );
         } else {
             return enumModel;
         }
+    }
+
+    private static String getEnumItemCommentAsString(EnumMemberModel enumMember) {
+        if (enumMember.getComments() == null) {
+            return "";
+        }
+        return " - " + enumMember.getComments().stream()
+                .map(s -> s.startsWith(DeprecationUtils.DEPRECATED) ? s.substring(1) : s)
+                .collect(Collectors.joining(" "));
     }
 
     private TsModel createAndUseTaggedUnions(final SymbolTable symbolTable, TsModel tsModel) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -1048,7 +1048,7 @@ public class ModelCompiler {
                     Stream.of("Values:"),
                     enumModel.getMembers().stream()
                         .map(enumMember -> "- `" + enumMember.getEnumValue() + "`"
-                                + getEnumItemCommentAsString(enumMember))
+                            + getEnumItemCommentAsString(enumMember))
                 )
                 .flatMap(Function.identity())
                 .collect(Collectors.toList())
@@ -1063,8 +1063,8 @@ public class ModelCompiler {
             return "";
         }
         return " - " + enumMember.getComments().stream()
-                .map(s -> s.startsWith(DeprecationUtils.DEPRECATED) ? s.substring(1) : s)
-                .collect(Collectors.joining(" "));
+            .map(s -> s.startsWith(DeprecationUtils.DEPRECATED) ? s.substring(1) : s)
+            .collect(Collectors.joining(" "));
     }
 
     private TsModel createAndUseTaggedUnions(final SymbolTable symbolTable, TsModel tsModel) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -8,9 +8,10 @@ import cz.habarta.typescript.generator.parser.Jackson2Parser;
 import cz.habarta.typescript.generator.parser.Model;
 import cz.habarta.typescript.generator.parser.PropertyModel;
 import java.io.File;
-import java.util.Arrays;
+import java.util.Collections;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Objects.requireNonNull;
@@ -18,12 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class JavadocTest {
+    final Settings settings = TestUtils.settings();
+    final TypeProcessor typeProcessor = new DefaultTypeProcessor();
+
+    @BeforeEach
+    void initSettings() {
+        settings.javadocXmlFiles = Collections.singletonList(new File("src/test/javadoc/test-javadoc.xml"));
+    }
 
     @Test
-    public void testJavadoc() {
-        final Settings settings = TestUtils.settings();
-        settings.javadocXmlFiles = Arrays.asList(new File("src/test/javadoc/test-javadoc.xml"));
-        final TypeProcessor typeProcessor = new DefaultTypeProcessor();
+    void javadocXml() {
         {
             final Model model = new Jackson2Parser(settings, typeProcessor).parseModel(ClassWithJavadoc.class);
             final BeanModel bean = model.getBeans().get(0);
@@ -36,6 +41,10 @@ public class JavadocTest {
             final EnumModel enumModel = model.getEnums().get(0);
             Assertions.assertEquals("Documentation for DummyEnum.", requireNonNull(enumModel.getComments()).get(0));
         }
+    }
+
+    @Test
+    void classWithoutJavadoc() {
         {
             final Model model = new Jackson2Parser(settings, typeProcessor).parseModel(ClassWithoutJavadoc.class);
             final BeanModel bean = model.getBeans().get(0);
@@ -43,6 +52,10 @@ public class JavadocTest {
             final PropertyModel property = bean.getProperties().get(0);
             Assertions.assertNull(property.getComments());
         }
+    }
+
+    @Test
+    void classWithEmbeddedExample() {
         {
             final String generated = new TypeScriptGenerator(settings).generateTypeScript(
                 Input.from(ClassWithJavadoc.class, InterfaceWithJavadoc.class, ClassWithEmbeddedExample.class));
@@ -66,6 +79,10 @@ public class JavadocTest {
             assertThat(generated).contains("00ff00");
             assertThat(generated).contains("0000ff");
         }
+    }
+
+    @Test
+    void deprecatedClassWithoutJavadoc() {
         {
             final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedClassWithoutJavadoc.class));
             final String expected = ""
@@ -80,6 +97,10 @@ public class JavadocTest {
                 + "}";
             Assertions.assertEquals(expected.trim(), generated.trim());
         }
+    }
+
+    @Test
+    void deprecatedEnumWithoutJavadoc() {
         {
             final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedEnumWithoutJavadoc.class));
             final String expected = ""
@@ -88,7 +109,7 @@ public class JavadocTest {
                 + " * \n"
                 + " * Values:\n"
                 + " * - `North`\n"
-                + " * - `East` - @deprecated\n"
+                + " * - `East` - deprecated\n"
                 + " * - `South`\n"
                 + " * - `West`\n"
                 + " */\n"
@@ -96,6 +117,33 @@ public class JavadocTest {
                 + "";
             Assertions.assertEquals(expected.trim(), generated.trim());
         }
+    }
+
+    @Test
+    void deprecatedEnumWItem() {
+        settings.mapEnum = EnumMapping.asEnum;
+        final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedEnumItem.class));
+        final String expected = ""
+                + "/**\n"
+                + " * Values:\n"
+                + " * - `First`\n"
+                + " * - `Second` - deprecated\n"
+                + " * - `Third`\n"
+                + " */\n"
+                + "declare const enum DeprecatedEnumItem {\n" +
+                "    First = \"First\",\n" +
+                "    /**\n" +
+                "     * @deprecated\n" +
+                "     */\n" +
+                "    Second = \"Second\",\n" +
+                "    Third = \"Third\",\n" +
+                "}"
+                + "";
+        Assertions.assertEquals(expected.trim(), generated.trim());
+    }
+
+    @Test
+    void classWithBrInJavadoc() {
         {
             final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithBrElements.class));
             Assertions.assertTrue(!generated.contains("<br>"));
@@ -104,6 +152,10 @@ public class JavadocTest {
             Assertions.assertTrue(generated.contains("Class documentation\n * \n"));
             Assertions.assertTrue(generated.contains("Some documentation\n * \n * for this class."));
         }
+    }
+
+    @Test
+    void classWithPInJavadoc() {
         {
             final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithPElements.class));
             Assertions.assertTrue(!generated.contains("<p>"));
@@ -186,6 +238,12 @@ public class JavadocTest {
 
     }
 
+    public enum DeprecatedEnumItem {
+        First,
+        @Deprecated Second,
+        Third;
+    }
+
     /**
      * This class comes with an embedded example!
      *
@@ -217,10 +275,10 @@ public class JavadocTest {
 
     /**
      * First sentence.
-     * 
+     *
      * <p> Long
      * paragraph </p>
-     * 
+     *
      * <p>Second
      * paragraph</p>
      */

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -124,21 +124,21 @@ public class JavadocTest {
         settings.mapEnum = EnumMapping.asEnum;
         final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedEnumItem.class));
         final String expected = ""
-                + "/**\n"
-                + " * Values:\n"
-                + " * - `First`\n"
-                + " * - `Second` - deprecated\n"
-                + " * - `Third`\n"
-                + " */\n"
-                + "declare const enum DeprecatedEnumItem {\n" +
-                "    First = \"First\",\n" +
-                "    /**\n" +
-                "     * @deprecated\n" +
-                "     */\n" +
-                "    Second = \"Second\",\n" +
-                "    Third = \"Third\",\n" +
-                "}"
-                + "";
+            + "/**\n"
+            + " * Values:\n"
+            + " * - `First`\n"
+            + " * - `Second` - deprecated\n"
+            + " * - `Third`\n"
+            + " */\n"
+            + "declare const enum DeprecatedEnumItem {\n" +
+            "    First = \"First\",\n" +
+            "    /**\n" +
+            "     * @deprecated\n" +
+            "     */\n" +
+            "    Second = \"Second\",\n" +
+            "    Third = \"Third\",\n" +
+            "}"
+            + "";
         Assertions.assertEquals(expected.trim(), generated.trim());
     }
 
@@ -240,7 +240,8 @@ public class JavadocTest {
 
     public enum DeprecatedEnumItem {
         First,
-        @Deprecated Second,
+        @Deprecated
+        Second,
         Third;
     }
 


### PR DESCRIPTION
Currently if some enum item a deprecated, then tsdoc is generated mentioning each item, and the deprecated ones are marked with `@deprecated`. 
```
Values:
- `First`
- `Second` - @deprecated
- `Third`
```

And then Intellij IDEA treats the whole enum as deprecated. I suggest omitting `@` from the generated comment:
```
Values:
- `First`
- `Second` - deprecated
- `Third`
```
