### PR TITLE
Fix tests, build, and support Id.MINIMAL_CLASS, and Id.SIMPLE_NAME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-java-version</id>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
         <kotlin.version>1.9.10</kotlin.version>
+        <immutables.version>2.9.3</immutables.version>
         <github.global.server>github</github.global.server>
     </properties>
 
@@ -172,6 +173,13 @@
                         <arg>-Xlint</arg>
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <dependency>
+                            <groupId>org.immutables</groupId>
+                            <artifactId>value</artifactId>
+                            <version>${immutables.version}</version>
+                        </dependency>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,30 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireMavenVersion>
+                            <version>[3,4]</version>
+                        </requireMavenVersion>
+                        <requireJavaVersion>
+                            <version>[11,12)</version>
+                        </requireJavaVersion>
+                    </rules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>

--- a/typescript-generator-core/pom.xml
+++ b/typescript-generator-core/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>2.9.3</version>
+            <version>${immutables.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTaggedUnionsTest.kt
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/KotlinTaggedUnionsTest.kt
@@ -1,0 +1,45 @@
+package cz.habarta.typescript.generator
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class KotlinTaggedUnionsTest {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+    sealed interface MinimalEffort {
+        data class A(
+            val a: String
+        ) : MinimalEffort
+
+        data object B : MinimalEffort
+    }
+
+    @Test
+    fun testMinimalEffortUnions() {
+        val settings = TestUtils.settings()
+        settings.quotes = "'"
+        val output = TypeScriptGenerator(settings)
+            .generateTypeScript(
+                Input.from(
+                    MinimalEffort::class.java,
+                    MinimalEffort.A::class.java,
+                    MinimalEffort.B::class.java
+                )
+            )
+        val expected = """
+        interface MinimalEffort {
+            '@c': 'cz.habarta.typescript.generator.KotlinTaggedUnionsTest${'$'}MinimalEffort${'$'}A' | 'cz.habarta.typescript.generator.KotlinTaggedUnionsTest${'$'}MinimalEffort${'$'}B';
+        }
+
+        interface A extends MinimalEffort {
+            '@c': 'cz.habarta.typescript.generator.KotlinTaggedUnionsTest${'$'}MinimalEffort${'$'}A';
+            a: string;
+        }
+
+        interface B extends MinimalEffort {
+            '@c': 'cz.habarta.typescript.generator.KotlinTaggedUnionsTest${'$'}MinimalEffort${'$'}B';
+        }
+        """.trimIndent()
+        Assertions.assertEquals(expected.trim(), output.trim())
+    }
+}


### PR DESCRIPTION
I have been using this library for years, and I use Tagged Unions extensively.
I have some situations where I have many sub-classes, and I would like to make writing code as compact and concise as possible.

Jackson supports different kinds of `use=Id` variants, however, only `NAME`, and `CLASS` are supported.

I originally tried to get `MINIMAL_CLASS`, and Jacksin 2.18's `SIMPLE_NAME` to work, however, I had problems with running the existing tests and building due to immutables not being on the compilation annotation path, and the fact that Java12+ isn't supported.

Fixed the immutables error by adding the annotation to the compilation path (this shouldn't affect the end jar).
Made building the project more error-obvious by introducing MavenEnforcer to demand it be built with Java 11.

Now that building and testing is easier, a Kotlin test is introduced (to allow testing for sealed things, as we are not building in Java17+ yet).

This allows us to write more minimal effort definitions like:

```
@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
    sealed interface MinimalEffort {
        data class A(
            val a: String
        ) : MinimalEffort

        data object B : MinimalEffort
    }
 ```
 
 And if we are using Jackson 2.18+, we can use Id.SIMPLE_NAME as well.
 
 It does this by, instead of detecting supported Id types, it detects non-compatible Id types, like `CUSTOM`, `NONE`, and `DEDUCTION`, which is a more forward compatible method.
 
 Without this, one would need to annotate every class with `@JsonTypeName(...)` in the case of `Id.NAME`, or be stuck with the full class: `Id.CLASS`.
