### PR TITLE
Add support for controlled trailing semi-colons and injecting custom properties

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -137,7 +137,7 @@ public class Settings {
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
     public boolean disableTrailingSemiColon = false;
-    public Map<Class<?>, List<String>> injectCustomProperties = Map.of();
+    public Map<String, List<String>> injectCustomProperties = Map.of();
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -137,6 +137,7 @@ public class Settings {
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
     public boolean disableTrailingSemiColon = false;
+    public Map<Class<?>, List<String>> injectCustomProperties = Map.of();
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Settings.java
@@ -136,6 +136,7 @@ public class Settings {
     public boolean jackson2ModuleDiscovery = false;
     public List<Class<? extends Module>> jackson2Modules = new ArrayList<>();
     public ClassLoader classLoader = null;
+    public boolean disableTrailingSemiColon = false;
 
     private boolean defaultStringEnumsOverriddenByExtension = false;
 
@@ -903,5 +904,4 @@ public class Settings {
             default: return 0;
         }
     }
-
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
@@ -24,7 +24,8 @@ public class TsProperty {
 
     public String format(Settings settings) {
         final String questionMark = (tsType instanceof TsType.OptionalType) ? "?" : "";
-        return Emitter.quoteIfNeeded(name, settings) + questionMark + ": " + tsType.format(settings) + ";";
+        final String trailingChar = settings.disableTrailingSemiColon ? "" : ";";
+        return Emitter.quoteIfNeeded(name, settings) + questionMark + ": " + tsType.format(settings) + trailingChar;
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -148,7 +148,7 @@ public class TypeScriptGenerator {
             final ModelParser.Factory modelParserFactory = getModelParserFactory();
             final List<TypeProcessor> specificTypeProcessors = Stream
                     .concat(
-                            restFactories.stream().map(factory -> factory.getSpecificTypeProcessor()),
+                            restFactories.stream().map(RestApplicationParser.Factory::getSpecificTypeProcessor),
                             Stream.of(modelParserFactory.getSpecificTypeProcessor())
                     )
                     .filter(Objects::nonNull)
@@ -167,8 +167,7 @@ public class TypeScriptGenerator {
         processors.add(new CustomMappingTypeProcessor(settings.getValidatedCustomTypeMappings()));
         processors.addAll(specificTypeProcessors);
         processors.add(new DefaultTypeProcessor(settings.getLoadedDataLibraries()));
-        final TypeProcessor typeProcessor = new TypeProcessor.Chain(processors);
-        return typeProcessor;
+        return new TypeProcessor.Chain(processors);
     }
 
     public ModelParser getModelParser() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -194,6 +194,7 @@ public class Emitter implements EmitterExtension.Writer {
         for (TsPropertyModel property : bean.getProperties()) {
             emitProperty(property);
         }
+        emitInjectedProperties(bean);
         if (bean.getConstructor() != null) {
             emitCallable(bean.getConstructor());
         }
@@ -213,6 +214,22 @@ public class Emitter implements EmitterExtension.Writer {
         final String questionMark = tsType instanceof TsType.OptionalType ? "?" : "";
         final String defaultString = property.getDefaultValue() != null ? " = " + property.getDefaultValue().format(settings) : "";
         writeIndentedLine(staticString + readonlyString + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + defaultString + getTrailingChar());
+    }
+
+    private void emitInjectedProperties(TsBeanModel bean) {
+
+        settings.injectCustomProperties
+                .keySet()
+                .stream().map(Class::getSimpleName)
+                .filter(key -> key.equals(bean.getName().getSimpleName()))
+                .findFirst().ifPresent((ignored) -> writeIndentedLine("// custom properties"));
+
+        settings.injectCustomProperties
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().getSimpleName().equals(bean.getName().getSimpleName()))
+                .flatMap(matched -> matched.getValue().stream())
+                .forEach(this::writeIndentedLine);
     }
 
     private void emitDecorators(List<TsDecorator> decorators) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -220,14 +220,14 @@ public class Emitter implements EmitterExtension.Writer {
 
         settings.injectCustomProperties
                 .keySet()
-                .stream().map(Class::getSimpleName)
-                .filter(key -> key.equals(bean.getName().getSimpleName()))
+                .stream()
+                .filter(className -> className.equals(bean.getName().getSimpleName()))
                 .findFirst().ifPresent((ignored) -> writeIndentedLine("// custom properties"));
 
         settings.injectCustomProperties
                 .entrySet()
                 .stream()
-                .filter(entry -> entry.getKey().getSimpleName().equals(bean.getName().getSimpleName()))
+                .filter(entry -> entry.getKey().equals(bean.getName().getSimpleName()))
                 .flatMap(matched -> matched.getValue().stream())
                 .forEach(this::writeIndentedLine);
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -76,14 +76,14 @@ public class Emitter implements EmitterExtension.Writer {
             writeNewLine();
             for (ModuleDependency dependency : settings.moduleDependencies) {
                 if (!dependency.global) {
-                    writeIndentedLine("import * as " + dependency.importAs + " from " + quote(dependency.importFrom, settings) + ";");
+                    writeIndentedLine("import * as " + dependency.importAs + " from " + quote(dependency.importFrom, settings) + getTrailingChar());
                 }
             }
         }
         if (settings.importDeclarations != null && !settings.importDeclarations.isEmpty()) {
             writeNewLine();
             for (String importDeclaration : settings.importDeclarations) {
-                writeIndentedLine(importDeclaration + ";");
+                writeIndentedLine(importDeclaration + getTrailingChar());
             }
         }
     }
@@ -212,7 +212,7 @@ public class Emitter implements EmitterExtension.Writer {
         final String readonlyString = property.modifiers.isReadonly ? "readonly " : "";
         final String questionMark = tsType instanceof TsType.OptionalType ? "?" : "";
         final String defaultString = property.getDefaultValue() != null ? " = " + property.getDefaultValue().format(settings) : "";
-        writeIndentedLine(staticString + readonlyString + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + defaultString + ";");
+        writeIndentedLine(staticString + readonlyString + quoteIfNeeded(property.getName(), settings) + questionMark + ": " + tsType.format(settings) + defaultString + getTrailingChar());
     }
 
     private void emitDecorators(List<TsDecorator> decorators) {
@@ -271,7 +271,7 @@ public class Emitter implements EmitterExtension.Writer {
             indent--;
             writeIndentedLine("}");
         } else {
-            writeIndentedLine(signature + ";");
+            writeIndentedLine(signature + getTrailingChar());
         }
     }
 
@@ -326,7 +326,7 @@ public class Emitter implements EmitterExtension.Writer {
 
     private void emitReturnStatement(TsReturnStatement returnStatement) {
         if (returnStatement.getExpression() != null) {
-            writeIndentedLine("return " + returnStatement.getExpression().format(settings) + ";");
+            writeIndentedLine("return " + returnStatement.getExpression().format(settings) + getTrailingChar());
         } else {
             writeIndentedLine("return;");
         }
@@ -347,7 +347,7 @@ public class Emitter implements EmitterExtension.Writer {
     }
 
     private void emitExpressionStatement(TsExpressionStatement expressionStatement) {
-        writeIndentedLine(expressionStatement.getExpression().format(settings) + ";");
+        writeIndentedLine(expressionStatement.getExpression().format(settings) + getTrailingChar());
     }
 
     private void emitVariableDeclarationStatement(TsVariableDeclarationStatement variableDeclarationStatement) {
@@ -356,7 +356,7 @@ public class Emitter implements EmitterExtension.Writer {
                 + variableDeclarationStatement.getName()
                 + (variableDeclarationStatement.getType() != null ? ": " + variableDeclarationStatement.getType().format(settings) : "")
                 + (variableDeclarationStatement.getInitializer() != null ? " = " + variableDeclarationStatement.getInitializer().format(settings) : "")
-                + ";"
+                + getTrailingChar()
         );
     }
 
@@ -385,7 +385,7 @@ public class Emitter implements EmitterExtension.Writer {
         final String genericParameters = alias.getTypeParameters().isEmpty()
                 ? ""
                 : "<" + formatList(settings, alias.getTypeParameters()) + ">";
-        writeIndentedLine(exportKeyword, "type " + alias.getName().getSimpleName() + genericParameters + " = " + alias.getDefinition().format(settings) + ";");
+        writeIndentedLine(exportKeyword, "type " + alias.getName().getSimpleName() + genericParameters + " = " + alias.getDefinition().format(settings) + getTrailingChar());
     }
 
     private void emitLiteralEnum(TsEnumModel enumModel, boolean exportKeyword, boolean declareKeyword) {
@@ -438,7 +438,7 @@ public class Emitter implements EmitterExtension.Writer {
     private void emitUmdNamespace() {
         if (settings.umdNamespace != null) {
             writeNewLine();
-            writeIndentedLine("export as namespace " + settings.umdNamespace + ";");
+            writeIndentedLine("export as namespace " + settings.umdNamespace + getTrailingChar());
         }
     }
 
@@ -502,4 +502,7 @@ public class Emitter implements EmitterExtension.Writer {
         }
     }
 
+    private String getTrailingChar() {
+        return settings.disableTrailingSemiColon ? "" : ";";
+    }
 }

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -131,7 +131,7 @@ public class GenerateTask extends DefaultTask {
     public List<String> jackson2Modules;
     public Logger.Level loggingLevel;
     public boolean disableTrailingSemiColon;
-    public Map<Class<?>, List<String>> injectCustomProperties;
+    public Map<String, List<String>> injectCustomProperties;
 
     private Settings createSettings(URLClassLoader classLoader) {
         final Settings settings = new Settings();

--- a/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
+++ b/typescript-generator-gradle-plugin/src/main/java/cz/habarta/typescript/generator/gradle/GenerateTask.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
@@ -129,6 +130,8 @@ public class GenerateTask extends DefaultTask {
     public boolean jackson2ModuleDiscovery;
     public List<String> jackson2Modules;
     public Logger.Level loggingLevel;
+    public boolean disableTrailingSemiColon;
+    public Map<Class<?>, List<String>> injectCustomProperties;
 
     private Settings createSettings(URLClassLoader classLoader) {
         final Settings settings = new Settings();
@@ -212,6 +215,8 @@ public class GenerateTask extends DefaultTask {
         settings.jackson2ModuleDiscovery = jackson2ModuleDiscovery;
         settings.loadJackson2Modules(classLoader, jackson2Modules);
         settings.classLoader = classLoader;
+        settings.disableTrailingSemiColon = disableTrailingSemiColon;
+        settings.injectCustomProperties = injectCustomProperties;
         return settings;
     }
 


### PR DESCRIPTION
In this PR, I would like to introduced the following two new settings,
1. `disableTrailingSemiColon` - A boolean flag indicating if the generator should append every line with a semi-colon
2. `injectCustomProperties` - A map of class to string property lists. Similar to `importDeclarations` but instead injects additional properties into the given type. This is useful for when we try to be backward-compatible in the FE API and update the backend logic to have the newer property names. Also avoids adding these properties manually every time after running the `typscript-generator`.

This PR also includes some minor improvements in other parts of the code.